### PR TITLE
GitHub pagination/rate-limits + Ollama extraction & embedding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ GITHUB_TOKEN=
 # Comma-separated list of repos to index, e.g. anubhab-m02/BuFin,anubhab-m02/adr-engine
 INDEXED_REPOS=
 
+# Max seconds to wait out a GitHub rate-limit reset before failing loudly
+GITHUB_RATE_LIMIT_WAIT_CEILING_SECONDS=60
+
 # Local Ollama
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_EXTRACTION_MODEL=phi4-mini

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     ollama_embedding_model: str
     gemini_api_key: str
     chroma_data_dir: str = "./chroma_data"
+    github_rate_limit_wait_ceiling_seconds: float = 60
 
     @field_validator("indexed_repos", mode="before")
     @classmethod

--- a/backend/ingestion/embed.py
+++ b/backend/ingestion/embed.py
@@ -1,0 +1,38 @@
+"""Ollama embedding wrapper: text -> vector.
+
+Shared by ingestion (embedding decision units) and retrieval (embedding
+queries), per ARCHITECTURE.md.
+"""
+
+import httpx
+
+from config import get_settings
+
+
+class EmbeddingError(Exception):
+    """Raised on connection failure or an unexpected Ollama response shape."""
+
+
+def embed_text(text: str) -> list[float]:
+    settings = get_settings()
+
+    try:
+        response = httpx.post(
+            f"{settings.ollama_host}/api/embeddings",
+            json={"model": settings.ollama_embedding_model, "prompt": text},
+        )
+    except httpx.HTTPError as exc:
+        raise EmbeddingError(f"failed to reach Ollama for embedding: {exc}") from exc
+
+    if response.is_error:
+        raise EmbeddingError(f"Ollama returned {response.status_code} during embedding")
+
+    try:
+        embedding = response.json()["embedding"]
+    except (ValueError, KeyError) as exc:
+        raise EmbeddingError("Ollama embedding response missing 'embedding' field") from exc
+
+    if not isinstance(embedding, list):
+        raise EmbeddingError("Ollama embedding response 'embedding' field was not a list")
+
+    return [float(value) for value in embedding]

--- a/backend/ingestion/extract.py
+++ b/backend/ingestion/extract.py
@@ -1,0 +1,103 @@
+"""Ollama-based extraction: commit/PR text -> DecisionUnit fields.
+
+Local-only, per ROADMAP.md's privacy stance (no cloud fallback). The
+model classifies trivial changes as "not a decision"; malformed output
+is retried once with a stricter reinforcement before giving up.
+"""
+
+import json
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from config import get_settings
+
+_PROMPT_TEMPLATE = """You are extracting the engineering decision behind a \
+commit or pull request, if any.
+
+Title: {title}
+
+Body:
+{body}
+
+Respond with a single JSON object and nothing else.
+
+If this represents a real engineering decision (a deliberate choice with a \
+rationale — not a typo fix, formatting change, or routine dependency bump), \
+respond with exactly these keys:
+{{"is_decision": true, "decision": "<what was decided>", \
+"rationale": "<why, or empty string if not inferable>", \
+"alternatives": ["<alternative considered>", ...]}}
+
+If this is not a decision, respond with exactly:
+{{"is_decision": false, "reason": "<short reason>"}}
+"""
+
+_RETRY_REINFORCEMENT = "Return only the JSON object matching the schema above. No other text."
+
+
+class ExtractionError(Exception):
+    """Raised when Ollama can't be reached for extraction."""
+
+
+class ExtractionResult(BaseModel):
+    is_decision: bool
+    decision: str
+    rationale: str
+    alternatives: list[str]
+
+
+def _build_prompt(title: str, body: str, reinforce: bool = False) -> str:
+    prompt = _PROMPT_TEMPLATE.format(title=title, body=body)
+    if reinforce:
+        prompt = f"{prompt}\n{_RETRY_REINFORCEMENT}"
+    return prompt
+
+
+def _call_ollama(prompt: str) -> str:
+    settings = get_settings()
+    try:
+        response = httpx.post(
+            f"{settings.ollama_host}/api/generate",
+            json={
+                "model": settings.ollama_extraction_model,
+                "prompt": prompt,
+                "format": "json",
+                "stream": False,
+            },
+        )
+    except httpx.HTTPError as exc:
+        raise ExtractionError(f"failed to reach Ollama for extraction: {exc}") from exc
+
+    if response.is_error:
+        raise ExtractionError(f"Ollama returned {response.status_code} during extraction")
+
+    return response.json()["response"]
+
+
+def _parse(raw: str) -> ExtractionResult | None:
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+
+    if data.get("is_decision") is False:
+        return ExtractionResult(is_decision=False, decision="", rationale="", alternatives=[])
+
+    try:
+        return ExtractionResult(
+            is_decision=True,
+            decision=data["decision"],
+            rationale=data["rationale"],
+            alternatives=data["alternatives"],
+        )
+    except (KeyError, ValidationError):
+        return None
+
+
+def extract_decision(title: str, body: str) -> ExtractionResult | None:
+    result = _parse(_call_ollama(_build_prompt(title, body)))
+    if result is not None:
+        return result
+
+    return _parse(_call_ollama(_build_prompt(title, body, reinforce=True)))

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -1,9 +1,11 @@
 """GitHub REST client: typed commit/PR fetching.
 
 Returns typed models only — GitHub's raw JSON schema must not leak past
-this module, per ARCHITECTURE.md. Single page only; pagination and
-rate-limit handling are handled in a later module.
+this module, per ARCHITECTURE.md. Follows `Link: rel="next"` pagination
+and fails clearly on rate-limit exhaustion rather than hanging a run.
 """
+
+import time
 
 import httpx
 from pydantic import BaseModel
@@ -18,6 +20,20 @@ class GitHubError(Exception):
         self.status_code = status_code
         self.message = message
         super().__init__(f"GitHub API error {status_code}: {message}")
+
+
+class GitHubRateLimitError(GitHubError):
+    """Raised when honoring the rate limit would require waiting longer
+    than the configured ceiling."""
+
+    def __init__(self, wait_seconds: float, ceiling_seconds: float):
+        self.wait_seconds = wait_seconds
+        self.ceiling_seconds = ceiling_seconds
+        message = (
+            f"rate limit exhausted; reset in {wait_seconds:.0f}s exceeds "
+            f"the {ceiling_seconds:.0f}s wait ceiling"
+        )
+        super().__init__(429, message)
 
 
 class CommitRef(BaseModel):
@@ -38,6 +54,37 @@ class PullRequestRef(BaseModel):
     review_comments: list[str]
 
 
+class _RateLimiter:
+    """Tracks the last response's rate-limit headers across the several
+    requests one top-level call (pagination pages, per-PR sub-requests)
+    may issue."""
+
+    def __init__(self):
+        self._last_response: httpx.Response | None = None
+
+    def check(self) -> None:
+        if self._last_response is None:
+            return
+
+        remaining = self._last_response.headers.get("x-ratelimit-remaining")
+        if remaining is None or int(remaining) > 0:
+            return
+
+        reset = self._last_response.headers.get("x-ratelimit-reset")
+        if reset is None:
+            return
+
+        wait_seconds = max(0.0, float(reset) - time.time())
+        ceiling_seconds = get_settings().github_rate_limit_wait_ceiling_seconds
+        if wait_seconds > ceiling_seconds:
+            raise GitHubRateLimitError(wait_seconds, ceiling_seconds)
+
+        time.sleep(wait_seconds)
+
+    def record(self, response: httpx.Response) -> None:
+        self._last_response = response
+
+
 def _headers() -> dict:
     return {
         "Authorization": f"Bearer {get_settings().github_token}",
@@ -45,8 +92,10 @@ def _headers() -> dict:
     }
 
 
-def _get(path: str, params: dict | None = None) -> list | dict:
-    response = httpx.get(f"{GITHUB_API_URL}{path}", headers=_headers(), params=params)
+def _get(url: str, rate_limiter: _RateLimiter, params: dict | None = None) -> httpx.Response:
+    rate_limiter.check()
+    response = httpx.get(url, headers=_headers(), params=params)
+    rate_limiter.record(response)
 
     if response.is_error:
         try:
@@ -55,12 +104,26 @@ def _get(path: str, params: dict | None = None) -> list | dict:
             message = response.text
         raise GitHubError(response.status_code, message)
 
-    return response.json()
+    return response
+
+
+def _paginate(path: str, rate_limiter: _RateLimiter, params: dict | None = None) -> list:
+    url = f"{GITHUB_API_URL}{path}"
+    items: list = []
+
+    while url:
+        response = _get(url, rate_limiter, params=params)
+        items.extend(response.json())
+        params = None  # the next-page URL already carries the query string
+        url = response.links.get("next", {}).get("url")
+
+    return items
 
 
 def list_commits(repo: str, since: str | None = None) -> list[CommitRef]:
     params = {"since": since} if since else None
-    data = _get(f"/repos/{repo}/commits", params=params)
+    rate_limiter = _RateLimiter()
+    data = _paginate(f"/repos/{repo}/commits", rate_limiter, params=params)
 
     return [
         CommitRef(
@@ -74,8 +137,8 @@ def list_commits(repo: str, since: str | None = None) -> list[CommitRef]:
     ]
 
 
-def _list_review_comments(repo: str, number: int) -> list[str]:
-    data = _get(f"/repos/{repo}/pulls/{number}/comments")
+def _list_review_comments(repo: str, number: int, rate_limiter: _RateLimiter) -> list[str]:
+    data = _paginate(f"/repos/{repo}/pulls/{number}/comments", rate_limiter)
     return [comment["body"] for comment in data]
 
 
@@ -83,7 +146,8 @@ def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
     # GitHub's PR list endpoint has no server-side "since" filter (unlike
     # /commits), so we sort newest-updated first and filter client-side.
     params = {"state": "closed", "sort": "updated", "direction": "desc"}
-    data = _get(f"/repos/{repo}/pulls", params=params)
+    rate_limiter = _RateLimiter()
+    data = _paginate(f"/repos/{repo}/pulls", rate_limiter, params=params)
 
     if since:
         data = [item for item in data if item["updated_at"] >= since]
@@ -96,7 +160,7 @@ def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
             url=item["html_url"],
             author=item["user"]["login"],
             merged_at=item["merged_at"],
-            review_comments=_list_review_comments(repo, item["number"]),
+            review_comments=_list_review_comments(repo, item["number"], rate_limiter),
         )
         for item in data
     ]

--- a/backend/tests/test_embed.py
+++ b/backend/tests/test_embed.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import config
+from ingestion.embed import EmbeddingError, embed_text
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+
+
+def test_embed_text_returns_vector_on_success():
+    with patch("ingestion.embed.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"embedding": [0.1, 0.2, 0.3]})
+
+        vector = embed_text("some decision text")
+
+    assert vector == [0.1, 0.2, 0.3]
+    assert all(isinstance(value, float) for value in vector)
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == {"model": "nomic-embed-text", "prompt": "some decision text"}
+
+
+def test_embed_text_raises_embedding_error_on_connection_failure():
+    with patch("ingestion.embed.httpx.post", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(EmbeddingError):
+            embed_text("some decision text")
+
+
+def test_embed_text_raises_embedding_error_on_non_2xx():
+    with patch("ingestion.embed.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(500, json={"error": "boom"})
+
+        with pytest.raises(EmbeddingError):
+            embed_text("some decision text")
+
+
+def test_embed_text_raises_embedding_error_on_unexpected_response_shape():
+    with patch("ingestion.embed.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"unexpected": "shape"})
+
+        with pytest.raises(EmbeddingError):
+            embed_text("some decision text")

--- a/backend/tests/test_extract.py
+++ b/backend/tests/test_extract.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import config
+from ingestion.extract import ExtractionError, ExtractionResult, extract_decision
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+
+
+def _ollama_response(text: str) -> httpx.Response:
+    return httpx.Response(200, json={"response": text})
+
+
+def test_extract_decision_returns_result_on_well_formed_json(load_fixture):
+    ok = load_fixture("extraction_ok.json")
+
+    with patch("ingestion.extract.httpx.post") as mock_post:
+        mock_post.return_value = _ollama_response(json.dumps(ok))
+
+        result = extract_decision(ok["title"], "body text")
+
+    assert result == ExtractionResult(
+        is_decision=True,
+        decision=ok["decision"],
+        rationale=ok["rationale"],
+        alternatives=ok["alternatives"],
+    )
+    assert mock_post.call_count == 1
+
+
+def test_extract_decision_retries_once_on_malformed_json_then_succeeds(load_fixture):
+    malformed = load_fixture("extraction_malformed.txt")
+    ok = load_fixture("extraction_ok.json")
+
+    with patch("ingestion.extract.httpx.post") as mock_post:
+        mock_post.side_effect = [
+            _ollama_response(malformed),
+            _ollama_response(json.dumps(ok)),
+        ]
+
+        result = extract_decision(ok["title"], "body text")
+
+    assert mock_post.call_count == 2
+    assert result == ExtractionResult(
+        is_decision=True,
+        decision=ok["decision"],
+        rationale=ok["rationale"],
+        alternatives=ok["alternatives"],
+    )
+
+
+def test_extract_decision_returns_none_after_two_malformed_attempts(load_fixture):
+    malformed = load_fixture("extraction_malformed.txt")
+
+    with patch("ingestion.extract.httpx.post") as mock_post:
+        mock_post.return_value = _ollama_response(malformed)
+
+        result = extract_decision("Switch auth to session tokens", "body text")
+
+    assert result is None
+    assert mock_post.call_count == 2
+
+
+def test_extract_decision_returns_not_a_decision_for_skip_signal(load_fixture):
+    skip = load_fixture("extraction_skip.json")
+
+    with patch("ingestion.extract.httpx.post") as mock_post:
+        mock_post.return_value = _ollama_response(json.dumps(skip))
+
+        result = extract_decision("Fix typo in README", "body text")
+
+    assert result == ExtractionResult(
+        is_decision=False, decision="", rationale="", alternatives=[]
+    )
+
+
+def test_extract_decision_raises_extraction_error_on_connection_failure():
+    with patch("ingestion.extract.httpx.post", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(ExtractionError):
+            extract_decision("title", "body text")

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 
 import httpx
@@ -7,6 +8,7 @@ import config
 from ingestion.github_client import (
     CommitRef,
     GitHubError,
+    GitHubRateLimitError,
     PullRequestRef,
     list_commits,
     list_prs,
@@ -173,3 +175,71 @@ def test_list_prs_keeps_items_updated_on_or_after_since(load_fixture):
         prs = list_prs("octocat/Hello-World", since="2026-03-01T00:00:00Z")
 
     assert len(prs) == 1
+
+
+def test_list_commits_follows_pagination_link_header(load_fixture):
+    commit = load_fixture("github_commit.json")
+    base_url = "https://api.github.com/repos/octocat/Hello-World/commits"
+    page2_url = f"{base_url}?page=2"
+    page3_url = f"{base_url}?page=3"
+
+    responses = [
+        httpx.Response(200, json=[commit], headers={"Link": f'<{page2_url}>; rel="next"'}),
+        httpx.Response(200, json=[commit], headers={"Link": f'<{page3_url}>; rel="next"'}),
+        httpx.Response(200, json=[commit]),
+    ]
+
+    with patch("ingestion.github_client.httpx.get", side_effect=responses) as mock_get:
+        commits = list_commits("octocat/Hello-World")
+
+    assert len(commits) == 3
+    assert mock_get.call_count == 3
+    assert mock_get.call_args_list[1].args[0] == page2_url
+    assert mock_get.call_args_list[2].args[0] == page3_url
+
+
+def test_list_commits_raises_rate_limit_error_when_wait_exceeds_ceiling():
+    reset_far_future = time.time() + 3600  # well beyond the default 60s ceiling
+    exhausted = httpx.Response(
+        200,
+        json=[],
+        headers={
+            "Link": (
+                '<https://api.github.com/repos/octocat/Hello-World/commits?page=2>; '
+                'rel="next"'
+            ),
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(reset_far_future)),
+        },
+    )
+
+    with patch("ingestion.github_client.httpx.get", return_value=exhausted) as mock_get:
+        with pytest.raises(GitHubRateLimitError):
+            list_commits("octocat/Hello-World")
+
+    assert mock_get.call_count == 1
+
+
+def test_list_commits_waits_and_continues_when_wait_is_within_ceiling(load_fixture):
+    commit = load_fixture("github_commit.json")
+    reset_soon = time.time() + 5  # well within the default 60s ceiling
+    page1 = httpx.Response(
+        200,
+        json=[commit],
+        headers={
+            "Link": (
+                '<https://api.github.com/repos/octocat/Hello-World/commits?page=2>; '
+                'rel="next"'
+            ),
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(reset_soon)),
+        },
+    )
+    page2 = httpx.Response(200, json=[commit])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=[page1, page2]):
+        with patch("ingestion.github_client.time.sleep") as mock_sleep:
+            commits = list_commits("octocat/Hello-World")
+
+    assert len(commits) == 2
+    mock_sleep.assert_called_once()


### PR DESCRIPTION
Closes #19
Closes #20
Closes #21

## Changelog
- GitHub client: Link-header pagination for commits/PRs, rate-limit-aware requests with a configurable wait ceiling (`GitHubRateLimitError` when the reset wait would exceed it)
- Ollama extraction module (`ingestion/extract.py`): commit/PR text -> `ExtractionResult`, with malformed-output retry and a "not a decision" skip signal
- Ollama embedding wrapper (`ingestion/embed.py`): `embed_text()` for both ingestion and future retrieval use