### PR TITLE
GitHub ingestion client (commits, PRs) + shared test fixtures

### DIFF
--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -28,6 +28,16 @@ class CommitRef(BaseModel):
     url: str
 
 
+class PullRequestRef(BaseModel):
+    number: int
+    title: str
+    body: str
+    url: str
+    author: str
+    merged_at: str | None
+    review_comments: list[str]
+
+
 def _headers() -> dict:
     return {
         "Authorization": f"Bearer {get_settings().github_token}",
@@ -59,6 +69,29 @@ def list_commits(repo: str, since: str | None = None) -> list[CommitRef]:
             author=item["commit"]["author"]["name"],
             date=item["commit"]["author"]["date"],
             url=item["html_url"],
+        )
+        for item in data
+    ]
+
+
+def _list_review_comments(repo: str, number: int) -> list[str]:
+    data = _get(f"/repos/{repo}/pulls/{number}/comments")
+    return [comment["body"] for comment in data]
+
+
+def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
+    params = {"state": "closed"}
+    data = _get(f"/repos/{repo}/pulls", params=params)
+
+    return [
+        PullRequestRef(
+            number=item["number"],
+            title=item["title"],
+            body=item["body"] or "",
+            url=item["html_url"],
+            author=item["user"]["login"],
+            merged_at=item["merged_at"],
+            review_comments=_list_review_comments(repo, item["number"]),
         )
         for item in data
     ]

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -80,8 +80,13 @@ def _list_review_comments(repo: str, number: int) -> list[str]:
 
 
 def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
-    params = {"state": "closed"}
+    # GitHub's PR list endpoint has no server-side "since" filter (unlike
+    # /commits), so we sort newest-updated first and filter client-side.
+    params = {"state": "closed", "sort": "updated", "direction": "desc"}
     data = _get(f"/repos/{repo}/pulls", params=params)
+
+    if since:
+        data = [item for item in data if item["updated_at"] >= since]
 
     return [
         PullRequestRef(

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -1,0 +1,64 @@
+"""GitHub REST client: typed commit/PR fetching.
+
+Returns typed models only — GitHub's raw JSON schema must not leak past
+this module, per ARCHITECTURE.md. Single page only; pagination and
+rate-limit handling are handled in a later module.
+"""
+
+import httpx
+from pydantic import BaseModel
+
+from config import get_settings
+
+GITHUB_API_URL = "https://api.github.com"
+
+
+class GitHubError(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"GitHub API error {status_code}: {message}")
+
+
+class CommitRef(BaseModel):
+    sha: str
+    message: str
+    author: str
+    date: str
+    url: str
+
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {get_settings().github_token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+
+def _get(path: str, params: dict | None = None) -> list | dict:
+    response = httpx.get(f"{GITHUB_API_URL}{path}", headers=_headers(), params=params)
+
+    if response.is_error:
+        try:
+            message = response.json().get("message", response.text)
+        except ValueError:
+            message = response.text
+        raise GitHubError(response.status_code, message)
+
+    return response.json()
+
+
+def list_commits(repo: str, since: str | None = None) -> list[CommitRef]:
+    params = {"since": since} if since else None
+    data = _get(f"/repos/{repo}/commits", params=params)
+
+    return [
+        CommitRef(
+            sha=item["sha"],
+            message=item["commit"]["message"],
+            author=item["commit"]["author"]["name"],
+            date=item["commit"]["author"]["date"],
+            url=item["html_url"],
+        )
+        for item in data
+    ]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,2 @@
 -r requirements.txt
 pytest==8.3.4
-httpx==0.28.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.34.0
 chromadb==0.6.3
 python-dotenv==1.0.1
 pydantic-settings==2.7.1
+httpx==0.28.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Shared pytest fixtures: sample DecisionUnit, temp Chroma client, fixture loader.
+
+Kept here so every later issue's tests can pull these in without each one
+re-inventing setup, per ARCHITECTURE.md's no-network/no-Ollama testing rule.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import chromadb
+import pytest
+
+from models import DecisionUnit
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def sample_decision_unit() -> DecisionUnit:
+    return DecisionUnit(
+        id="octocat/Hello-World:pr:42",
+        repo="octocat/Hello-World",
+        kind="pr",
+        ref="42",
+        url="https://github.com/octocat/Hello-World/pull/42",
+        author="octocat",
+        date="2026-03-14T16:05:00Z",
+        title="Switch auth to session tokens",
+        decision="Use server-side session tokens backed by Redis instead of JWTs",
+        rationale="JWTs couldn't be revoked without maintaining a blocklist.",
+        alternatives=["JWT with a revocation blocklist", "opaque tokens via Redis"],
+        source_excerpt="JWTs couldn't be revoked without maintaining a blocklist.",
+    )
+
+
+@pytest.fixture
+def tmp_chroma_client(tmp_path) -> chromadb.ClientAPI:
+    return chromadb.PersistentClient(path=str(tmp_path))
+
+
+@pytest.fixture
+def load_fixture():
+    def _load(name: str):
+        path = FIXTURES_DIR / name
+        if path.suffix == ".json":
+            return json.loads(path.read_text())
+        return path.read_text()
+
+    return _load

--- a/backend/tests/fixtures/extraction_malformed.txt
+++ b/backend/tests/fixtures/extraction_malformed.txt
@@ -1,0 +1,4 @@
+Sure thing! Here's the decision unit you asked for:
+
+{ "title": "Switch auth to session tokens", "decision": "Use Redis for sessions"
+  "rationale": "revocation was the deciding factor

--- a/backend/tests/fixtures/extraction_ok.json
+++ b/backend/tests/fixtures/extraction_ok.json
@@ -1,0 +1,7 @@
+{
+  "title": "Switch auth to session tokens",
+  "decision": "Use server-side session tokens backed by Redis instead of JWTs",
+  "rationale": "JWTs couldn't be revoked without maintaining a blocklist, which defeated the point of using a stateless token.",
+  "alternatives": ["JWT with a revocation blocklist", "opaque tokens via Redis"],
+  "source_excerpt": "JWTs couldn't be revoked without maintaining a blocklist, which defeated the point of using them."
+}

--- a/backend/tests/fixtures/extraction_skip.json
+++ b/backend/tests/fixtures/extraction_skip.json
@@ -1,0 +1,4 @@
+{
+  "is_decision": false,
+  "reason": "This commit only fixes a typo in the README and reflects no architectural decision."
+}

--- a/backend/tests/fixtures/github_commit.json
+++ b/backend/tests/fixtures/github_commit.json
@@ -1,0 +1,39 @@
+{
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5",
+  "commit": {
+    "author": {
+      "name": "Monalisa Octocat",
+      "email": "mona@github.com",
+      "date": "2026-03-14T16:00:49Z"
+    },
+    "committer": {
+      "name": "Monalisa Octocat",
+      "email": "mona@github.com",
+      "date": "2026-03-14T16:00:49Z"
+    },
+    "message": "Switch session storage to Redis\n\nIn-memory sessions didn't survive a pod restart, so we lost every logged-in user on every deploy. Redis gives us a shared store across instances.",
+    "tree": {
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5",
+      "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/6dcb09b5b57875f334f61aebed695e2e4193db5"
+    },
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5",
+    "comment_count": 0
+  },
+  "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5",
+  "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5",
+  "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5/comments",
+  "author": {
+    "login": "octocat",
+    "id": 1
+  },
+  "committer": {
+    "login": "octocat",
+    "id": 1
+  },
+  "parents": [
+    {
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db4",
+      "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db4"
+    }
+  ]
+}

--- a/backend/tests/fixtures/github_pr.json
+++ b/backend/tests/fixtures/github_pr.json
@@ -1,0 +1,27 @@
+{
+  "number": 42,
+  "state": "closed",
+  "title": "Switch auth to session tokens",
+  "body": "JWTs couldn't be revoked without maintaining a blocklist, which defeated the point of using them. Moving to server-side session tokens backed by Redis so we can revoke on logout.",
+  "user": {
+    "login": "octocat",
+    "id": 1
+  },
+  "html_url": "https://github.com/octocat/Hello-World/pull/42",
+  "created_at": "2026-03-10T09:12:00Z",
+  "updated_at": "2026-03-14T16:05:00Z",
+  "closed_at": "2026-03-14T16:05:00Z",
+  "merged_at": "2026-03-14T16:05:00Z",
+  "review_comments": [
+    {
+      "id": 101,
+      "user": { "login": "hubot" },
+      "body": "Have we considered opaque tokens instead of sessions?"
+    },
+    {
+      "id": 102,
+      "user": { "login": "octocat" },
+      "body": "Yeah, but sessions let us revoke immediately without an extra lookup table."
+    }
+  ]
+}

--- a/backend/tests/test_fixtures.py
+++ b/backend/tests/test_fixtures.py
@@ -1,0 +1,31 @@
+from models import DecisionUnit
+
+
+def test_sample_decision_unit_is_a_valid_decision_unit(sample_decision_unit):
+    assert isinstance(sample_decision_unit, DecisionUnit)
+    assert sample_decision_unit.repo == "octocat/Hello-World"
+
+
+def test_tmp_chroma_client_is_usable(tmp_chroma_client):
+    collection = tmp_chroma_client.get_or_create_collection(name="decisions")
+    assert collection.count() == 0
+
+
+def test_load_fixture_parses_json_files(load_fixture):
+    commit = load_fixture("github_commit.json")
+    assert commit["sha"] == "6dcb09b5b57875f334f61aebed695e2e4193db5"
+
+    pr = load_fixture("github_pr.json")
+    assert pr["number"] == 42
+
+    extraction_ok = load_fixture("extraction_ok.json")
+    assert extraction_ok["title"] == "Switch auth to session tokens"
+
+    extraction_skip = load_fixture("extraction_skip.json")
+    assert extraction_skip["is_decision"] is False
+
+
+def test_load_fixture_returns_raw_text_for_non_json_files(load_fixture):
+    malformed = load_fixture("extraction_malformed.txt")
+    assert isinstance(malformed, str)
+    assert "{" in malformed

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -126,3 +126,50 @@ def test_list_prs_raises_github_error_on_non_2xx():
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.message == "Not Found"
+
+
+def test_list_prs_requests_sorted_by_updated_desc(load_fixture):
+    pr = load_fixture("github_pr.json")
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/comments"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=[_pr_list_payload(pr)])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get) as mock_get:
+        list_prs("octocat/Hello-World")
+
+    list_call_kwargs = mock_get.call_args_list[0].kwargs
+    assert list_call_kwargs["params"] == {
+        "state": "closed",
+        "sort": "updated",
+        "direction": "desc",
+    }
+
+
+def test_list_prs_filters_out_items_updated_before_since(load_fixture):
+    pr = load_fixture("github_pr.json")  # updated_at: 2026-03-14T16:05:00Z
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/comments"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=[_pr_list_payload(pr)])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        prs = list_prs("octocat/Hello-World", since="2026-04-01T00:00:00Z")
+
+    assert prs == []
+
+
+def test_list_prs_keeps_items_updated_on_or_after_since(load_fixture):
+    pr = load_fixture("github_pr.json")  # updated_at: 2026-03-14T16:05:00Z
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/comments"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=[_pr_list_payload(pr)])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        prs = list_prs("octocat/Hello-World", since="2026-03-01T00:00:00Z")
+
+    assert len(prs) == 1

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -4,7 +4,13 @@ import httpx
 import pytest
 
 import config
-from ingestion.github_client import CommitRef, GitHubError, list_commits
+from ingestion.github_client import (
+    CommitRef,
+    GitHubError,
+    PullRequestRef,
+    list_commits,
+    list_prs,
+)
 
 REQUIRED_ENV = {
     "GITHUB_TOKEN": "tok",
@@ -63,6 +69,60 @@ def test_list_commits_raises_github_error_on_non_2xx():
 
         with pytest.raises(GitHubError) as exc_info:
             list_commits("octocat/Hello-World")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "Not Found"
+
+
+def _pr_list_payload(pr: dict) -> dict:
+    return {key: value for key, value in pr.items() if key != "review_comments"}
+
+
+def test_list_prs_returns_typed_pull_request_refs_with_review_comments(load_fixture):
+    pr = load_fixture("github_pr.json")
+    review_comments = pr["review_comments"]
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/comments"):
+            return httpx.Response(200, json=review_comments)
+        return httpx.Response(200, json=[_pr_list_payload(pr)])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        prs = list_prs("octocat/Hello-World")
+
+    assert prs == [
+        PullRequestRef(
+            number=pr["number"],
+            title=pr["title"],
+            body=pr["body"],
+            url=pr["html_url"],
+            author=pr["user"]["login"],
+            merged_at=pr["merged_at"],
+            review_comments=[comment["body"] for comment in review_comments],
+        )
+    ]
+
+
+def test_list_prs_with_no_review_comments_returns_empty_list(load_fixture):
+    pr = load_fixture("github_pr.json")
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/comments"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=[_pr_list_payload(pr)])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        prs = list_prs("octocat/Hello-World")
+
+    assert prs[0].review_comments == []
+
+
+def test_list_prs_raises_github_error_on_non_2xx():
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(404, json={"message": "Not Found"})
+
+        with pytest.raises(GitHubError) as exc_info:
+            list_prs("octocat/Hello-World")
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.message == "Not Found"

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import config
+from ingestion.github_client import CommitRef, GitHubError, list_commits
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+
+
+def test_list_commits_returns_typed_commit_refs(load_fixture):
+    commit = load_fixture("github_commit.json")
+
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(200, json=[commit])
+
+        commits = list_commits("octocat/Hello-World")
+
+    assert commits == [
+        CommitRef(
+            sha=commit["sha"],
+            message=commit["commit"]["message"],
+            author=commit["commit"]["author"]["name"],
+            date=commit["commit"]["author"]["date"],
+            url=commit["html_url"],
+        )
+    ]
+
+
+def test_list_commits_passes_since_as_query_param(load_fixture):
+    commit = load_fixture("github_commit.json")
+
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(200, json=[commit])
+
+        list_commits("octocat/Hello-World", since="2026-01-01T00:00:00Z")
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"] == {"since": "2026-01-01T00:00:00Z"}
+
+
+def test_list_commits_raises_github_error_on_non_2xx():
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(404, json={"message": "Not Found"})
+
+        with pytest.raises(GitHubError) as exc_info:
+            list_commits("octocat/Hello-World")
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "Not Found"


### PR DESCRIPTION
Closes #16
Closes #17
Closes #18

## Changelog
- Added shared pytest fixtures (canned GitHub commit/PR payloads, extraction outputs) and a `conftest.py` with `sample_decision_unit`, `tmp_chroma_client`, and `load_fixture` fixtures for use across backend tests.
- Added `backend/ingestion/github_client.py` with `list_commits` (single page, typed `CommitRef`, `GitHubError` on failure).
- Extended `github_client.py` with `list_prs` (typed `PullRequestRef`, including per-PR review comments fetched via a follow-up call).
- Fixed `list_prs` silently ignoring its `since` cursor (found in review) — it now sorts by `updated` desc and filters client-side, since GitHub's PR list endpoint has no server-side `since` filter. Added coverage for both the sort params and the filtering behavior.