### PR TITLE
Daily agent progress

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,35 @@
+"""Application settings.
+
+The only place environment variables are read. Every other module
+imports `get_settings()` instead of touching `os.environ` directly.
+"""
+
+from functools import lru_cache
+from typing import Annotated
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    github_token: str
+    indexed_repos: Annotated[list[str], NoDecode]
+    ollama_host: str = "http://localhost:11434"
+    ollama_extraction_model: str
+    ollama_embedding_model: str
+    gemini_api_key: str
+    chroma_data_dir: str = "./chroma_data"
+
+    @field_validator("indexed_repos", mode="before")
+    @classmethod
+    def _split_indexed_repos(cls, value: str | list[str]) -> list[str]:
+        if isinstance(value, str):
+            return [repo.strip() for repo in value.split(",") if repo.strip()]
+        return value
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -1,0 +1,66 @@
+"""Chroma store layer: idempotent DecisionUnit upsert and ingestion cursors.
+
+Chroma's own `id` field is `DecisionUnit.id`, so upserting an already-seen
+commit/PR overwrites the existing entry instead of duplicating it. The
+cursor file lives at `{CHROMA_DATA_DIR}/cursors.json`, keyed by repo, per
+SYSTEM-DESIGN.md.
+"""
+
+import json
+from pathlib import Path
+
+import chromadb
+
+from chroma_client import get_chroma_client
+from config import get_settings
+from models import DecisionUnit
+
+COLLECTION_NAME = "decisions"
+
+
+def get_collection() -> chromadb.Collection:
+    return get_chroma_client().get_or_create_collection(name=COLLECTION_NAME)
+
+
+def _document_text(unit: DecisionUnit) -> str:
+    return f"{unit.title}\n{unit.decision}\n{unit.rationale}"
+
+
+def _metadata(unit: DecisionUnit) -> dict:
+    metadata = unit.model_dump(exclude={"id"})
+    metadata["alternatives"] = json.dumps(metadata["alternatives"])
+    return metadata
+
+
+def upsert_units(units: list[DecisionUnit], embeddings: list[list[float]]) -> None:
+    if not units:
+        return
+
+    get_collection().upsert(
+        ids=[unit.id for unit in units],
+        embeddings=embeddings,
+        documents=[_document_text(unit) for unit in units],
+        metadatas=[_metadata(unit) for unit in units],
+    )
+
+
+def _cursor_path() -> Path:
+    return Path(get_settings().chroma_data_dir) / "cursors.json"
+
+
+def get_cursor(repo: str) -> dict:
+    path = _cursor_path()
+    if not path.exists():
+        return {}
+
+    cursors = json.loads(path.read_text())
+    return cursors.get(repo, {})
+
+
+def set_cursor(repo: str, cursor: dict) -> None:
+    path = _cursor_path()
+    cursors = json.loads(path.read_text()) if path.exists() else {}
+    cursors[repo] = cursor
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cursors))

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,75 @@
+"""DecisionUnit and API request/response models.
+
+Shared typed vocabulary for ingestion, retrieval, synthesis, and routers.
+See docs/SYSTEM-DESIGN.md's data model and API contracts sections.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class DecisionUnit(BaseModel):
+    id: str
+    repo: str
+    kind: Literal["commit", "pr"]
+    ref: str
+    url: str
+    author: str
+    date: str
+    title: str
+    decision: str
+    rationale: str
+    alternatives: list[str]
+    source_excerpt: str
+
+
+class IngestRequest(BaseModel):
+    repo: str | None = None
+
+
+class IngestResult(BaseModel):
+    repo: str
+    fetched: int
+    extracted: int
+    skipped: int
+    stored: int
+
+
+class IngestResponse(BaseModel):
+    repos: list[IngestResult]
+
+
+class RetrieveRequest(BaseModel):
+    query: str
+    k: int = 5
+    repos: list[str] | None = None
+
+
+class RetrieveResult(BaseModel):
+    unit: DecisionUnit
+    score: float
+
+
+class RetrieveResponse(BaseModel):
+    results: list[RetrieveResult]
+
+
+class QueryRequest(BaseModel):
+    question: str
+    repos: list[str] | None = None
+
+
+class QueryResponse(BaseModel):
+    answer: str
+    citations: list[DecisionUnit]
+    retrieved_count: int
+
+
+class RepoInfo(BaseModel):
+    repo: str
+    indexed_units: int
+
+
+class ReposResponse(BaseModel):
+    repos: list[RepoInfo]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.6
 uvicorn[standard]==0.34.0
 chromadb==0.6.3
 python-dotenv==1.0.1
+pydantic-settings==2.7.1

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pydantic import ValidationError
+
+from config import Settings, get_settings
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "ghp_test",
+    "INDEXED_REPOS": "anubhab-m02/BuFin, anubhab-m02/adr-engine ,owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "gemini_test",
+}
+
+
+def _set_required_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_settings_loads_every_var_from_env(monkeypatch):
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama.internal:11434")
+    monkeypatch.setenv("CHROMA_DATA_DIR", "/data/chroma")
+
+    settings = Settings()
+
+    assert settings.github_token == "ghp_test"
+    assert settings.indexed_repos == [
+        "anubhab-m02/BuFin",
+        "anubhab-m02/adr-engine",
+        "owner/repo",
+    ]
+    assert settings.ollama_host == "http://ollama.internal:11434"
+    assert settings.ollama_extraction_model == "phi4-mini"
+    assert settings.ollama_embedding_model == "nomic-embed-text"
+    assert settings.gemini_api_key == "gemini_test"
+    assert settings.chroma_data_dir == "/data/chroma"
+
+
+def test_settings_applies_defaults_when_optional_vars_absent(monkeypatch):
+    _set_required_env(monkeypatch)
+
+    settings = Settings()
+
+    assert settings.ollama_host == "http://localhost:11434"
+    assert settings.chroma_data_dir == "./chroma_data"
+
+
+def test_indexed_repos_splits_on_comma_and_strips_whitespace(monkeypatch):
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("INDEXED_REPOS", " a/b ,c/d,  e/f  ")
+
+    settings = Settings()
+
+    assert settings.indexed_repos == ["a/b", "c/d", "e/f"]
+
+
+def test_missing_required_var_raises_validation_error(monkeypatch):
+    _set_required_env(monkeypatch)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_get_settings_is_cached(monkeypatch):
+    _set_required_env(monkeypatch)
+    get_settings.cache_clear()
+
+    first = get_settings()
+    second = get_settings()
+
+    assert first is second
+    get_settings.cache_clear()

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,99 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pydantic import ValidationError
+
+from models import (
+    DecisionUnit,
+    IngestRequest,
+    IngestResponse,
+    IngestResult,
+    QueryRequest,
+    QueryResponse,
+    RepoInfo,
+    ReposResponse,
+    RetrieveRequest,
+    RetrieveResponse,
+    RetrieveResult,
+)
+
+
+def make_decision_unit(**overrides) -> DecisionUnit:
+    fields = {
+        "id": "anubhab-m02/BuFin:pr:42",
+        "repo": "anubhab-m02/BuFin",
+        "kind": "pr",
+        "ref": "42",
+        "url": "https://github.com/anubhab-m02/BuFin/pull/42",
+        "author": "anubhab-m02",
+        "date": "2026-01-01T00:00:00Z",
+        "title": "Switch auth to session tokens",
+        "decision": "Use server-side session tokens instead of JWTs",
+        "rationale": "JWTs couldn't be revoked without a blocklist",
+        "alternatives": ["JWT with blocklist", "opaque tokens via Redis"],
+        "source_excerpt": "We discussed JWT revocation and decided against it.",
+    }
+    fields.update(overrides)
+    return DecisionUnit(**fields)
+
+
+def test_decision_unit_round_trips_through_json():
+    unit = make_decision_unit()
+
+    restored = DecisionUnit.model_validate_json(unit.model_dump_json())
+
+    assert restored == unit
+
+
+def test_decision_unit_rejects_invalid_kind():
+    with pytest.raises(ValidationError):
+        make_decision_unit(kind="issue")
+
+
+def test_ingest_models_round_trip():
+    response = IngestResponse(
+        repos=[
+            IngestResult(repo="owner/repo", fetched=10, extracted=8, skipped=2, stored=8)
+        ]
+    )
+
+    restored = IngestResponse.model_validate_json(response.model_dump_json())
+
+    assert restored == response
+    assert IngestRequest().repo is None
+    assert IngestRequest(repo="owner/repo").repo == "owner/repo"
+
+
+def test_retrieve_models_round_trip():
+    unit = make_decision_unit()
+    response = RetrieveResponse(results=[RetrieveResult(unit=unit, score=0.87)])
+
+    restored = RetrieveResponse.model_validate_json(response.model_dump_json())
+
+    assert restored == response
+    assert RetrieveRequest(query="why session tokens?").k == 5
+    assert RetrieveRequest(query="why session tokens?", repos=["owner/repo"]).repos == [
+        "owner/repo"
+    ]
+
+
+def test_query_models_round_trip():
+    unit = make_decision_unit()
+    response = QueryResponse(answer="Because of revocation.", citations=[unit], retrieved_count=1)
+
+    restored = QueryResponse.model_validate_json(response.model_dump_json())
+
+    assert restored == response
+    assert QueryRequest(question="why session tokens?").repos is None
+
+
+def test_repos_response_round_trips():
+    response = ReposResponse(repos=[RepoInfo(repo="owner/repo", indexed_units=3)])
+
+    restored = ReposResponse.model_validate_json(response.model_dump_json())
+
+    assert restored == response

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+
+import chroma_client
+import config
+from models import DecisionUnit
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+def make_unit(**overrides) -> DecisionUnit:
+    fields = {
+        "id": "owner/repo:pr:1",
+        "repo": "owner/repo",
+        "kind": "pr",
+        "ref": "1",
+        "url": "https://github.com/owner/repo/pull/1",
+        "author": "someone",
+        "date": "2026-01-01T00:00:00Z",
+        "title": "Add caching layer",
+        "decision": "Use Redis for the cache",
+        "rationale": "Needed shared state across instances",
+        "alternatives": ["in-memory cache", "Memcached"],
+        "source_excerpt": "Discussion about caching options.",
+    }
+    fields.update(overrides)
+    return DecisionUnit(**fields)
+
+
+@pytest.fixture
+def store_module(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+    from ingestion import store
+
+    yield store
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+
+def test_upserting_same_id_twice_does_not_duplicate(store_module):
+    unit = make_unit()
+
+    store_module.upsert_units([unit], embeddings=[[0.1, 0.2, 0.3]])
+    store_module.upsert_units(
+        [make_unit(title="Add caching layer (revised)")],
+        embeddings=[[0.4, 0.5, 0.6]],
+    )
+
+    collection = store_module.get_collection()
+    assert collection.count() == 1
+
+    stored = collection.get(ids=[unit.id], include=["metadatas", "documents"])
+    assert stored["metadatas"][0]["title"] == "Add caching layer (revised)"
+    assert stored["documents"][0].startswith("Add caching layer (revised)")
+
+
+def test_upsert_units_stores_metadata_and_document_text(store_module):
+    unit = make_unit()
+
+    store_module.upsert_units([unit], embeddings=[[0.1, 0.2, 0.3]])
+
+    collection = store_module.get_collection()
+    stored = collection.get(ids=[unit.id], include=["metadatas", "documents"])
+
+    assert stored["documents"][0] == "Add caching layer\nUse Redis for the cache\nNeeded shared state across instances"
+    assert stored["metadatas"][0]["repo"] == "owner/repo"
+    assert stored["metadatas"][0]["kind"] == "pr"
+
+
+def test_upsert_units_with_empty_list_is_a_noop(store_module):
+    store_module.upsert_units([], embeddings=[])
+
+    assert store_module.get_collection().count() == 0
+
+
+def test_get_cursor_with_no_prior_cursor_returns_empty_dict(store_module):
+    assert store_module.get_cursor("owner/repo") == {}
+
+
+def test_cursor_round_trips_through_disk(store_module):
+    store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
+
+    assert store_module.get_cursor("owner/repo") == {
+        "last_commit_date": "2026-01-01T00:00:00Z"
+    }
+    assert store_module.get_cursor("owner/other") == {}
+
+
+def test_set_cursor_preserves_other_repos(store_module):
+    store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
+    store_module.set_cursor("owner/other", {"last_commit_date": "2026-02-01T00:00:00Z"})
+
+    assert store_module.get_cursor("owner/repo") == {
+        "last_commit_date": "2026-01-01T00:00:00Z"
+    }
+    assert store_module.get_cursor("owner/other") == {
+        "last_commit_date": "2026-02-01T00:00:00Z"
+    }


### PR DESCRIPTION
Rolling PR accumulating unattended daily-agent work on `agent/rolling`.

Closes #13
Closes #14
Closes #15

## Changelog

- Add `backend/config.py`: pydantic-settings `Settings` centralizing all env reads, with a cached `get_settings()` accessor and comma-separated `indexed_repos` parsing.
- Add `backend/models.py`: `DecisionUnit` and all API request/response models per SYSTEM-DESIGN.md's data model and API contracts.
- Add `backend/ingestion/store.py`: idempotent Chroma upsert (keyed on `DecisionUnit.id`) and per-repo cursor persistence to `cursors.json`.