### PR TITLE
Retrieval: search with relevance floor + /retrieve and /repos endpoints

### DIFF
--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -19,7 +19,9 @@ COLLECTION_NAME = "decisions"
 
 
 def get_collection() -> chromadb.Collection:
-    return get_chroma_client().get_or_create_collection(name=COLLECTION_NAME)
+    return get_chroma_client().get_or_create_collection(
+        name=COLLECTION_NAME, metadata={"hnsw:space": "cosine"}
+    )
 
 
 def _document_text(unit: DecisionUnit) -> str:
@@ -32,6 +34,12 @@ def _metadata(unit: DecisionUnit) -> dict:
     return metadata
 
 
+def _unit_from_metadata(id: str, metadata: dict) -> DecisionUnit:
+    fields = dict(metadata)
+    fields["alternatives"] = json.loads(fields["alternatives"])
+    return DecisionUnit(id=id, **fields)
+
+
 def upsert_units(units: list[DecisionUnit], embeddings: list[list[float]]) -> None:
     if not units:
         return
@@ -42,6 +50,30 @@ def upsert_units(units: list[DecisionUnit], embeddings: list[list[float]]) -> No
         documents=[_document_text(unit) for unit in units],
         metadatas=[_metadata(unit) for unit in units],
     )
+
+
+def query_units(
+    vector: list[float], k: int, repos: list[str] | None = None
+) -> list[tuple[DecisionUnit, float]]:
+    """Top-k nearest units to `vector`, scored by cosine similarity (1 -
+    cosine distance, per the collection's `hnsw:space: cosine` config)."""
+    where = {"repo": {"$in": repos}} if repos else None
+
+    result = get_collection().query(
+        query_embeddings=[vector],
+        n_results=k,
+        where=where,
+        include=["metadatas", "distances"],
+    )
+
+    ids = result["ids"][0]
+    metadatas = result["metadatas"][0]
+    distances = result["distances"][0]
+
+    return [
+        (_unit_from_metadata(id, metadata), 1 - distance)
+        for id, metadata, distance in zip(ids, metadatas, distances)
+    ]
 
 
 def _cursor_path() -> Path:

--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -76,6 +76,10 @@ def query_units(
     ]
 
 
+def count_units(repo: str) -> int:
+    return len(get_collection().get(where={"repo": repo}, include=[])["ids"])
+
+
 def _cursor_path() -> Path:
     return Path(get_settings().chroma_data_dir) / "cursors.json"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,11 @@ from fastapi import FastAPI
 
 from chroma_client import get_chroma_client
 from routers.ingest import router as ingest_router
+from routers.retrieve import router as retrieve_router
 
 app = FastAPI(title="adr-engine")
 app.include_router(ingest_router)
+app.include_router(retrieve_router)
 
 
 @app.get("/health")

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,11 +4,13 @@ from fastapi import FastAPI
 
 from chroma_client import get_chroma_client
 from routers.ingest import router as ingest_router
+from routers.repos import router as repos_router
 from routers.retrieve import router as retrieve_router
 
 app = FastAPI(title="adr-engine")
 app.include_router(ingest_router)
 app.include_router(retrieve_router)
+app.include_router(repos_router)
 
 
 @app.get("/health")

--- a/backend/retrieval/search.py
+++ b/backend/retrieval/search.py
@@ -1,0 +1,21 @@
+"""Query embedding + top-k retrieval + relevance floor, per SYSTEM-DESIGN.md.
+
+RELEVANCE_FLOOR is a starting value; tune manually via docs/eval-questions.md
+as retrieval quality against the golden questions is evaluated.
+"""
+
+from ingestion import embed, store
+from models import RetrieveResult
+
+RELEVANCE_FLOOR = 0.3
+
+
+def search(query: str, k: int = 5, repos: list[str] | None = None) -> list[RetrieveResult]:
+    vector = embed.embed_text(query)
+    results = store.query_units(vector, k, repos)
+
+    return [
+        RetrieveResult(unit=unit, score=score)
+        for unit, score in results
+        if score >= RELEVANCE_FLOOR
+    ]

--- a/backend/routers/repos.py
+++ b/backend/routers/repos.py
@@ -1,0 +1,23 @@
+"""GET /repos: thin wiring from HTTP to store.count_units per configured repo.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. No business logic here.
+"""
+
+from fastapi import APIRouter
+
+from config import get_settings
+from ingestion.store import count_units
+from models import RepoInfo, ReposResponse
+
+router = APIRouter()
+
+
+@router.get("/repos", response_model=ReposResponse)
+def repos() -> ReposResponse:
+    return ReposResponse(
+        repos=[
+            RepoInfo(repo=repo, indexed_units=count_units(repo))
+            for repo in get_settings().indexed_repos
+        ]
+    )

--- a/backend/routers/retrieve.py
+++ b/backend/routers/retrieve.py
@@ -1,0 +1,18 @@
+"""POST /retrieve: thin wiring from HTTP to retrieval.search.search.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. No business logic here.
+"""
+
+from fastapi import APIRouter
+
+from models import RetrieveRequest, RetrieveResponse
+from retrieval.search import search
+
+router = APIRouter()
+
+
+@router.post("/retrieve", response_model=RetrieveResponse)
+def retrieve(request: RetrieveRequest) -> RetrieveResponse:
+    results = search(request.query, k=request.k, repos=request.repos)
+    return RetrieveResponse(results=results)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -64,6 +64,29 @@ def tmp_chroma_client(tmp_path) -> chromadb.ClientAPI:
 
 
 @pytest.fixture
+def make_unit():
+    def _make(**overrides) -> DecisionUnit:
+        fields = {
+            "id": "owner/repo:pr:1",
+            "repo": "owner/repo",
+            "kind": "pr",
+            "ref": "1",
+            "url": "https://github.com/owner/repo/pull/1",
+            "author": "someone",
+            "date": "2026-01-01T00:00:00Z",
+            "title": "Add caching layer",
+            "decision": "Use Redis for the cache",
+            "rationale": "Needed shared state across instances",
+            "alternatives": ["in-memory cache", "Memcached"],
+            "source_excerpt": "Discussion about caching options.",
+        }
+        fields.update(overrides)
+        return DecisionUnit(**fields)
+
+    return _make
+
+
+@pytest.fixture
 def load_fixture():
     def _load(name: str):
         path = FIXTURES_DIR / name

--- a/backend/tests/test_repos_router.py
+++ b/backend/tests/test_repos_router.py
@@ -5,7 +5,6 @@ import chroma_client
 import config
 from ingestion import store
 from main import app
-from models import DecisionUnit
 
 client = TestClient(app)
 
@@ -26,30 +25,11 @@ def _repos_env(tmp_path, monkeypatch):
     chroma_client.get_chroma_client.cache_clear()
 
 
-def make_unit(**overrides) -> DecisionUnit:
-    fields = {
-        "id": "owner/a:pr:1",
-        "repo": "owner/a",
-        "kind": "pr",
-        "ref": "1",
-        "url": "https://github.com/owner/a/pull/1",
-        "author": "someone",
-        "date": "2026-01-01T00:00:00Z",
-        "title": "Add caching layer",
-        "decision": "Use Redis for the cache",
-        "rationale": "Needed shared state across instances",
-        "alternatives": [],
-        "source_excerpt": "Discussion about caching options.",
-    }
-    fields.update(overrides)
-    return DecisionUnit(**fields)
-
-
-def test_repos_returns_counts_per_repo():
+def test_repos_returns_counts_per_repo(make_unit):
     store.upsert_units(
         [
-            make_unit(id="owner/a:pr:1"),
-            make_unit(id="owner/a:pr:2"),
+            make_unit(id="owner/a:pr:1", repo="owner/a", url="https://github.com/owner/a/pull/1"),
+            make_unit(id="owner/a:pr:2", repo="owner/a", url="https://github.com/owner/a/pull/2"),
             make_unit(id="owner/b:pr:1", repo="owner/b", url="https://github.com/owner/b/pull/1"),
         ],
         embeddings=[[1, 0], [1, 0], [1, 0]],
@@ -66,8 +46,11 @@ def test_repos_returns_counts_per_repo():
     }
 
 
-def test_repos_with_zero_indexed_units_still_appears():
-    store.upsert_units([make_unit()], embeddings=[[1, 0]])
+def test_repos_with_zero_indexed_units_still_appears(make_unit):
+    store.upsert_units(
+        [make_unit(id="owner/a:pr:1", repo="owner/a", url="https://github.com/owner/a/pull/1")],
+        embeddings=[[1, 0]],
+    )
 
     response = client.get("/repos")
 

--- a/backend/tests/test_repos_router.py
+++ b/backend/tests/test_repos_router.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import chroma_client
+import config
+from ingestion import store
+from main import app
+from models import DecisionUnit
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _repos_env(tmp_path, monkeypatch):
+    """This router counts real Chroma-stored units, so it needs its own
+    tmp_path collection and multi-repo config (overrides conftest's
+    single-repo, no-Chroma-write default)."""
+    monkeypatch.setenv("INDEXED_REPOS", "owner/a,owner/b")
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+
+def make_unit(**overrides) -> DecisionUnit:
+    fields = {
+        "id": "owner/a:pr:1",
+        "repo": "owner/a",
+        "kind": "pr",
+        "ref": "1",
+        "url": "https://github.com/owner/a/pull/1",
+        "author": "someone",
+        "date": "2026-01-01T00:00:00Z",
+        "title": "Add caching layer",
+        "decision": "Use Redis for the cache",
+        "rationale": "Needed shared state across instances",
+        "alternatives": [],
+        "source_excerpt": "Discussion about caching options.",
+    }
+    fields.update(overrides)
+    return DecisionUnit(**fields)
+
+
+def test_repos_returns_counts_per_repo():
+    store.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1"),
+            make_unit(id="owner/a:pr:2"),
+            make_unit(id="owner/b:pr:1", repo="owner/b", url="https://github.com/owner/b/pull/1"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    response = client.get("/repos")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "repos": [
+            {"repo": "owner/a", "indexed_units": 2},
+            {"repo": "owner/b", "indexed_units": 1},
+        ]
+    }
+
+
+def test_repos_with_zero_indexed_units_still_appears():
+    store.upsert_units([make_unit()], embeddings=[[1, 0]])
+
+    response = client.get("/repos")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "repos": [
+            {"repo": "owner/a", "indexed_units": 1},
+            {"repo": "owner/b", "indexed_units": 0},
+        ]
+    }

--- a/backend/tests/test_retrieve_router.py
+++ b/backend/tests/test_retrieve_router.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+from models import DecisionUnit, RetrieveResult
+
+client = TestClient(app)
+
+
+def _result(ref: str, score: float) -> RetrieveResult:
+    return RetrieveResult(
+        unit=DecisionUnit(
+            id=f"owner/repo:pr:{ref}",
+            repo="owner/repo",
+            kind="pr",
+            ref=ref,
+            url=f"https://github.com/owner/repo/pull/{ref}",
+            author="someone",
+            date="2026-01-01T00:00:00Z",
+            title="Add caching layer",
+            decision="Use Redis for the cache",
+            rationale="Needed shared state across instances",
+            alternatives=[],
+            source_excerpt="Discussion about caching options.",
+        ),
+        score=score,
+    )
+
+
+def test_retrieve_returns_search_results():
+    with patch("routers.retrieve.search") as search:
+        search.return_value = [_result("1", 0.9), _result("2", 0.5)]
+
+        response = client.post("/retrieve", json={"query": "why redis?", "k": 3})
+
+    assert response.status_code == 200
+    search.assert_called_once_with("why redis?", k=3, repos=None)
+    assert response.json() == {
+        "results": [r.model_dump() for r in [_result("1", 0.9), _result("2", 0.5)]]
+    }
+
+
+def test_retrieve_omitted_k_defaults_to_5():
+    with patch("routers.retrieve.search") as search:
+        search.return_value = []
+
+        response = client.post("/retrieve", json={"query": "why redis?"})
+
+    assert response.status_code == 200
+    search.assert_called_once_with("why redis?", k=5, repos=None)
+
+
+def test_retrieve_omitted_repos_searches_all():
+    with patch("routers.retrieve.search") as search:
+        search.return_value = []
+
+        client.post("/retrieve", json={"query": "why redis?", "repos": None})
+
+    search.assert_called_once_with("why redis?", k=5, repos=None)
+
+
+def test_retrieve_passes_repos_through():
+    with patch("routers.retrieve.search") as search:
+        search.return_value = []
+
+        client.post("/retrieve", json={"query": "why redis?", "repos": ["owner/repo"]})
+
+    search.assert_called_once_with("why redis?", k=5, repos=["owner/repo"])

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -4,42 +4,11 @@ import pytest
 
 import chroma_client
 import config
-from models import DecisionUnit
-
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
-
-def make_unit(**overrides) -> DecisionUnit:
-    fields = {
-        "id": "owner/repo:pr:1",
-        "repo": "owner/repo",
-        "kind": "pr",
-        "ref": "1",
-        "url": "https://github.com/owner/repo/pull/1",
-        "author": "someone",
-        "date": "2026-01-01T00:00:00Z",
-        "title": "Add caching layer",
-        "decision": "Use Redis for the cache",
-        "rationale": "Needed shared state across instances",
-        "alternatives": ["in-memory cache", "Memcached"],
-        "source_excerpt": "Discussion about caching options.",
-    }
-    fields.update(overrides)
-    return DecisionUnit(**fields)
 
 
 @pytest.fixture
 def search_module(tmp_path, monkeypatch):
     monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-
     config.get_settings.cache_clear()
     chroma_client.get_chroma_client.cache_clear()
 
@@ -52,7 +21,7 @@ def search_module(tmp_path, monkeypatch):
     chroma_client.get_chroma_client.cache_clear()
 
 
-def test_search_returns_top_k_ordered_by_score(search_module):
+def test_search_returns_top_k_ordered_by_score(search_module, make_unit):
     search, store = search_module
     store.upsert_units(
         [
@@ -69,7 +38,7 @@ def test_search_returns_top_k_ordered_by_score(search_module):
     assert results[0].score > results[1].score
 
 
-def test_search_excludes_results_below_relevance_floor(search_module):
+def test_search_excludes_results_below_relevance_floor(search_module, make_unit):
     search, store = search_module
     store.upsert_units(
         [
@@ -85,7 +54,7 @@ def test_search_excludes_results_below_relevance_floor(search_module):
     assert [r.unit.id for r in results] == ["owner/repo:pr:1"]
 
 
-def test_search_filters_by_repo(search_module):
+def test_search_filters_by_repo(search_module, make_unit):
     search, store = search_module
     store.upsert_units(
         [
@@ -101,7 +70,7 @@ def test_search_filters_by_repo(search_module):
     assert [r.unit.id for r in results] == ["owner/a:pr:1"]
 
 
-def test_search_embeds_query_via_embed_text(search_module):
+def test_search_embeds_query_via_embed_text(search_module, make_unit):
     search, store = search_module
     store.upsert_units([make_unit()], embeddings=[[1, 0]])
 

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,111 @@
+from unittest.mock import patch
+
+import pytest
+
+import chroma_client
+import config
+from models import DecisionUnit
+
+REQUIRED_ENV = {
+    "GITHUB_TOKEN": "tok",
+    "INDEXED_REPOS": "owner/repo",
+    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
+    "GEMINI_API_KEY": "key",
+}
+
+
+def make_unit(**overrides) -> DecisionUnit:
+    fields = {
+        "id": "owner/repo:pr:1",
+        "repo": "owner/repo",
+        "kind": "pr",
+        "ref": "1",
+        "url": "https://github.com/owner/repo/pull/1",
+        "author": "someone",
+        "date": "2026-01-01T00:00:00Z",
+        "title": "Add caching layer",
+        "decision": "Use Redis for the cache",
+        "rationale": "Needed shared state across instances",
+        "alternatives": ["in-memory cache", "Memcached"],
+        "source_excerpt": "Discussion about caching options.",
+    }
+    fields.update(overrides)
+    return DecisionUnit(**fields)
+
+
+@pytest.fixture
+def search_module(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    for key, value in REQUIRED_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+    from ingestion import store
+    from retrieval import search
+
+    yield search, store
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+
+def test_search_returns_top_k_ordered_by_score(search_module):
+    search, store = search_module
+    store.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", title="Exact match"),
+            make_unit(id="owner/repo:pr:2", title="Partial match"),
+        ],
+        embeddings=[[2, 0], [1, 1]],
+    )
+
+    with patch("ingestion.embed.embed_text", return_value=[1, 0]):
+        results = search.search("why redis?", k=2)
+
+    assert [r.unit.id for r in results] == ["owner/repo:pr:1", "owner/repo:pr:2"]
+    assert results[0].score > results[1].score
+
+
+def test_search_excludes_results_below_relevance_floor(search_module):
+    search, store = search_module
+    store.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", title="Exact match"),
+            make_unit(id="owner/repo:pr:2", title="Unrelated"),
+        ],
+        embeddings=[[2, 0], [0, 1]],
+    )
+
+    with patch("ingestion.embed.embed_text", return_value=[1, 0]):
+        results = search.search("why redis?", k=2)
+
+    assert [r.unit.id for r in results] == ["owner/repo:pr:1"]
+
+
+def test_search_filters_by_repo(search_module):
+    search, store = search_module
+    store.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a"),
+            make_unit(id="owner/b:pr:1", repo="owner/b"),
+        ],
+        embeddings=[[1, 0], [1, 0]],
+    )
+
+    with patch("ingestion.embed.embed_text", return_value=[1, 0]):
+        results = search.search("why redis?", k=5, repos=["owner/a"])
+
+    assert [r.unit.id for r in results] == ["owner/a:pr:1"]
+
+
+def test_search_embeds_query_via_embed_text(search_module):
+    search, store = search_module
+    store.upsert_units([make_unit()], embeddings=[[1, 0]])
+
+    with patch("ingestion.embed.embed_text", return_value=[1, 0]) as embed_text:
+        search.search("why redis?", k=1)
+
+    embed_text.assert_called_once_with("why redis?")

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1,48 +1,12 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
 import pytest
 
 import chroma_client
 import config
-from models import DecisionUnit
-
-REQUIRED_ENV = {
-    "GITHUB_TOKEN": "tok",
-    "INDEXED_REPOS": "owner/repo",
-    "OLLAMA_EXTRACTION_MODEL": "phi4-mini",
-    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text",
-    "GEMINI_API_KEY": "key",
-}
-
-
-def make_unit(**overrides) -> DecisionUnit:
-    fields = {
-        "id": "owner/repo:pr:1",
-        "repo": "owner/repo",
-        "kind": "pr",
-        "ref": "1",
-        "url": "https://github.com/owner/repo/pull/1",
-        "author": "someone",
-        "date": "2026-01-01T00:00:00Z",
-        "title": "Add caching layer",
-        "decision": "Use Redis for the cache",
-        "rationale": "Needed shared state across instances",
-        "alternatives": ["in-memory cache", "Memcached"],
-        "source_excerpt": "Discussion about caching options.",
-    }
-    fields.update(overrides)
-    return DecisionUnit(**fields)
 
 
 @pytest.fixture
 def store_module(tmp_path, monkeypatch):
     monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
-    for key, value in REQUIRED_ENV.items():
-        monkeypatch.setenv(key, value)
-
     config.get_settings.cache_clear()
     chroma_client.get_chroma_client.cache_clear()
 
@@ -54,7 +18,7 @@ def store_module(tmp_path, monkeypatch):
     chroma_client.get_chroma_client.cache_clear()
 
 
-def test_upserting_same_id_twice_does_not_duplicate(store_module):
+def test_upserting_same_id_twice_does_not_duplicate(store_module, make_unit):
     unit = make_unit()
 
     store_module.upsert_units([unit], embeddings=[[0.1, 0.2, 0.3]])
@@ -71,7 +35,7 @@ def test_upserting_same_id_twice_does_not_duplicate(store_module):
     assert stored["documents"][0].startswith("Add caching layer (revised)")
 
 
-def test_upsert_units_stores_metadata_and_document_text(store_module):
+def test_upsert_units_stores_metadata_and_document_text(store_module, make_unit):
     unit = make_unit()
 
     store_module.upsert_units([unit], embeddings=[[0.1, 0.2, 0.3]])
@@ -103,7 +67,7 @@ def test_cursor_round_trips_through_disk(store_module):
     assert store_module.get_cursor("owner/other") == {}
 
 
-def test_query_units_orders_by_score_descending(store_module):
+def test_query_units_orders_by_score_descending(store_module, make_unit):
     store_module.upsert_units(
         [make_unit(id="owner/repo:pr:1"), make_unit(id="owner/repo:pr:2", title="Other")],
         embeddings=[[1, 0], [0, 1]],
@@ -115,7 +79,7 @@ def test_query_units_orders_by_score_descending(store_module):
     assert results[0][1] > results[1][1]
 
 
-def test_query_units_filters_by_repo(store_module):
+def test_query_units_filters_by_repo(store_module, make_unit):
     store_module.upsert_units(
         [
             make_unit(id="owner/a:pr:1", repo="owner/a"),
@@ -129,7 +93,7 @@ def test_query_units_filters_by_repo(store_module):
     assert [unit.id for unit, _score in results] == ["owner/a:pr:1"]
 
 
-def test_query_units_reconstructs_full_decision_unit(store_module):
+def test_query_units_reconstructs_full_decision_unit(store_module, make_unit):
     unit = make_unit()
     store_module.upsert_units([unit], embeddings=[[1, 0]])
 
@@ -139,7 +103,7 @@ def test_query_units_reconstructs_full_decision_unit(store_module):
     assert score == pytest.approx(1.0)
 
 
-def test_count_units_counts_only_matching_repo(store_module):
+def test_count_units_counts_only_matching_repo(store_module, make_unit):
     store_module.upsert_units(
         [
             make_unit(id="owner/repo:pr:1"),

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -103,6 +103,42 @@ def test_cursor_round_trips_through_disk(store_module):
     assert store_module.get_cursor("owner/other") == {}
 
 
+def test_query_units_orders_by_score_descending(store_module):
+    store_module.upsert_units(
+        [make_unit(id="owner/repo:pr:1"), make_unit(id="owner/repo:pr:2", title="Other")],
+        embeddings=[[1, 0], [0, 1]],
+    )
+
+    results = store_module.query_units([1, 0], k=2)
+
+    assert [unit.id for unit, _score in results] == ["owner/repo:pr:1", "owner/repo:pr:2"]
+    assert results[0][1] > results[1][1]
+
+
+def test_query_units_filters_by_repo(store_module):
+    store_module.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a"),
+            make_unit(id="owner/b:pr:1", repo="owner/b"),
+        ],
+        embeddings=[[1, 0], [1, 0]],
+    )
+
+    results = store_module.query_units([1, 0], k=5, repos=["owner/a"])
+
+    assert [unit.id for unit, _score in results] == ["owner/a:pr:1"]
+
+
+def test_query_units_reconstructs_full_decision_unit(store_module):
+    unit = make_unit()
+    store_module.upsert_units([unit], embeddings=[[1, 0]])
+
+    [(returned, score)] = store_module.query_units([1, 0], k=1)
+
+    assert returned == unit
+    assert score == pytest.approx(1.0)
+
+
 def test_set_cursor_preserves_other_repos(store_module):
     store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
     store_module.set_cursor("owner/other", {"last_commit_date": "2026-02-01T00:00:00Z"})

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -139,6 +139,24 @@ def test_query_units_reconstructs_full_decision_unit(store_module):
     assert score == pytest.approx(1.0)
 
 
+def test_count_units_counts_only_matching_repo(store_module):
+    store_module.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1"),
+            make_unit(id="owner/repo:pr:2"),
+            make_unit(id="owner/other:pr:1", repo="owner/other"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    assert store_module.count_units("owner/repo") == 2
+    assert store_module.count_units("owner/other") == 1
+
+
+def test_count_units_with_no_matches_returns_zero(store_module):
+    assert store_module.count_units("owner/repo") == 0
+
+
 def test_set_cursor_preserves_other_repos(store_module):
     store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
     store_module.set_cursor("owner/other", {"last_commit_date": "2026-02-01T00:00:00Z"})


### PR DESCRIPTION
## Summary

- Closes #24
- Closes #25
- Closes #26

## Changelog

- Add `retrieval/search.py`: `search(query, k, repos)` embeds the query via `embed.embed_text`, retrieves top-k via a new `store.query_units` (Chroma collection now configured for cosine similarity, score = 1 - distance), and drops results below `RELEVANCE_FLOOR` (0.3).
- Add `POST /retrieve` (`routers/retrieve.py`), wired into `main.py`: thin wiring from `RetrieveRequest` to `search()` and back to `RetrieveResponse`.
- Add `GET /repos` (`routers/repos.py`), wired into `main.py`: lists each configured repo with its indexed-unit count via a new `store.count_units(repo)` helper (Chroma metadata `where` filter); repos with zero indexed units still appear.
- Cleanup (found in ponytail review): the `make_unit()` DecisionUnit-factory helper had been copy-pasted into three test files (including `test_store.py`, left over from before the conftest consolidation two PRs ago). Centralized into one `make_unit` fixture in `conftest.py`, following the same pattern as the existing `load_fixture` fixture. Also dropped a `REQUIRED_ENV`/manual-env-loop reintroduced in `test_search.py` that duplicated conftest's autouse fixture — matched it to `test_repos_router.py`'s existing minimal-override pattern instead.