### PR TITLE
Synthesis via Gemini, POST /query endpoint, golden eval questions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
 # Cloud model for synthesis/citation (only retrieved snippets are sent, not full corpus)
 GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash
+
+# Per-request timeout (seconds) for outbound Gemini calls
+GEMINI_REQUEST_TIMEOUT_SECONDS=30
 
 # Chroma persistence directory
 CHROMA_DATA_DIR=./chroma_data

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,6 +74,14 @@ commits/PRs via branch/PR references. Scoped when Phase 1 ships.
 ## Phase 3 — Slack (opt-in per channel)
 Privacy-sensitive; needs its own scoping pass.
 
+## Evaluation
+
+No automated eval harness in Phase 1 (see SYSTEM-DESIGN.md). Quality is
+checked manually against [docs/eval-questions.md](docs/eval-questions.md),
+a running list of golden questions with their expected cited source —
+run each through `/query` after a retrieval or extraction change and
+watch for drift.
+
 ## Non-goals (for now)
 Hosted/multi-user deployment, auth, real-time ingestion, fine-tuning,
 TypeScript migration.

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,10 +20,12 @@ class Settings(BaseSettings):
     ollama_extraction_model: str
     ollama_embedding_model: str
     gemini_api_key: str
+    gemini_model: str = "gemini-2.5-flash"
     chroma_data_dir: str = "./chroma_data"
     github_rate_limit_wait_ceiling_seconds: float = 60
     github_request_timeout_seconds: float = 10
     ollama_request_timeout_seconds: float = 60
+    gemini_request_timeout_seconds: float = 30
 
     @field_validator("indexed_repos", mode="before")
     @classmethod

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,12 +4,14 @@ from fastapi import FastAPI
 
 from chroma_client import get_chroma_client
 from routers.ingest import router as ingest_router
+from routers.query import router as query_router
 from routers.repos import router as repos_router
 from routers.retrieve import router as retrieve_router
 
 app = FastAPI(title="adr-engine")
 app.include_router(ingest_router)
 app.include_router(retrieve_router)
+app.include_router(query_router)
 app.include_router(repos_router)
 
 

--- a/backend/routers/query.py
+++ b/backend/routers/query.py
@@ -1,20 +1,33 @@
 """POST /query: thin wiring from HTTP to retrieval.search + synthesis.answer.
 
 Per ARCHITECTURE.md's "routers are thin" rule: parse request, call the
-service functions, shape response. No business logic here.
+service functions, shape response. No business logic here — the only
+addition beyond that is the HTTP-status translation ARCHITECTURE.md's
+error-handling section assigns to routers specifically, per
+SYSTEM-DESIGN.md's failure-modes table (embedding failure -> 503, Gemini
+failure -> 502).
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
+from ingestion.embed import EmbeddingError
 from models import QueryRequest, QueryResponse
 from retrieval.search import search
-from synthesis.answer import synthesize
+from synthesis.answer import SynthesisError, synthesize
 
 router = APIRouter()
 
 
 @router.post("/query", response_model=QueryResponse)
 def query(request: QueryRequest) -> QueryResponse:
-    results = search(request.question, repos=request.repos)
-    answer, citations = synthesize(request.question, [r.unit for r in results])
+    try:
+        results = search(request.question, repos=request.repos)
+    except EmbeddingError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    try:
+        answer, citations = synthesize(request.question, [r.unit for r in results])
+    except SynthesisError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
     return QueryResponse(answer=answer, citations=citations, retrieved_count=len(results))

--- a/backend/routers/query.py
+++ b/backend/routers/query.py
@@ -1,0 +1,20 @@
+"""POST /query: thin wiring from HTTP to retrieval.search + synthesis.answer.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call the
+service functions, shape response. No business logic here.
+"""
+
+from fastapi import APIRouter
+
+from models import QueryRequest, QueryResponse
+from retrieval.search import search
+from synthesis.answer import synthesize
+
+router = APIRouter()
+
+
+@router.post("/query", response_model=QueryResponse)
+def query(request: QueryRequest) -> QueryResponse:
+    results = search(request.question, repos=request.repos)
+    answer, citations = synthesize(request.question, [r.unit for r in results])
+    return QueryResponse(answer=answer, citations=citations, retrieved_count=len(results))

--- a/backend/synthesis/answer.py
+++ b/backend/synthesis/answer.py
@@ -1,0 +1,92 @@
+"""Gemini-based synthesis: retrieved DecisionUnits -> cited answer.
+
+Cloud call, per ROADMAP.md's privacy stance: only the retrieved top-k units
+are ever sent here, never the full corpus. Citations are resolved
+server-side against the input units — the model is never trusted to echo
+unit data, only to cite an id.
+"""
+
+import re
+
+import httpx
+
+from config import get_settings
+from models import DecisionUnit
+
+_NO_COVERAGE_ANSWER = "Nothing in the indexed history covers this question."
+
+_PROMPT_TEMPLATE = """You are answering a question about why an engineering \
+decision was made, using only the decisions listed below.
+
+Question: {question}
+
+Decisions:
+{units}
+
+Answer the question using only the information in these decisions. Cite \
+each decision you use inline by its id in square brackets, e.g. [{example_id}]. \
+If the decisions above don't cover the question, respond with exactly: \
+"{no_coverage}"
+"""
+
+_CITATION_PATTERN = re.compile(r"\[([^\[\]]+)\]")
+
+
+class SynthesisError(Exception):
+    """Raised when Gemini can't be reached, or returns an error, for synthesis."""
+
+
+def _format_unit(unit: DecisionUnit) -> str:
+    return (
+        f"id: {unit.id}\n"
+        f"title: {unit.title}\n"
+        f"decision: {unit.decision}\n"
+        f"rationale: {unit.rationale}\n"
+        f"url: {unit.url}"
+    )
+
+
+def _build_prompt(question: str, units: list[DecisionUnit]) -> str:
+    return _PROMPT_TEMPLATE.format(
+        question=question,
+        units="\n\n".join(_format_unit(unit) for unit in units),
+        example_id=units[0].id,
+        no_coverage=_NO_COVERAGE_ANSWER,
+    )
+
+
+def _call_gemini(prompt: str) -> str:
+    settings = get_settings()
+    try:
+        response = httpx.post(
+            f"https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{settings.gemini_model}:generateContent",
+            params={"key": settings.gemini_api_key},
+            json={"contents": [{"parts": [{"text": prompt}]}]},
+            timeout=settings.gemini_request_timeout_seconds,
+        )
+    except httpx.HTTPError as exc:
+        raise SynthesisError(f"failed to reach Gemini for synthesis: {exc}") from exc
+
+    if response.is_error:
+        raise SynthesisError(f"Gemini returned {response.status_code} during synthesis")
+
+    try:
+        return response.json()["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError) as exc:
+        raise SynthesisError("Gemini response missing expected candidate text") from exc
+
+
+def _resolve_citations(answer: str, units: list[DecisionUnit]) -> list[DecisionUnit]:
+    units_by_id = {unit.id: unit for unit in units}
+    cited_ids = dict.fromkeys(_CITATION_PATTERN.findall(answer))
+
+    return [units_by_id[unit_id] for unit_id in cited_ids if unit_id in units_by_id]
+
+
+def synthesize(question: str, units: list[DecisionUnit]) -> tuple[str, list[DecisionUnit]]:
+    if not units:
+        return _NO_COVERAGE_ANSWER, []
+
+    answer = _call_gemini(_build_prompt(question, units))
+    return answer, _resolve_citations(answer, units)

--- a/backend/synthesis/answer.py
+++ b/backend/synthesis/answer.py
@@ -73,7 +73,9 @@ def _call_gemini(prompt: str) -> str:
 
     try:
         return response.json()["candidates"][0]["content"]["parts"][0]["text"]
-    except (KeyError, IndexError) as exc:
+    except (KeyError, IndexError, ValueError) as exc:
+        # ValueError also catches json.JSONDecodeError from response.json()
+        # itself, e.g. a non-JSON 200 body.
         raise SynthesisError("Gemini response missing expected candidate text") from exc
 
 

--- a/backend/tests/test_answer.py
+++ b/backend/tests/test_answer.py
@@ -101,6 +101,16 @@ def test_synthesize_raises_synthesis_error_on_malformed_response_shape(make_unit
             synthesize("why redis?", units)
 
 
+def test_synthesize_raises_synthesis_error_on_non_json_response_body(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, content=b"not json")
+
+        with pytest.raises(SynthesisError):
+            synthesize("why redis?", units)
+
+
 def test_synthesize_passes_configured_timeout_and_api_key(make_unit):
     units = [make_unit()]
 

--- a/backend/tests/test_answer.py
+++ b/backend/tests/test_answer.py
@@ -1,0 +1,115 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import config
+from synthesis.answer import SynthesisError, synthesize
+
+
+def _gemini_response(text: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"candidates": [{"content": {"parts": [{"text": text}]}}]},
+    )
+
+
+def test_synthesize_resolves_only_cited_units(make_unit):
+    units = [
+        make_unit(id="owner/repo:pr:1", ref="1"),
+        make_unit(id="owner/repo:pr:2", ref="2"),
+        make_unit(id="owner/repo:pr:3", ref="3"),
+    ]
+    answer_text = "Redis was chosen [owner/repo:pr:1], see also [owner/repo:pr:2]."
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = _gemini_response(answer_text)
+
+        answer, citations = synthesize("why redis?", units)
+
+    assert answer == answer_text
+    assert citations == [units[0], units[1]]
+    assert mock_post.call_count == 1
+
+
+def test_synthesize_drops_cited_ids_not_in_input_units(make_unit):
+    units = [make_unit(id="owner/repo:pr:1", ref="1")]
+    answer_text = "Decided per [owner/repo:pr:1] and [owner/repo:pr:99]."
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = _gemini_response(answer_text)
+
+        _, citations = synthesize("why redis?", units)
+
+    assert citations == [units[0]]
+
+
+def test_synthesize_dedupes_repeated_citations(make_unit):
+    units = [make_unit(id="owner/repo:pr:1", ref="1")]
+    answer_text = "Per [owner/repo:pr:1], and again [owner/repo:pr:1]."
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = _gemini_response(answer_text)
+
+        _, citations = synthesize("why redis?", units)
+
+    assert citations == [units[0]]
+
+
+def test_synthesize_empty_units_returns_fixed_answer_without_calling_gemini():
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        answer, citations = synthesize("why redis?", [])
+
+    assert answer == "Nothing in the indexed history covers this question."
+    assert citations == []
+    mock_post.assert_not_called()
+
+
+def test_synthesize_raises_synthesis_error_on_connection_failure(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(SynthesisError):
+            synthesize("why redis?", units)
+
+
+def test_synthesize_raises_synthesis_error_on_timeout(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post", side_effect=httpx.TimeoutException("timed out")):
+        with pytest.raises(SynthesisError):
+            synthesize("why redis?", units)
+
+
+def test_synthesize_raises_synthesis_error_on_error_status(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(401, json={"error": "unauthorized"})
+
+        with pytest.raises(SynthesisError):
+            synthesize("why redis?", units)
+
+
+def test_synthesize_raises_synthesis_error_on_malformed_response_shape(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"candidates": []})
+
+        with pytest.raises(SynthesisError):
+            synthesize("why redis?", units)
+
+
+def test_synthesize_passes_configured_timeout_and_api_key(make_unit):
+    units = [make_unit()]
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = _gemini_response("no citations here")
+
+        synthesize("why redis?", units)
+
+    _, kwargs = mock_post.call_args
+    settings = config.get_settings()
+    assert kwargs["timeout"] == settings.gemini_request_timeout_seconds
+    assert kwargs["params"] == {"key": settings.gemini_api_key}

--- a/backend/tests/test_query_router.py
+++ b/backend/tests/test_query_router.py
@@ -2,34 +2,25 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
+from ingestion.embed import EmbeddingError
 from main import app
-from models import DecisionUnit, RetrieveResult
+from models import RetrieveResult
+from synthesis.answer import SynthesisError
 
 client = TestClient(app)
 
 
-def _result(ref: str) -> RetrieveResult:
+def _result(make_unit, ref: str) -> RetrieveResult:
     return RetrieveResult(
-        unit=DecisionUnit(
-            id=f"owner/repo:pr:{ref}",
-            repo="owner/repo",
-            kind="pr",
-            ref=ref,
-            url=f"https://github.com/owner/repo/pull/{ref}",
-            author="someone",
-            date="2026-01-01T00:00:00Z",
-            title="Add caching layer",
-            decision="Use Redis for the cache",
-            rationale="Needed shared state across instances",
-            alternatives=[],
-            source_excerpt="Discussion about caching options.",
+        unit=make_unit(
+            id=f"owner/repo:pr:{ref}", ref=ref, url=f"https://github.com/owner/repo/pull/{ref}"
         ),
         score=0.9,
     )
 
 
-def test_query_returns_answer_with_resolved_citations_and_retrieved_count():
-    results = [_result("1"), _result("2"), _result("3")]
+def test_query_returns_answer_with_resolved_citations_and_retrieved_count(make_unit):
+    results = [_result(make_unit, "1"), _result(make_unit, "2"), _result(make_unit, "3")]
     cited = [results[0].unit, results[1].unit]
 
     with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
@@ -65,3 +56,24 @@ def test_query_omitted_repos_searches_all():
         client.post("/query", json={"question": "why redis?"})
 
     search.assert_called_once_with("why redis?", repos=None)
+
+
+def test_query_translates_synthesis_error_to_502():
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = []
+        synthesize.side_effect = SynthesisError("Gemini returned 401 during synthesis")
+
+        response = client.post("/query", json={"question": "why redis?"})
+
+    assert response.status_code == 502
+    assert "Gemini returned 401" in response.json()["detail"]
+
+
+def test_query_translates_embedding_error_to_503():
+    with patch("routers.query.search") as search:
+        search.side_effect = EmbeddingError("failed to reach Ollama for embedding")
+
+        response = client.post("/query", json={"question": "why redis?"})
+
+    assert response.status_code == 503
+    assert "failed to reach Ollama" in response.json()["detail"]

--- a/backend/tests/test_query_router.py
+++ b/backend/tests/test_query_router.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+from models import DecisionUnit, RetrieveResult
+
+client = TestClient(app)
+
+
+def _result(ref: str) -> RetrieveResult:
+    return RetrieveResult(
+        unit=DecisionUnit(
+            id=f"owner/repo:pr:{ref}",
+            repo="owner/repo",
+            kind="pr",
+            ref=ref,
+            url=f"https://github.com/owner/repo/pull/{ref}",
+            author="someone",
+            date="2026-01-01T00:00:00Z",
+            title="Add caching layer",
+            decision="Use Redis for the cache",
+            rationale="Needed shared state across instances",
+            alternatives=[],
+            source_excerpt="Discussion about caching options.",
+        ),
+        score=0.9,
+    )
+
+
+def test_query_returns_answer_with_resolved_citations_and_retrieved_count():
+    results = [_result("1"), _result("2"), _result("3")]
+    cited = [results[0].unit, results[1].unit]
+
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = results
+        synthesize.return_value = ("Redis was chosen [owner/repo:pr:1].", cited)
+
+        response = client.post("/query", json={"question": "why redis?"})
+
+    assert response.status_code == 200
+    synthesize.assert_called_once_with("why redis?", [r.unit for r in results])
+    assert response.json() == {
+        "answer": "Redis was chosen [owner/repo:pr:1].",
+        "citations": [unit.model_dump() for unit in cited],
+        "retrieved_count": 3,
+    }
+
+
+def test_query_passes_repos_through_to_search():
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = []
+        synthesize.return_value = ("Nothing in the indexed history covers this question.", [])
+
+        client.post("/query", json={"question": "why redis?", "repos": ["owner/repo"]})
+
+    search.assert_called_once_with("why redis?", repos=["owner/repo"])
+
+
+def test_query_omitted_repos_searches_all():
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = []
+        synthesize.return_value = ("Nothing in the indexed history covers this question.", [])
+
+        client.post("/query", json={"question": "why redis?"})
+
+    search.assert_called_once_with("why redis?", repos=None)

--- a/docs/eval-questions.md
+++ b/docs/eval-questions.md
@@ -1,0 +1,43 @@
+# Golden evaluation questions
+
+Per [SYSTEM-DESIGN.md](SYSTEM-DESIGN.md#evaluation-lightweight-phase-1),
+this is the manual quality gate: no automated eval harness exists in
+Phase 1. Once both repos are indexed (`POST /ingest`), run each question
+below through `POST /query` (or the UI once it exists) and compare the
+returned citations to the "expected source" column. A regression is any
+question whose citation set stops matching after a retrieval or
+extraction change — note it here or in the PR that caused it.
+
+Sources are drawn from real commit history in
+[anubhab-m02/BuFin](https://github.com/anubhab-m02/BuFin) (the sibling
+project this engine is built to query) and from adr-engine's own PR
+history. Commit SHAs are shown short (8 chars); the full SHA resolves on
+GitHub.
+
+## BuFin questions
+
+| # | Question | Expected source | Why |
+|---|---|---|---|
+| 1 | Why does the AI task router try Ollama before Gemini for lightweight tasks? | `anubhab-m02/BuFin` commit [`469a45f3`](https://github.com/anubhab-m02/BuFin/commit/469a45f3d9df021bb20d40e5a3eb6be473639666) | "route lightweight AI tasks to local Ollama model, upgrade reasoning calls to Gemini 3 Flash" — a deliberate cost/latency split between local and cloud models. |
+| 2 | Why do debt-repayment transactions carry a link back to the debt they repay? | `anubhab-m02/BuFin` commit [`2e768a70`](https://github.com/anubhab-m02/BuFin/commit/2e768a708cb5892fa8918ccd79673c90490232c9) | "link debt-repayment transactions to their debt so deleting the transaction reverts debt status" — without the link, deleting a repayment can't undo its effect on the debt. |
+| 3 | Why was `migrate_db.py` replaced with Alembic? | `anubhab-m02/BuFin` commit [`bdad01bc`](https://github.com/anubhab-m02/BuFin/commit/bdad01bc73df4082b03234f92fea331a1128b303) | "pin backend deps, migrate to Pydantic v2 syntax, add Alembic migrations" — moved schema migrations off a hand-rolled script onto a standard tool. |
+| 4 | Why does the transaction classifier parse JSON with a balanced bracket parser instead of a regex? | `anubhab-m02/BuFin` commit [`6a738c85`](https://github.com/anubhab-m02/BuFin/commit/6a738c8561162d6d2835b0d7036d77cc4101b7ed) | "replace greedy JSON regex with balanced bracket parser in transaction classifier" — a greedy regex over-matched on nested/adjacent JSON. |
+| 5 | Why does subscription detection require a minimum time gap between charges? | `anubhab-m02/BuFin` commit [`0fbc9b7a`](https://github.com/anubhab-m02/BuFin/commit/0fbc9b7ae23197a5a80558be65a2bcccf1b8f10a) | "require min time gap for subscription detection and use proportional leak-detection floor" — guards against same-day duplicate charges being mistaken for a recurring subscription. |
+| 6 | Why are achievements based on distinct-day activity instead of point-in-time totals? | `anubhab-m02/BuFin` commit [`fd15b085`](https://github.com/anubhab-m02/BuFin/commit/fd15b0855ccea84ae50326abcbdd4e67a5517ea2) | "base achievements on distinct-day activity instead of point-in-time totals to prevent gaming" — a point-in-time total could be gamed by repeated same-moment actions. |
+| 7 | Why does `repayDebt` guard against duplicate repayment transactions? | `anubhab-m02/BuFin` commit [`f4301801`](https://github.com/anubhab-m02/BuFin/commit/f4301801e94b7c94e4237e3f6a9d111a3e92407e) | "guard repayDebt against duplicate repayment transactions from double-clicks/retries" — a double-click or client retry could otherwise record the same repayment twice. |
+| 8 | Why was the last-working-day date resolution logic extracted into a shared util? | `anubhab-m02/BuFin` commit [`01025d97`](https://github.com/anubhab-m02/BuFin/commit/01025d9798e92b3ab56d3acf07e87de0883a05f3) | "extract duplicated last-working-day date resolution into shared utils.resolveExpectedDay" — the same weekend-skipping logic had drifted into multiple call sites. |
+| 9 | Why does the backend spending alert use the frontend's local date instead of computing its own? | `anubhab-m02/BuFin` commit [`5d18ce7d`](https://github.com/anubhab-m02/BuFin/commit/5d18ce7dac28a88673be202c43c4715ee1c605c8) | "use frontend local date as source of truth for backend spending alert to avoid timezone divergence" — the backend's server timezone could disagree with the user's local day boundary. |
+| 10 | Why was the "average BuFin user" benchmark in insights replaced? | `anubhab-m02/BuFin` commit [`49eb2e75`](https://github.com/anubhab-m02/BuFin/commit/49eb2e7516cd014b65280805fe9da3f56441161e) | "replace fabricated 'average BuFin user' benchmark with user's own historical average" — the cross-user benchmark wasn't backed by real data. |
+
+## adr-engine questions
+
+adr-engine's own history is thin so far — work has landed as a handful of
+batched rolling PRs (see `gh pr list --state merged`) rather than one
+decision per PR, so citations here resolve at PR granularity rather than
+a single tightly-scoped commit. Revisit this section as more PRs land
+after the rolling PR model has been running longer.
+
+| # | Question | Expected source | Why |
+|---|---|---|---|
+| 11 | Why does retrieval drop results below a similarity floor instead of always returning the top k? | `anubhab-m02/adr-engine` PR [#47](https://github.com/anubhab-m02/adr-engine/pull/47) | Per SYSTEM-DESIGN.md: a low-relevance result forced into the top-k would get cited by synthesis anyway, risking a confidently-wrong answer instead of an honest "not found." |
+| 12 | Why does ingestion abort the whole run if Ollama is unreachable, instead of skipping and continuing? | `anubhab-m02/adr-engine` PR [#46](https://github.com/anubhab-m02/adr-engine/pull/46) | Per ARCHITECTURE.md's error-handling conventions: ingestion is per-item fault-tolerant but per-run fail-loud — Ollama being down isn't a bad item, it's an environment problem that would silently skip everything. |


### PR DESCRIPTION
Closes #27
Closes #28
Closes #29

## Changelog

- `synthesis/answer.py`: retrieved DecisionUnits -> cited answer via Gemini's REST API (httpx, no SDK dependency, matching the existing Ollama-call pattern in `extract.py`/`embed.py`). Citations are resolved server-side against the input units; ids the model cites that aren't in the input are dropped. Empty `units` short-circuits to a fixed "no coverage" answer without a Gemini call.
- `routers/query.py`: `POST /query` wiring `retrieval.search` + `synthesis.answer.synthesize` together, the main product endpoint.
- `config.py`: added `gemini_model` and `gemini_request_timeout_seconds` settings.
- `docs/eval-questions.md`: 12 golden questions (10 from BuFin's real commit history, 2 from adr-engine's own PR history) with expected cited source, linked from a new ROADMAP.md Evaluation section.

## Fixes from code review

- **Standards violation**: `routers/query.py` had no exception handling, so a `SynthesisError` (Gemini down/unauthorized) or `EmbeddingError` (Ollama down during query embedding) propagated as an unhandled 500 instead of the 502/503 SYSTEM-DESIGN.md's failure-modes table specifies, and ARCHITECTURE.md's "custom exceptions translated to HTTP status codes only in routers" rule went unmet. Now caught and translated explicitly.
- **Spec gap**: `synthesis/answer.py`'s `_call_gemini` didn't catch a non-JSON 200 response body — `response.json()` itself can raise `json.JSONDecodeError`, uncovered by the existing `(KeyError, IndexError)` catch. Now caught as `SynthesisError` too, with a test.
- **Ponytail**: `test_query_router.py`'s `_result()` hand-built a full `DecisionUnit` inline instead of using the `make_unit` fixture already established in `conftest.py`.