### PR TITLE
Request timeouts + ingestion orchestrator + POST /ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ INDEXED_REPOS=
 # Max seconds to wait out a GitHub rate-limit reset before failing loudly
 GITHUB_RATE_LIMIT_WAIT_CEILING_SECONDS=60
 
+# Per-request timeout (seconds) for outbound GitHub API calls
+GITHUB_REQUEST_TIMEOUT_SECONDS=10
+
+# Per-request timeout (seconds) for outbound Ollama calls (extraction/embedding)
+OLLAMA_REQUEST_TIMEOUT_SECONDS=60
+
 # Local Ollama
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_EXTRACTION_MODEL=phi4-mini

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     gemini_api_key: str
     chroma_data_dir: str = "./chroma_data"
     github_rate_limit_wait_ceiling_seconds: float = 60
+    github_request_timeout_seconds: float = 10
+    ollama_request_timeout_seconds: float = 60
 
     @field_validator("indexed_repos", mode="before")
     @classmethod

--- a/backend/ingestion/embed.py
+++ b/backend/ingestion/embed.py
@@ -20,6 +20,7 @@ def embed_text(text: str) -> list[float]:
         response = httpx.post(
             f"{settings.ollama_host}/api/embeddings",
             json={"model": settings.ollama_embedding_model, "prompt": text},
+            timeout=settings.ollama_request_timeout_seconds,
         )
     except httpx.HTTPError as exc:
         raise EmbeddingError(f"failed to reach Ollama for embedding: {exc}") from exc

--- a/backend/ingestion/extract.py
+++ b/backend/ingestion/extract.py
@@ -65,6 +65,7 @@ def _call_ollama(prompt: str) -> str:
                 "format": "json",
                 "stream": False,
             },
+            timeout=settings.ollama_request_timeout_seconds,
         )
     except httpx.HTTPError as exc:
         raise ExtractionError(f"failed to reach Ollama for extraction: {exc}") from exc

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -94,7 +94,15 @@ def _headers() -> dict:
 
 def _get(url: str, rate_limiter: _RateLimiter, params: dict | None = None) -> httpx.Response:
     rate_limiter.check()
-    response = httpx.get(url, headers=_headers(), params=params)
+    try:
+        response = httpx.get(
+            url,
+            headers=_headers(),
+            params=params,
+            timeout=get_settings().github_request_timeout_seconds,
+        )
+    except httpx.TimeoutException as exc:
+        raise GitHubError(504, f"request to GitHub timed out: {exc}") from exc
     rate_limiter.record(response)
 
     if response.is_error:

--- a/backend/ingestion/run.py
+++ b/backend/ingestion/run.py
@@ -1,0 +1,122 @@
+"""Ingestion orchestrator: fetch -> extract -> embed -> store, per repo.
+
+Per-item fault-tolerant (a commit/PR the extractor can't parse, or that
+isn't a decision, is skipped and counted); per-run fail-loud (GitHub or
+Ollama being unreachable propagates and aborts the run without advancing
+the cursor), per ARCHITECTURE.md's error-handling conventions.
+"""
+
+from ingestion import embed, extract, github_client, store
+from ingestion.github_client import CommitRef, PullRequestRef
+from models import DecisionUnit, IngestResult
+
+
+def _split_commit_message(message: str) -> tuple[str, str]:
+    title, _, rest = message.partition("\n")
+    return title, rest.strip()
+
+
+def _commit_unit(repo: str, commit: CommitRef, result: extract.ExtractionResult) -> DecisionUnit:
+    return DecisionUnit(
+        id=f"{repo}:commit:{commit.sha}",
+        repo=repo,
+        kind="commit",
+        ref=commit.sha,
+        url=commit.url,
+        author=commit.author,
+        date=commit.date,
+        title=_split_commit_message(commit.message)[0],
+        decision=result.decision,
+        rationale=result.rationale,
+        alternatives=result.alternatives,
+        source_excerpt=commit.message.strip(),
+    )
+
+
+def _pr_body(pr: PullRequestRef) -> str:
+    return "\n\n".join([pr.body, *pr.review_comments]).strip()
+
+
+def _pr_unit(repo: str, pr: PullRequestRef, body: str, result: extract.ExtractionResult) -> DecisionUnit:
+    return DecisionUnit(
+        id=f"{repo}:pr:{pr.number}",
+        repo=repo,
+        kind="pr",
+        ref=str(pr.number),
+        url=pr.url,
+        author=pr.author,
+        date=pr.merged_at or "",
+        title=pr.title,
+        decision=result.decision,
+        rationale=result.rationale,
+        alternatives=result.alternatives,
+        source_excerpt=body,
+    )
+
+
+def _ingest_commits(repo: str, commits: list[CommitRef]) -> tuple[int, int, list[DecisionUnit]]:
+    extracted = 0
+    skipped = 0
+    units: list[DecisionUnit] = []
+
+    for commit in commits:
+        title, body = _split_commit_message(commit.message)
+        result = extract.extract_decision(title, body)
+        if result is None or not result.is_decision:
+            skipped += 1
+            continue
+
+        extracted += 1
+        vector = embed.embed_text(result.decision)
+        unit = _commit_unit(repo, commit, result)
+        store.upsert_units([unit], embeddings=[vector])
+        units.append(unit)
+
+    return extracted, skipped, units
+
+
+def _ingest_prs(repo: str, prs: list[PullRequestRef]) -> tuple[int, int, list[DecisionUnit]]:
+    extracted = 0
+    skipped = 0
+    units: list[DecisionUnit] = []
+
+    for pr in prs:
+        body = _pr_body(pr)
+        result = extract.extract_decision(pr.title, body)
+        if result is None or not result.is_decision:
+            skipped += 1
+            continue
+
+        extracted += 1
+        vector = embed.embed_text(result.decision)
+        unit = _pr_unit(repo, pr, body, result)
+        store.upsert_units([unit], embeddings=[vector])
+        units.append(unit)
+
+    return extracted, skipped, units
+
+
+def run_ingestion(repo: str) -> IngestResult:
+    cursor = store.get_cursor(repo)
+
+    commits = github_client.list_commits(repo, since=cursor.get("last_commit_date"))
+    prs = github_client.list_prs(repo, since=cursor.get("last_pr_updated_at"))
+
+    commit_extracted, commit_skipped, commit_units = _ingest_commits(repo, commits)
+    pr_extracted, pr_skipped, pr_units = _ingest_prs(repo, prs)
+
+    new_cursor = dict(cursor)
+    if commits:
+        new_cursor["last_commit_date"] = max(commit.date for commit in commits)
+    pr_dates = [pr.merged_at for pr in prs if pr.merged_at]
+    if pr_dates:
+        new_cursor["last_pr_updated_at"] = max(pr_dates)
+    store.set_cursor(repo, new_cursor)
+
+    return IngestResult(
+        repo=repo,
+        fetched=len(commits) + len(prs),
+        extracted=commit_extracted + pr_extracted,
+        skipped=commit_skipped + pr_skipped,
+        stored=len(commit_units) + len(pr_units),
+    )

--- a/backend/ingestion/run.py
+++ b/backend/ingestion/run.py
@@ -6,6 +6,8 @@ Ollama being unreachable propagates and aborts the run without advancing
 the cursor), per ARCHITECTURE.md's error-handling conventions.
 """
 
+from typing import Callable
+
 from ingestion import embed, extract, github_client, store
 from ingestion.github_client import CommitRef, PullRequestRef
 from models import DecisionUnit, IngestResult
@@ -54,13 +56,17 @@ def _pr_unit(repo: str, pr: PullRequestRef, body: str, result: extract.Extractio
     )
 
 
-def _ingest_commits(repo: str, commits: list[CommitRef]) -> tuple[int, int, list[DecisionUnit]]:
+def _ingest_items(
+    items: list,
+    title_body: Callable[[object], tuple[str, str]],
+    build_unit: Callable[[object, str, extract.ExtractionResult], DecisionUnit],
+) -> tuple[int, int, list[DecisionUnit]]:
     extracted = 0
     skipped = 0
     units: list[DecisionUnit] = []
 
-    for commit in commits:
-        title, body = _split_commit_message(commit.message)
+    for item in items:
+        title, body = title_body(item)
         result = extract.extract_decision(title, body)
         if result is None or not result.is_decision:
             skipped += 1
@@ -68,28 +74,7 @@ def _ingest_commits(repo: str, commits: list[CommitRef]) -> tuple[int, int, list
 
         extracted += 1
         vector = embed.embed_text(result.decision)
-        unit = _commit_unit(repo, commit, result)
-        store.upsert_units([unit], embeddings=[vector])
-        units.append(unit)
-
-    return extracted, skipped, units
-
-
-def _ingest_prs(repo: str, prs: list[PullRequestRef]) -> tuple[int, int, list[DecisionUnit]]:
-    extracted = 0
-    skipped = 0
-    units: list[DecisionUnit] = []
-
-    for pr in prs:
-        body = _pr_body(pr)
-        result = extract.extract_decision(pr.title, body)
-        if result is None or not result.is_decision:
-            skipped += 1
-            continue
-
-        extracted += 1
-        vector = embed.embed_text(result.decision)
-        unit = _pr_unit(repo, pr, body, result)
+        unit = build_unit(item, body, result)
         store.upsert_units([unit], embeddings=[vector])
         units.append(unit)
 
@@ -102,8 +87,16 @@ def run_ingestion(repo: str) -> IngestResult:
     commits = github_client.list_commits(repo, since=cursor.get("last_commit_date"))
     prs = github_client.list_prs(repo, since=cursor.get("last_pr_updated_at"))
 
-    commit_extracted, commit_skipped, commit_units = _ingest_commits(repo, commits)
-    pr_extracted, pr_skipped, pr_units = _ingest_prs(repo, prs)
+    commit_extracted, commit_skipped, commit_units = _ingest_items(
+        commits,
+        title_body=lambda commit: _split_commit_message(commit.message),
+        build_unit=lambda commit, _body, result: _commit_unit(repo, commit, result),
+    )
+    pr_extracted, pr_skipped, pr_units = _ingest_items(
+        prs,
+        title_body=lambda pr: (pr.title, _pr_body(pr)),
+        build_unit=lambda pr, body, result: _pr_unit(repo, pr, body, result),
+    )
 
     new_cursor = dict(cursor)
     if commits:

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,10 @@
 from fastapi import FastAPI
 
 from chroma_client import get_chroma_client
+from routers.ingest import router as ingest_router
 
 app = FastAPI(title="adr-engine")
+app.include_router(ingest_router)
 
 
 @app.get("/health")

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,0 +1,19 @@
+"""POST /ingest: thin wiring from HTTP to ingestion.run.run_ingestion.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. No business logic here.
+"""
+
+from fastapi import APIRouter
+
+from config import get_settings
+from ingestion.run import run_ingestion
+from models import IngestRequest, IngestResponse
+
+router = APIRouter()
+
+
+@router.post("/ingest", response_model=IngestResponse)
+def ingest(request: IngestRequest = IngestRequest()) -> IngestResponse:
+    repos = [request.repo] if request.repo else get_settings().indexed_repos
+    return IngestResponse(repos=[run_ingestion(repo) for repo in repos])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,9 +13,31 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import chromadb
 import pytest
 
+import config
 from models import DecisionUnit
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    """Populate required Settings env vars for every test; individual
+    tests/modules can monkeypatch additional overrides afterward."""
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
 
 
 @pytest.fixture

--- a/backend/tests/test_embed.py
+++ b/backend/tests/test_embed.py
@@ -59,3 +59,19 @@ def test_embed_text_raises_embedding_error_on_unexpected_response_shape():
 
         with pytest.raises(EmbeddingError):
             embed_text("some decision text")
+
+
+def test_embed_text_raises_embedding_error_on_timeout():
+    with patch("ingestion.embed.httpx.post", side_effect=httpx.TimeoutException("timed out")):
+        with pytest.raises(EmbeddingError):
+            embed_text("some decision text")
+
+
+def test_embed_text_passes_configured_timeout():
+    with patch("ingestion.embed.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"embedding": [0.1]})
+
+        embed_text("some decision text")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == config.get_settings().ollama_request_timeout_seconds

--- a/backend/tests/test_embed.py
+++ b/backend/tests/test_embed.py
@@ -6,25 +6,6 @@ import pytest
 import config
 from ingestion.embed import EmbeddingError, embed_text
 
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
-
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-    config.get_settings.cache_clear()
-
-    yield
-
-    config.get_settings.cache_clear()
-
 
 def test_embed_text_returns_vector_on_success():
     with patch("ingestion.embed.httpx.post") as mock_post:

--- a/backend/tests/test_extract.py
+++ b/backend/tests/test_extract.py
@@ -98,3 +98,21 @@ def test_extract_decision_raises_extraction_error_on_connection_failure():
     with patch("ingestion.extract.httpx.post", side_effect=httpx.ConnectError("refused")):
         with pytest.raises(ExtractionError):
             extract_decision("title", "body text")
+
+
+def test_extract_decision_raises_extraction_error_on_timeout():
+    with patch("ingestion.extract.httpx.post", side_effect=httpx.TimeoutException("timed out")):
+        with pytest.raises(ExtractionError):
+            extract_decision("title", "body text")
+
+
+def test_call_ollama_passes_configured_timeout(load_fixture):
+    ok = load_fixture("extraction_ok.json")
+
+    with patch("ingestion.extract.httpx.post") as mock_post:
+        mock_post.return_value = _ollama_response(json.dumps(ok))
+
+        extract_decision(ok["title"], "body text")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == config.get_settings().ollama_request_timeout_seconds

--- a/backend/tests/test_extract.py
+++ b/backend/tests/test_extract.py
@@ -7,25 +7,6 @@ import pytest
 import config
 from ingestion.extract import ExtractionError, ExtractionResult, extract_decision
 
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
-
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-    config.get_settings.cache_clear()
-
-    yield
-
-    config.get_settings.cache_clear()
-
 
 def _ollama_response(text: str) -> httpx.Response:
     return httpx.Response(200, json={"response": text})

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -220,6 +220,26 @@ def test_list_commits_raises_rate_limit_error_when_wait_exceeds_ceiling():
     assert mock_get.call_count == 1
 
 
+def test_get_passes_configured_timeout(load_fixture):
+    commit = load_fixture("github_commit.json")
+
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(200, json=[commit])
+
+        list_commits("octocat/Hello-World")
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["timeout"] == config.get_settings().github_request_timeout_seconds
+
+
+def test_list_commits_raises_github_error_on_timeout():
+    with patch("ingestion.github_client.httpx.get", side_effect=httpx.TimeoutException("timed out")):
+        with pytest.raises(GitHubError) as exc_info:
+            list_commits("octocat/Hello-World")
+
+    assert exc_info.value.status_code == 504
+
+
 def test_list_commits_waits_and_continues_when_wait_is_within_ceiling(load_fixture):
     commit = load_fixture("github_commit.json")
     reset_soon = time.time() + 5  # well within the default 60s ceiling

--- a/backend/tests/test_github_client.py
+++ b/backend/tests/test_github_client.py
@@ -14,25 +14,6 @@ from ingestion.github_client import (
     list_prs,
 )
 
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
-
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-    config.get_settings.cache_clear()
-
-    yield
-
-    config.get_settings.cache_clear()
-
 
 def test_list_commits_returns_typed_commit_refs(load_fixture):
     commit = load_fixture("github_commit.json")
@@ -84,7 +65,7 @@ def test_list_prs_returns_typed_pull_request_refs_with_review_comments(load_fixt
     pr = load_fixture("github_pr.json")
     review_comments = pr["review_comments"]
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         if url.endswith("/comments"):
             return httpx.Response(200, json=review_comments)
         return httpx.Response(200, json=[_pr_list_payload(pr)])
@@ -108,7 +89,7 @@ def test_list_prs_returns_typed_pull_request_refs_with_review_comments(load_fixt
 def test_list_prs_with_no_review_comments_returns_empty_list(load_fixture):
     pr = load_fixture("github_pr.json")
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         if url.endswith("/comments"):
             return httpx.Response(200, json=[])
         return httpx.Response(200, json=[_pr_list_payload(pr)])
@@ -133,7 +114,7 @@ def test_list_prs_raises_github_error_on_non_2xx():
 def test_list_prs_requests_sorted_by_updated_desc(load_fixture):
     pr = load_fixture("github_pr.json")
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         if url.endswith("/comments"):
             return httpx.Response(200, json=[])
         return httpx.Response(200, json=[_pr_list_payload(pr)])
@@ -152,7 +133,7 @@ def test_list_prs_requests_sorted_by_updated_desc(load_fixture):
 def test_list_prs_filters_out_items_updated_before_since(load_fixture):
     pr = load_fixture("github_pr.json")  # updated_at: 2026-03-14T16:05:00Z
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         if url.endswith("/comments"):
             return httpx.Response(200, json=[])
         return httpx.Response(200, json=[_pr_list_payload(pr)])
@@ -166,7 +147,7 @@ def test_list_prs_filters_out_items_updated_before_since(load_fixture):
 def test_list_prs_keeps_items_updated_on_or_after_since(load_fixture):
     pr = load_fixture("github_pr.json")  # updated_at: 2026-03-14T16:05:00Z
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         if url.endswith("/comments"):
             return httpx.Response(200, json=[])
         return httpx.Response(200, json=[_pr_list_payload(pr)])

--- a/backend/tests/test_ingest_router.py
+++ b/backend/tests/test_ingest_router.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
 from unittest.mock import call, patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,19 +7,12 @@ import config
 from main import app
 from models import IngestResult
 
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/a,owner/b",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
 
 @pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
+def _multi_repo_env(monkeypatch):
+    """This router exercises multi-repo fan-out, so override conftest's
+    single-repo default (runs after conftest's autouse _settings_env)."""
+    monkeypatch.setenv("INDEXED_REPOS", "owner/a,owner/b")
     config.get_settings.cache_clear()
 
     yield

--- a/backend/tests/test_ingest_router.py
+++ b/backend/tests/test_ingest_router.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+from unittest.mock import call, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import config
+from main import app
+from models import IngestResult
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/a,owner/b",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+
+
+client = TestClient(app)
+
+
+def _result(repo: str) -> IngestResult:
+    return IngestResult(repo=repo, fetched=1, extracted=1, skipped=0, stored=1)
+
+
+def test_ingest_with_repo_runs_just_that_repo():
+    with patch("routers.ingest.run_ingestion") as run_ingestion:
+        run_ingestion.return_value = _result("owner/a")
+
+        response = client.post("/ingest", json={"repo": "owner/a"})
+
+    assert response.status_code == 200
+    run_ingestion.assert_called_once_with("owner/a")
+    assert response.json() == {"repos": [_result("owner/a").model_dump()]}
+
+
+def test_ingest_with_empty_json_body_runs_all_configured_repos():
+    with patch("routers.ingest.run_ingestion") as run_ingestion:
+        run_ingestion.side_effect = _result
+
+        response = client.post("/ingest", json={})
+
+    assert response.status_code == 200
+    assert run_ingestion.call_args_list == [call("owner/a"), call("owner/b")]
+    assert [r["repo"] for r in response.json()["repos"]] == ["owner/a", "owner/b"]
+
+
+def test_ingest_with_no_body_at_all_runs_all_configured_repos():
+    with patch("routers.ingest.run_ingestion") as run_ingestion:
+        run_ingestion.side_effect = _result
+
+        response = client.post("/ingest")
+
+    assert response.status_code == 200
+    assert run_ingestion.call_args_list == [call("owner/a"), call("owner/b")]
+
+
+def test_ingest_response_matches_ingest_response_shape():
+    with patch("routers.ingest.run_ingestion") as run_ingestion:
+        run_ingestion.return_value = _result("owner/a")
+
+        response = client.post("/ingest", json={"repo": "owner/a"})
+
+    body = response.json()
+    assert set(body.keys()) == {"repos"}
+    assert set(body["repos"][0].keys()) == {"repo", "fetched", "extracted", "skipped", "stored"}

--- a/backend/tests/test_ingestion_run.py
+++ b/backend/tests/test_ingestion_run.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 
@@ -12,14 +8,6 @@ from ingestion.extract import ExtractionResult
 from ingestion.github_client import CommitRef, GitHubError, PullRequestRef
 from ingestion.run import run_ingestion
 from models import IngestResult
-
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
 
 DECISION = ExtractionResult(
     is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=["Memcached"]
@@ -48,17 +36,6 @@ def _pr(number=1, title="Add caching layer", body="Use Redis.", merged_at="2026-
         merged_at=merged_at,
         review_comments=review_comments or [],
     )
-
-
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-    config.get_settings.cache_clear()
-
-    yield
-
-    config.get_settings.cache_clear()
 
 
 @pytest.fixture

--- a/backend/tests/test_ingestion_run.py
+++ b/backend/tests/test_ingestion_run.py
@@ -1,0 +1,186 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+
+import chroma_client
+import config
+from ingestion.extract import ExtractionResult
+from ingestion.github_client import CommitRef, GitHubError, PullRequestRef
+from ingestion.run import run_ingestion
+from models import IngestResult
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+DECISION = ExtractionResult(
+    is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=["Memcached"]
+)
+NOT_A_DECISION = ExtractionResult(is_decision=False, decision="", rationale="", alternatives=[])
+
+
+def _commit(sha="abc123", message="Switch auth to sessions\n\nDropped JWTs.", date="2026-01-01T00:00:00Z"):
+    return CommitRef(
+        sha=sha,
+        message=message,
+        author="octocat",
+        date=date,
+        url=f"https://github.com/owner/repo/commit/{sha}",
+    )
+
+
+def _pr(number=1, title="Add caching layer", body="Use Redis.", merged_at="2026-02-01T00:00:00Z",
+        review_comments=None):
+    return PullRequestRef(
+        number=number,
+        title=title,
+        body=body,
+        url=f"https://github.com/owner/repo/pull/{number}",
+        author="octocat",
+        merged_at=merged_at,
+        review_comments=review_comments or [],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+    config.get_settings.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+
+
+@pytest.fixture
+def mocks():
+    with patch("ingestion.run.github_client.list_commits") as list_commits, \
+            patch("ingestion.run.github_client.list_prs") as list_prs, \
+            patch("ingestion.run.extract.extract_decision") as extract_decision, \
+            patch("ingestion.run.embed.embed_text") as embed_text, \
+            patch("ingestion.run.store.get_cursor") as get_cursor, \
+            patch("ingestion.run.store.set_cursor") as set_cursor, \
+            patch("ingestion.run.store.upsert_units") as upsert_units:
+        get_cursor.return_value = {}
+        embed_text.return_value = [0.1, 0.2]
+        yield {
+            "list_commits": list_commits,
+            "list_prs": list_prs,
+            "extract_decision": extract_decision,
+            "embed_text": embed_text,
+            "get_cursor": get_cursor,
+            "set_cursor": set_cursor,
+            "upsert_units": upsert_units,
+        }
+
+
+def test_run_ingestion_returns_counts_for_a_full_run(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["list_prs"].return_value = [_pr()]
+    mocks["extract_decision"].return_value = DECISION
+
+    result = run_ingestion("owner/repo")
+
+    assert result == IngestResult(repo="owner/repo", fetched=2, extracted=2, skipped=0, stored=2)
+    assert mocks["upsert_units"].call_count == 2
+    mocks["set_cursor"].assert_called_once()
+
+
+def test_run_ingestion_skips_non_decision_items(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["list_prs"].return_value = [_pr()]
+    mocks["extract_decision"].return_value = NOT_A_DECISION
+
+    result = run_ingestion("owner/repo")
+
+    assert result == IngestResult(repo="owner/repo", fetched=2, extracted=0, skipped=2, stored=0)
+    mocks["upsert_units"].assert_not_called()
+    mocks["set_cursor"].assert_called_once()
+
+
+def test_run_ingestion_skips_malformed_extraction_result(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["list_prs"].return_value = []
+    mocks["extract_decision"].return_value = None
+
+    result = run_ingestion("owner/repo")
+
+    assert result.skipped == 1
+    assert result.stored == 0
+
+
+def test_run_ingestion_advances_cursor_to_newest_fetched_dates(mocks):
+    mocks["list_commits"].return_value = [
+        _commit(sha="a", date="2026-01-01T00:00:00Z"),
+        _commit(sha="b", date="2026-01-05T00:00:00Z"),
+    ]
+    mocks["list_prs"].return_value = [
+        _pr(number=1, merged_at="2026-02-01T00:00:00Z"),
+        _pr(number=2, merged_at="2026-02-10T00:00:00Z"),
+    ]
+    mocks["extract_decision"].return_value = NOT_A_DECISION
+
+    run_ingestion("owner/repo")
+
+    mocks["set_cursor"].assert_called_once_with(
+        "owner/repo",
+        {"last_commit_date": "2026-01-05T00:00:00Z", "last_pr_updated_at": "2026-02-10T00:00:00Z"},
+    )
+
+
+def test_run_ingestion_passes_cursor_since_to_github_client(mocks):
+    mocks["get_cursor"].return_value = {
+        "last_commit_date": "2026-01-01T00:00:00Z",
+        "last_pr_updated_at": "2026-02-01T00:00:00Z",
+    }
+    mocks["list_commits"].return_value = []
+    mocks["list_prs"].return_value = []
+
+    run_ingestion("owner/repo")
+
+    mocks["list_commits"].assert_called_once_with("owner/repo", since="2026-01-01T00:00:00Z")
+    mocks["list_prs"].assert_called_once_with("owner/repo", since="2026-02-01T00:00:00Z")
+
+
+def test_run_ingestion_raises_and_does_not_advance_cursor_on_github_error(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["list_prs"].side_effect = GitHubError(403, "rate limited")
+
+    with pytest.raises(GitHubError):
+        run_ingestion("owner/repo")
+
+    mocks["set_cursor"].assert_not_called()
+    mocks["upsert_units"].assert_not_called()
+
+
+def test_run_ingestion_does_not_duplicate_stored_units_on_repeat_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+    from ingestion import store
+
+    with patch("ingestion.run.github_client.list_commits") as list_commits, \
+            patch("ingestion.run.github_client.list_prs") as list_prs, \
+            patch("ingestion.run.extract.extract_decision") as extract_decision, \
+            patch("ingestion.run.embed.embed_text") as embed_text:
+        list_commits.return_value = [_commit()]
+        list_prs.return_value = []
+        extract_decision.return_value = DECISION
+        embed_text.return_value = [0.1, 0.2]
+
+        run_ingestion("owner/repo")
+        run_ingestion("owner/repo")
+
+    assert store.get_collection().count() == 1
+
+    chroma_client.get_chroma_client.cache_clear()


### PR DESCRIPTION
## Summary

- Closes #45
- Closes #22
- Closes #23

## Changelog

- Add configurable per-request timeouts (`github_request_timeout_seconds`, `ollama_request_timeout_seconds`) to every outbound GitHub/Ollama HTTP call, translating a GitHub timeout into `GitHubError` instead of hanging.
- Add the ingestion orchestrator (`ingestion/run.py`): `run_ingestion(repo)` ties `github_client` → `extract` → `embed` → `store` together, per-item fault-tolerant (skip + count non-decisions/malformed output) and per-run fail-loud (GitHub/Ollama errors abort without advancing the cursor).
- Add `POST /ingest` (`routers/ingest.py`), wired into `main.py`: runs a single repo when given, or every configured repo on an empty/absent body.
- Cleanup (found in ponytail review): moved the `REQUIRED_ENV`/`_settings_env` test fixture, copy-pasted across five test files, into one autouse fixture in `conftest.py`; dropped `sys.path.insert` boilerplate in two test files already covered by `conftest.py`; unified `_ingest_commits`/`_ingest_prs` in `run.py` into one generic `_ingest_items`. Also fixed a pre-existing bug this surfaced: `test_github_client.py`'s `fake_get` mocks didn't accept the `timeout` kwarg added earlier in this PR, silently breaking 5 `list_prs` tests until they were fixed here.