### PR TITLE
Frontend: AnswerCard/MessageList/RepoFilter, api.js, App wiring, README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,78 @@ Every answer is cited back to the exact commit or PR it came from.
 See [ROADMAP.md](ROADMAP.md) for current scope and [CLAUDE.md](CLAUDE.md)
 for architecture/stack notes.
 
+## Quickstart
+
+### Prerequisites
+
+- Python 3.12+
+- Node 22+
+- [Ollama](https://ollama.com) running locally, with the two models used
+  by indexing pulled:
+  ```
+  ollama pull nomic-embed-text
+  ollama pull phi4-mini
+  ```
+  (`phi4-mini` is the default extraction model; if you set a different
+  `OLLAMA_EXTRACTION_MODEL`, pull that one instead.)
+- A GitHub token with `repo:read` access to whatever repos you want to
+  index
+- A [Gemini API key](https://ai.google.dev/) (synthesis only — retrieved
+  snippets are sent, never the full corpus)
+
+### Backend
+
+```
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example .env
+```
+
+Fill in `backend/.env`: `GITHUB_TOKEN`, `INDEXED_REPOS` (comma-separated
+`owner/repo` list), and `GEMINI_API_KEY`. Then:
+
+```
+uvicorn main:app --reload
+```
+
+Confirm it's up with `curl http://localhost:8000/health`.
+
+### Frontend
+
+In a second terminal:
+
+```
+cd frontend
+npm install
+cp .env.example .env
+npm run dev
+```
+
+`frontend/.env`'s `VITE_API_BASE_URL` already points at
+`http://localhost:8000` to match the backend above. Open the URL Vite
+prints (defaults to `http://localhost:5173`).
+
+### First ingestion
+
+Index every repo listed in `INDEXED_REPOS`:
+
+```
+curl -X POST http://localhost:8000/ingest
+```
+
+This fetches commits/PRs, extracts decision units, and stores them in
+Chroma — the response reports `fetched`/`extracted`/`skipped`/`stored`
+counts per repo. It can take a while on a repo's first run.
+
+### First question
+
+In the browser tab from the frontend step, click one of the example
+chips (or type your own question about the repos you indexed) and
+submit. You should get a cited answer with citation cards linking back
+to the source commit/PR — or a calm "nothing in the indexed history
+covers this" message if nothing relevant was indexed yet.
+
 ## Status
 
 Early scaffold — see open issues labeled `daily-task` for in-flight work.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the adr-engine backend (no trailing slash)
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,21 +1,116 @@
+import { useEffect, useState } from 'react'
+import { getRepos, postQuery } from './api.js'
+import ChatInput from './components/ChatInput.jsx'
+import MessageList from './components/MessageList.jsx'
+import RepoFilter from './components/RepoFilter.jsx'
+
+const EXAMPLE_QUESTIONS = [
+  'Why is authentication done this way?',
+  'What alternatives did we consider for the database?',
+  'Who made the decision to use Redis, and when?',
+]
+
 function App() {
+  const [repos, setRepos] = useState(undefined)
+  const [selectedRepos, setSelectedRepos] = useState([])
+  const [messages, setMessages] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [chatKey, setChatKey] = useState(0)
+  const [prefill, setPrefill] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+
+    getRepos()
+      .then((result) => {
+        if (cancelled) return
+        setRepos(result.repos)
+        setSelectedRepos(result.repos.map((repo) => repo.repo))
+      })
+      .catch(() => {
+        if (cancelled) return
+        setRepos([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function runQuery(question) {
+    setLoading(true)
+    try {
+      const result = await postQuery({ question, repos: selectedRepos })
+      setMessages((prev) => [
+        ...prev.slice(0, -1),
+        { role: 'assistant', type: 'answer', answer: result.answer, citations: result.citations },
+      ])
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev.slice(0, -1),
+        { role: 'assistant', type: 'error', message: err.message, onRetry: () => retry(question) },
+      ])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function retry(question) {
+    setMessages((prev) => [...prev.slice(0, -1), { role: 'assistant', type: 'loading' }])
+    runQuery(question)
+  }
+
+  function handleAsk(question) {
+    setMessages((prev) => [
+      ...prev,
+      { role: 'user', content: question },
+      { role: 'assistant', type: 'loading' },
+    ])
+    runQuery(question)
+  }
+
+  function handleChipClick(question) {
+    setPrefill(question)
+    setChatKey((key) => key + 1)
+  }
+
   return (
-    <div className="min-h-svh bg-surface text-ink flex items-center justify-center p-4">
-      <div className="max-w-md w-full bg-panel rounded-xl p-4 gap-4 flex flex-col shadow">
-        <h1 className="text-lg font-semibold">adr-engine</h1>
-        <p className="text-base">
-          "Why Did We Build It This Way?" — ask a question about the
-          indexed repos and get a cited answer.
-        </p>
-        <p className="text-sm text-ink-muted">
-          Design tokens wired up: surface, panel, ink, ink-muted.
-        </p>
-        <button
-          type="button"
-          className="rounded-lg bg-accent text-white px-4 py-2 text-sm font-semibold self-start"
-        >
-          Accent button
-        </button>
+    <div className="min-h-svh bg-surface text-ink flex flex-col">
+      <header className="h-14 shrink-0 bg-panel flex items-center justify-between px-4">
+        <span className="text-lg font-semibold">adr-engine</span>
+        <RepoFilter repos={repos} selected={selectedRepos} onChange={setSelectedRepos} />
+      </header>
+
+      <main className="flex-1 overflow-y-auto px-4 py-4">
+        {messages.length === 0 ? (
+          <div className="h-full flex flex-col items-center justify-center gap-4 text-center">
+            <p className="text-base text-ink-muted">
+              Ask why something in your codebase is the way it is
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              {EXAMPLE_QUESTIONS.map((question) => (
+                <button
+                  key={question}
+                  type="button"
+                  onClick={() => handleChipClick(question)}
+                  className="rounded-lg border border-transparent bg-panel text-ink text-sm px-4 py-2 hover:border-accent"
+                >
+                  {question}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-3xl mx-auto">
+            <MessageList messages={messages} />
+          </div>
+        )}
+      </main>
+
+      <div className="sticky bottom-0 shrink-0 bg-panel px-4 py-4">
+        <div className="max-w-3xl mx-auto">
+          <ChatInput key={chatKey} initialValue={prefill} onSubmit={handleAsk} disabled={loading} />
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
       })
       .catch(() => {
         if (cancelled) return
-        setRepos([])
+        setRepos('error')
       })
 
     return () => {
@@ -37,26 +37,34 @@ function App() {
     }
   }, [])
 
+  function replaceLastMessage(message) {
+    setMessages((prev) => [...prev.slice(0, -1), message])
+  }
+
   async function runQuery(question) {
     setLoading(true)
     try {
       const result = await postQuery({ question, repos: selectedRepos })
-      setMessages((prev) => [
-        ...prev.slice(0, -1),
-        { role: 'assistant', type: 'answer', answer: result.answer, citations: result.citations },
-      ])
+      replaceLastMessage({
+        role: 'assistant',
+        type: 'answer',
+        answer: result.answer,
+        citations: result.citations,
+      })
     } catch (err) {
-      setMessages((prev) => [
-        ...prev.slice(0, -1),
-        { role: 'assistant', type: 'error', message: err.message, onRetry: () => retry(question) },
-      ])
+      replaceLastMessage({
+        role: 'assistant',
+        type: 'error',
+        message: err.message,
+        onRetry: () => retry(question),
+      })
     } finally {
       setLoading(false)
     }
   }
 
   function retry(question) {
-    setMessages((prev) => [...prev.slice(0, -1), { role: 'assistant', type: 'loading' }])
+    replaceLastMessage({ role: 'assistant', type: 'loading' })
     runQuery(question)
   }
 
@@ -102,7 +110,7 @@ function App() {
           </div>
         ) : (
           <div className="max-w-3xl mx-auto">
-            <MessageList messages={messages} />
+            <MessageList messages={messages} disabled={loading} />
           </div>
         )}
       </main>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -62,6 +62,45 @@ describe('App', () => {
     expect(postQuery).toHaveBeenCalledTimes(2)
   })
 
+  it('disables Retry while a retry is in flight, preventing a double-fire race', async () => {
+    const user = userEvent.setup()
+    getRepos.mockResolvedValue(REPOS)
+    postQuery.mockRejectedValueOnce(new Error('Gemini returned 401'))
+
+    render(<App />)
+
+    await user.type(screen.getByLabelText('Ask a question'), 'Why Redis?')
+    await user.click(screen.getByRole('button', { name: 'Ask' }))
+
+    expect(await screen.findByText('Gemini returned 401')).toBeInTheDocument()
+
+    let resolveRetry
+    postQuery.mockReturnValueOnce(new Promise((resolve) => { resolveRetry = resolve }))
+
+    const retryButton = screen.getByRole('button', { name: 'Retry' })
+    await user.click(retryButton)
+
+    // Retry is now in flight (rendered as a LoadingCard) — the button that
+    // triggered it is gone, and nothing else can fire a second concurrent
+    // call while this one resolves.
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+    expect(await screen.findByRole('status')).toBeInTheDocument()
+
+    resolveRetry({ answer: 'Redis was already used for caching.', citations: [], retrieved_count: 0 })
+
+    expect(await screen.findByText('Redis was already used for caching.')).toBeInTheDocument()
+    expect(postQuery).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows a distinct failed state, not an eternal skeleton, when GET /repos fails', async () => {
+    getRepos.mockRejectedValue(new Error('network error'))
+
+    render(<App />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load repos")
+    expect(screen.queryByRole('status', { name: 'Loading repos' })).not.toBeInTheDocument()
+  })
+
   it('fills the input when an example chip is clicked', async () => {
     const user = userEvent.setup()
     getRepos.mockResolvedValue(REPOS)

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App.jsx'
+import { getRepos, postQuery } from './api.js'
+
+vi.mock('./api.js', () => ({
+  getRepos: vi.fn(),
+  postQuery: vi.fn(),
+}))
+
+const REPOS = { repos: [{ repo: 'owner/repo-a', indexed_units: 12 }] }
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('App', () => {
+  it('shows a loading state then an answer after submitting a question', async () => {
+    const user = userEvent.setup()
+    getRepos.mockResolvedValue(REPOS)
+    let resolveQuery
+    postQuery.mockReturnValue(new Promise((resolve) => { resolveQuery = resolve }))
+
+    render(<App />)
+
+    await user.type(screen.getByLabelText('Ask a question'), 'Why OAuth2?')
+    await user.click(screen.getByRole('button', { name: 'Ask' }))
+
+    expect(await screen.findByRole('status')).toBeInTheDocument()
+    expect(postQuery).toHaveBeenCalledWith({ question: 'Why OAuth2?', repos: ['owner/repo-a'] })
+
+    resolveQuery({ answer: 'We use OAuth2 for auth.', citations: [], retrieved_count: 0 })
+
+    expect(await screen.findByText('We use OAuth2 for auth.')).toBeInTheDocument()
+  })
+
+  it('shows an ErrorCard with a working retry on a failed call', async () => {
+    const user = userEvent.setup()
+    getRepos.mockResolvedValue(REPOS)
+    postQuery.mockRejectedValueOnce(new Error('Gemini returned 401'))
+
+    render(<App />)
+
+    await user.type(screen.getByLabelText('Ask a question'), 'Why Redis?')
+    await user.click(screen.getByRole('button', { name: 'Ask' }))
+
+    expect(await screen.findByText('Gemini returned 401')).toBeInTheDocument()
+
+    postQuery.mockResolvedValueOnce({
+      answer: 'Redis was already used for caching.',
+      citations: [],
+      retrieved_count: 0,
+    })
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Redis was already used for caching.')).toBeInTheDocument()
+    expect(postQuery).toHaveBeenCalledTimes(2)
+  })
+
+  it('fills the input when an example chip is clicked', async () => {
+    const user = userEvent.setup()
+    getRepos.mockResolvedValue(REPOS)
+
+    render(<App />)
+
+    const chip = await screen.findByRole('button', { name: 'Why is authentication done this way?' })
+    await user.click(chip)
+
+    expect(screen.getByLabelText('Ask a question')).toHaveValue(
+      'Why is authentication done this way?',
+    )
+  })
+})

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,43 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+export class ApiError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}
+
+async function request(path, options) {
+  let response
+  try {
+    response = await fetch(`${BASE_URL}${path}`, options)
+  } catch {
+    throw new ApiError(0, 'Could not reach the backend. Is it running?')
+  }
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`
+    try {
+      const body = await response.json()
+      if (body?.detail) message = body.detail
+    } catch {
+      // response body wasn't JSON — fall back to the generic message
+    }
+    throw new ApiError(response.status, message)
+  }
+
+  return response.json()
+}
+
+export function getRepos() {
+  return request('/repos', { method: 'GET' })
+}
+
+export function postQuery({ question, repos }) {
+  return request('/query', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question, repos }),
+  })
+}

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, getRepos, postQuery } from './api.js'
+
+function mockFetchOnce(response) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: () => Promise.resolve(response.body),
+    }),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getRepos', () => {
+  it('GETs /repos and resolves with the parsed body', async () => {
+    const body = { repos: [{ repo: 'owner/repo-a', indexed_units: 12 }] }
+    mockFetchOnce({ body })
+
+    const result = await getRepos()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, options] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/repos$/)
+    expect(options.method).toBe('GET')
+    expect(result).toEqual(body)
+  })
+})
+
+describe('postQuery', () => {
+  it('POSTs /query with the question and repos as JSON', async () => {
+    const body = { answer: 'Because Redis was already in use.', citations: [], retrieved_count: 0 }
+    mockFetchOnce({ body })
+
+    const result = await postQuery({ question: 'Why Redis?', repos: ['owner/repo-a'] })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, options] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/query$/)
+    expect(options.method).toBe('POST')
+    expect(options.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(options.body)).toEqual({ question: 'Why Redis?', repos: ['owner/repo-a'] })
+    expect(result).toEqual(body)
+  })
+})
+
+describe('error handling', () => {
+  it('throws an ApiError with the backend detail message on a non-2xx response', async () => {
+    mockFetchOnce({ ok: false, status: 502, body: { detail: 'Gemini returned 401' } })
+
+    await expect(getRepos()).rejects.toMatchObject(
+      new ApiError(502, 'Gemini returned 401'),
+    )
+  })
+
+  it('falls back to a generic message when the error body has no detail', async () => {
+    mockFetchOnce({ ok: false, status: 500, body: {} })
+
+    await expect(getRepos()).rejects.toMatchObject(
+      new ApiError(500, 'Request failed with status 500'),
+    )
+  })
+
+  it('throws an ApiError when the network request itself fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    await expect(getRepos()).rejects.toBeInstanceOf(ApiError)
+  })
+})

--- a/frontend/src/components/AnswerCard.jsx
+++ b/frontend/src/components/AnswerCard.jsx
@@ -1,12 +1,11 @@
 import CitationCard from './CitationCard.jsx'
+import { MESSAGE_CARD_BASE } from './messageCardBase.js'
 
 function AnswerCard({ answer, citations }) {
   const hasCitations = citations.length > 0
 
   return (
-    <div
-      className={`max-w-3xl rounded-xl bg-panel p-4 ${hasCitations ? 'text-ink' : 'text-ink-muted'}`}
-    >
+    <div className={`${MESSAGE_CARD_BASE} ${hasCitations ? 'text-ink' : 'text-ink-muted'}`}>
       <p className="text-base">{answer}</p>
       {hasCitations && (
         <div className="mt-4 flex flex-wrap gap-4">

--- a/frontend/src/components/AnswerCard.jsx
+++ b/frontend/src/components/AnswerCard.jsx
@@ -1,0 +1,22 @@
+import CitationCard from './CitationCard.jsx'
+
+function AnswerCard({ answer, citations }) {
+  const hasCitations = citations.length > 0
+
+  return (
+    <div
+      className={`max-w-3xl rounded-xl bg-panel p-4 ${hasCitations ? 'text-ink' : 'text-ink-muted'}`}
+    >
+      <p className="text-base">{answer}</p>
+      {hasCitations && (
+        <div className="mt-4 flex flex-wrap gap-4">
+          {citations.map((unit) => (
+            <CitationCard key={unit.url} unit={unit} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AnswerCard

--- a/frontend/src/components/AnswerCard.test.jsx
+++ b/frontend/src/components/AnswerCard.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AnswerCard from './AnswerCard.jsx'
+
+const citation = {
+  kind: 'pr',
+  ref: '42',
+  url: 'https://github.com/owner/repo/pull/42',
+  title: 'Switch auth to OAuth2 for third-party integrations',
+  author: 'octocat',
+  date: '2024-01-01T00:00:00Z',
+  repo: 'owner/repo',
+}
+
+describe('AnswerCard', () => {
+  it('renders the answer text and a citation for each unit', () => {
+    render(<AnswerCard answer="We use OAuth2 for auth." citations={[citation]} />)
+
+    expect(screen.getByText('We use OAuth2 for auth.')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', citation.url)
+  })
+
+  it('renders no citation links when citations is empty', () => {
+    render(<AnswerCard answer="Nothing in the indexed history covers this." citations={[]} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('styles the no-answer variant as muted, not an error', () => {
+    render(<AnswerCard answer="Nothing in the indexed history covers this." citations={[]} />)
+
+    const card = screen.getByText('Nothing in the indexed history covers this.').parentElement
+    expect(card.className).toContain('text-ink-muted')
+    expect(card.className).not.toContain('danger')
+  })
+})

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
-function ChatInput({ onSubmit, disabled }) {
-  const [value, setValue] = useState('')
+function ChatInput({ onSubmit, disabled, initialValue = '' }) {
+  const [value, setValue] = useState(initialValue)
 
   function submit() {
     const question = value.trim()

--- a/frontend/src/components/ErrorCard.jsx
+++ b/frontend/src/components/ErrorCard.jsx
@@ -1,6 +1,8 @@
+import { MESSAGE_CARD_BASE } from './messageCardBase.js'
+
 function ErrorCard({ message, onRetry }) {
   return (
-    <div className="max-w-3xl rounded-xl bg-panel border border-danger p-4">
+    <div className={`${MESSAGE_CARD_BASE} border border-danger`}>
       <p className="text-base text-danger">{message}</p>
       <button
         type="button"

--- a/frontend/src/components/ErrorCard.jsx
+++ b/frontend/src/components/ErrorCard.jsx
@@ -1,0 +1,16 @@
+function ErrorCard({ message, onRetry }) {
+  return (
+    <div className="max-w-3xl rounded-xl bg-panel border border-danger p-4">
+      <p className="text-base text-danger">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+export default ErrorCard

--- a/frontend/src/components/ErrorCard.jsx
+++ b/frontend/src/components/ErrorCard.jsx
@@ -1,13 +1,14 @@
 import { MESSAGE_CARD_BASE } from './messageCardBase.js'
 
-function ErrorCard({ message, onRetry }) {
+function ErrorCard({ message, onRetry, disabled }) {
   return (
     <div className={`${MESSAGE_CARD_BASE} border border-danger`}>
       <p className="text-base text-danger">{message}</p>
       <button
         type="button"
         onClick={onRetry}
-        className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
+        disabled={disabled}
+        className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2 disabled:opacity-50"
       >
         Retry
       </button>

--- a/frontend/src/components/ErrorCard.test.jsx
+++ b/frontend/src/components/ErrorCard.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ErrorCard from './ErrorCard.jsx'
+
+describe('ErrorCard', () => {
+  it('renders the error message', () => {
+    render(<ErrorCard message="Backend unreachable" onRetry={() => {}} />)
+    expect(screen.getByText('Backend unreachable')).toBeInTheDocument()
+  })
+
+  it('calls onRetry exactly once per click', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    render(<ErrorCard message="Backend unreachable" onRetry={onRetry} />)
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/components/ErrorCard.test.jsx
+++ b/frontend/src/components/ErrorCard.test.jsx
@@ -20,4 +20,9 @@ describe('ErrorCard', () => {
     await user.click(screen.getByRole('button', { name: 'Retry' }))
     expect(onRetry).toHaveBeenCalledTimes(2)
   })
+
+  it('disables the Retry button when disabled is true', () => {
+    render(<ErrorCard message="Backend unreachable" onRetry={() => {}} disabled />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled()
+  })
 })

--- a/frontend/src/components/LoadingCard.jsx
+++ b/frontend/src/components/LoadingCard.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+const STATUSES = [
+  'Searching decision history…',
+  'Reading citations…',
+  'Synthesizing an answer…',
+]
+
+function LoadingCard() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % STATUSES.length)
+    }, 2000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div role="status" className="max-w-3xl rounded-xl bg-panel p-4">
+      <div className="flex gap-1">
+        <span className="h-2 w-2 rounded-full bg-ink-muted animate-pulse" />
+        <span className="h-2 w-2 rounded-full bg-ink-muted animate-pulse [animation-delay:150ms]" />
+        <span className="h-2 w-2 rounded-full bg-ink-muted animate-pulse [animation-delay:300ms]" />
+      </div>
+      <p className="text-sm text-ink-muted mt-2">{STATUSES[index]}</p>
+    </div>
+  )
+}
+
+export default LoadingCard

--- a/frontend/src/components/LoadingCard.jsx
+++ b/frontend/src/components/LoadingCard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { MESSAGE_CARD_BASE } from './messageCardBase.js'
 
 const STATUSES = [
   'Searching decision history…',
@@ -17,7 +18,7 @@ function LoadingCard() {
   }, [])
 
   return (
-    <div role="status" className="max-w-3xl rounded-xl bg-panel p-4">
+    <div role="status" className={MESSAGE_CARD_BASE}>
       <div className="flex gap-1">
         <span className="h-2 w-2 rounded-full bg-ink-muted animate-pulse" />
         <span className="h-2 w-2 rounded-full bg-ink-muted animate-pulse [animation-delay:150ms]" />

--- a/frontend/src/components/LoadingCard.test.jsx
+++ b/frontend/src/components/LoadingCard.test.jsx
@@ -1,0 +1,32 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import LoadingCard from './LoadingCard.jsx'
+
+describe('LoadingCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders an initial status message', () => {
+    render(<LoadingCard />)
+    expect(screen.getByText('Searching decision history…')).toBeInTheDocument()
+  })
+
+  it('rotates the status text over time', () => {
+    render(<LoadingCard />)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(screen.getByText('Reading citations…')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(screen.getByText('Synthesizing an answer…')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -3,10 +3,10 @@ import AnswerCard from './AnswerCard.jsx'
 import ErrorCard from './ErrorCard.jsx'
 import LoadingCard from './LoadingCard.jsx'
 
-function AssistantMessage({ message }) {
+function AssistantMessage({ message, disabled }) {
   if (message.type === 'loading') return <LoadingCard />
   if (message.type === 'error') {
-    return <ErrorCard message={message.message} onRetry={message.onRetry} />
+    return <ErrorCard message={message.message} onRetry={message.onRetry} disabled={disabled} />
   }
   // `type` is optional and defaults to 'answer' per its spec — but a
   // genuinely unrecognized value (a typo, a future untyped state) is a
@@ -14,10 +14,16 @@ function AssistantMessage({ message }) {
   if (!message.type || message.type === 'answer') {
     return <AnswerCard answer={message.answer} citations={message.citations ?? []} />
   }
-  return <ErrorCard message={`Unrecognized message type: "${message.type}"`} onRetry={() => {}} />
+  return (
+    <ErrorCard
+      message={`Unrecognized message type: "${message.type}"`}
+      onRetry={() => {}}
+      disabled={disabled}
+    />
+  )
 }
 
-function MessageList({ messages }) {
+function MessageList({ messages, disabled }) {
   const bottomRef = useRef(null)
 
   useEffect(() => {
@@ -35,7 +41,7 @@ function MessageList({ messages }) {
           </div>
         ) : (
           <div key={index} className="flex justify-start">
-            <AssistantMessage message={message} />
+            <AssistantMessage message={message} disabled={disabled} />
           </div>
         ),
       )}

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react'
+import AnswerCard from './AnswerCard.jsx'
+import ErrorCard from './ErrorCard.jsx'
+import LoadingCard from './LoadingCard.jsx'
+
+function AssistantMessage({ message }) {
+  if (message.type === 'loading') return <LoadingCard />
+  if (message.type === 'error') {
+    return <ErrorCard message={message.message} onRetry={message.onRetry} />
+  }
+  return <AnswerCard answer={message.answer} citations={message.citations ?? []} />
+}
+
+function MessageList({ messages }) {
+  const bottomRef = useRef(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' })
+  }, [messages])
+
+  return (
+    <div className="flex flex-col gap-4">
+      {messages.map((message, index) =>
+        message.role === 'user' ? (
+          <div key={index} className="flex justify-end">
+            <div className="max-w-3xl rounded-xl bg-accent text-white p-4">
+              {message.content}
+            </div>
+          </div>
+        ) : (
+          <div key={index} className="flex justify-start">
+            <AssistantMessage message={message} />
+          </div>
+        ),
+      )}
+      <div ref={bottomRef} />
+    </div>
+  )
+}
+
+export default MessageList

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -8,7 +8,13 @@ function AssistantMessage({ message }) {
   if (message.type === 'error') {
     return <ErrorCard message={message.message} onRetry={message.onRetry} />
   }
-  return <AnswerCard answer={message.answer} citations={message.citations ?? []} />
+  // `type` is optional and defaults to 'answer' per its spec — but a
+  // genuinely unrecognized value (a typo, a future untyped state) is a
+  // bug, not a silent answer with undefined content.
+  if (!message.type || message.type === 'answer') {
+    return <AnswerCard answer={message.answer} citations={message.citations ?? []} />
+  }
+  return <ErrorCard message={`Unrecognized message type: "${message.type}"`} onRetry={() => {}} />
 }
 
 function MessageList({ messages }) {

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -49,6 +49,20 @@ describe('MessageList', () => {
     expect(screen.getByRole('link')).toHaveAttribute('href', citation.url)
   })
 
+  it('renders AnswerCard for an assistant message with an omitted type (defaults to answer)', () => {
+    render(
+      <MessageList
+        messages={[{ role: 'assistant', answer: 'We use OAuth2 for auth.', citations: [] }]}
+      />,
+    )
+    expect(screen.getByText('We use OAuth2 for auth.')).toBeInTheDocument()
+  })
+
+  it('renders ErrorCard with a generic message for an unrecognized type', () => {
+    render(<MessageList messages={[{ role: 'assistant', type: 'bogus' }]} />)
+    expect(screen.getByText('Unrecognized message type: "bogus"')).toBeInTheDocument()
+  })
+
   it('scrolls to the newest message on update', () => {
     const { rerender } = render(<MessageList messages={[{ role: 'user', content: 'first' }]} />)
     expect(Element.prototype.scrollIntoView).toHaveBeenCalled()

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -37,6 +37,16 @@ describe('MessageList', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
   })
 
+  it('disables the Retry button when the list is disabled', () => {
+    render(
+      <MessageList
+        messages={[{ role: 'assistant', type: 'error', message: 'Backend unreachable', onRetry: () => {} }]}
+        disabled
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled()
+  })
+
   it('renders AnswerCard for an assistant answer message', () => {
     render(
       <MessageList

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MessageList from './MessageList.jsx'
+
+const citation = {
+  kind: 'pr',
+  ref: '42',
+  url: 'https://github.com/owner/repo/pull/42',
+  title: 'Switch auth to OAuth2 for third-party integrations',
+  author: 'octocat',
+  date: '2024-01-01T00:00:00Z',
+  repo: 'owner/repo',
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe('MessageList', () => {
+  it('renders a right-aligned question bubble for user messages', () => {
+    render(<MessageList messages={[{ role: 'user', content: 'Why OAuth2?' }]} />)
+    expect(screen.getByText('Why OAuth2?')).toBeInTheDocument()
+  })
+
+  it('renders LoadingCard for an assistant loading message', () => {
+    render(<MessageList messages={[{ role: 'assistant', type: 'loading' }]} />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('renders ErrorCard for an assistant error message', () => {
+    render(
+      <MessageList
+        messages={[{ role: 'assistant', type: 'error', message: 'Backend unreachable', onRetry: () => {} }]}
+      />,
+    )
+    expect(screen.getByText('Backend unreachable')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('renders AnswerCard for an assistant answer message', () => {
+    render(
+      <MessageList
+        messages={[
+          { role: 'assistant', type: 'answer', answer: 'We use OAuth2 for auth.', citations: [citation] },
+        ]}
+      />,
+    )
+    expect(screen.getByText('We use OAuth2 for auth.')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', citation.url)
+  })
+
+  it('scrolls to the newest message on update', () => {
+    const { rerender } = render(<MessageList messages={[{ role: 'user', content: 'first' }]} />)
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+
+    Element.prototype.scrollIntoView.mockClear()
+    rerender(
+      <MessageList
+        messages={[
+          { role: 'user', content: 'first' },
+          { role: 'user', content: 'second' },
+        ]}
+      />,
+    )
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/RepoFilter.jsx
+++ b/frontend/src/components/RepoFilter.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+
+function RepoFilter({ repos, selected, onChange }) {
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const containerRef = useRef(null)
+
+  const loading = repos == null || repos.length === 0
+
+  useEffect(() => {
+    if (!open) return
+
+    function handleClickOutside(event) {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading repos"
+        className="h-9 w-28 rounded-lg bg-panel animate-pulse"
+      />
+    )
+  }
+
+  if (repos.length === 1) {
+    return (
+      <span className="inline-block rounded-lg bg-panel text-ink text-sm px-3 py-1.5">
+        {repos[0].repo}
+      </span>
+    )
+  }
+
+  const label =
+    selected.length === repos.length
+      ? 'All repos'
+      : `${selected.length} repo${selected.length === 1 ? '' : 's'}`
+
+  function toggle(repo) {
+    onChange(
+      selected.includes(repo)
+        ? selected.filter((r) => r !== repo)
+        : [...selected, repo],
+    )
+  }
+
+  function handleKeyDown(event) {
+    if (!open) return
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, repos.length - 1))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+    } else if (event.key === ' ') {
+      event.preventDefault()
+      toggle(repos[activeIndex].repo)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative" onKeyDown={handleKeyDown}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="rounded-lg bg-panel text-ink text-sm px-3 py-1.5"
+      >
+        {label}
+      </button>
+      {open && (
+        <ul
+          role="listbox"
+          aria-multiselectable="true"
+          className="absolute right-0 z-10 mt-2 w-56 rounded-xl bg-panel p-2 shadow"
+        >
+          {repos.map((r, index) => (
+            <li
+              key={r.repo}
+              role="option"
+              aria-selected={selected.includes(r.repo)}
+              tabIndex={-1}
+              onClick={() => toggle(r.repo)}
+              className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm cursor-pointer ${
+                index === activeIndex ? 'bg-surface' : ''
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={selected.includes(r.repo)}
+                readOnly
+                className="pointer-events-none"
+              />
+              <span className="text-ink">{r.repo}</span>
+              <span className="ml-auto text-ink-muted">{r.indexed_units}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default RepoFilter

--- a/frontend/src/components/RepoFilter.jsx
+++ b/frontend/src/components/RepoFilter.jsx
@@ -5,7 +5,8 @@ function RepoFilter({ repos, selected, onChange }) {
   const [activeIndex, setActiveIndex] = useState(0)
   const containerRef = useRef(null)
 
-  const loading = repos == null || repos.length === 0
+  const loading = repos === undefined
+  const failed = repos === 'error'
 
   useEffect(() => {
     if (!open) return
@@ -27,6 +28,17 @@ function RepoFilter({ repos, selected, onChange }) {
         aria-label="Loading repos"
         className="h-9 w-28 rounded-lg bg-panel animate-pulse"
       />
+    )
+  }
+
+  if (failed) {
+    return (
+      <span
+        role="alert"
+        className="inline-block rounded-lg bg-panel text-danger text-sm px-3 py-1.5"
+      >
+        Couldn't load repos
+      </span>
     )
   }
 

--- a/frontend/src/components/RepoFilter.test.jsx
+++ b/frontend/src/components/RepoFilter.test.jsx
@@ -10,9 +10,15 @@ const repos = [
 ]
 
 describe('RepoFilter', () => {
-  it('renders a loading skeleton when repos is empty or undefined', () => {
+  it('renders a loading skeleton when repos is undefined', () => {
     render(<RepoFilter repos={undefined} selected={[]} onChange={() => {}} />)
     expect(screen.getByRole('status', { name: 'Loading repos' })).toBeInTheDocument()
+  })
+
+  it('renders a distinct failed state when repos is "error", not an eternal skeleton', () => {
+    render(<RepoFilter repos="error" selected={[]} onChange={() => {}} />)
+    expect(screen.queryByRole('status', { name: 'Loading repos' })).not.toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent("Couldn't load repos")
   })
 
   it('renders a static badge for a single repo, not a dropdown', () => {

--- a/frontend/src/components/RepoFilter.test.jsx
+++ b/frontend/src/components/RepoFilter.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import RepoFilter from './RepoFilter.jsx'
+
+const repos = [
+  { repo: 'owner/repo-a', indexed_units: 12 },
+  { repo: 'owner/repo-b', indexed_units: 3 },
+  { repo: 'owner/repo-c', indexed_units: 7 },
+]
+
+describe('RepoFilter', () => {
+  it('renders a loading skeleton when repos is empty or undefined', () => {
+    render(<RepoFilter repos={undefined} selected={[]} onChange={() => {}} />)
+    expect(screen.getByRole('status', { name: 'Loading repos' })).toBeInTheDocument()
+  })
+
+  it('renders a static badge for a single repo, not a dropdown', () => {
+    render(
+      <RepoFilter
+        repos={[repos[0]]}
+        selected={['owner/repo-a']}
+        onChange={() => {}}
+      />,
+    )
+    expect(screen.getByText('owner/repo-a')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('is closed by default and shows "All repos" when everything is selected', () => {
+    render(
+      <RepoFilter
+        repos={repos}
+        selected={repos.map((r) => r.repo)}
+        onChange={() => {}}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'All repos' })).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('shows a short summary when a subset is selected', () => {
+    render(<RepoFilter repos={repos} selected={['owner/repo-a']} onChange={() => {}} />)
+    expect(screen.getByRole('button', { name: '1 repo' })).toBeInTheDocument()
+  })
+
+  it('opens on click and closes on Escape', async () => {
+    const user = userEvent.setup()
+    render(
+      <RepoFilter repos={repos} selected={repos.map((r) => r.repo)} onChange={() => {}} />,
+    )
+
+    await user.click(screen.getByRole('button'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('has aria-haspopup="listbox" on the trigger button', () => {
+    render(
+      <RepoFilter repos={repos} selected={repos.map((r) => r.repo)} onChange={() => {}} />,
+    )
+    expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'listbox')
+  })
+
+  it('toggles a repo on click', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <RepoFilter repos={repos} selected={['owner/repo-a']} onChange={onChange} />,
+    )
+
+    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByText('owner/repo-b'))
+
+    expect(onChange).toHaveBeenCalledWith(['owner/repo-a', 'owner/repo-b'])
+  })
+
+  it('toggles the active option with arrow keys + Space', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<RepoFilter repos={repos} selected={[]} onChange={onChange} />)
+
+    await user.click(screen.getByRole('button'))
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard(' ')
+
+    expect(onChange).toHaveBeenCalledWith(['owner/repo-b'])
+  })
+})

--- a/frontend/src/components/messageCardBase.js
+++ b/frontend/src/components/messageCardBase.js
@@ -1,0 +1,3 @@
+// Shared wrapper classes for the message-list cards (AnswerCard, ErrorCard,
+// LoadingCard) — each composes this with its own state-specific classes.
+export const MESSAGE_CARD_BASE = 'max-w-3xl rounded-xl bg-panel p-4'


### PR DESCRIPTION
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38

## Changelog
- Add `AnswerCard`, with a muted no-answer variant when citations are empty
- Add `LoadingCard` (rotating status text) and `ErrorCard` (retry button)
- Add `MessageList`, composing the above per message type and auto-scrolling to the newest message
- Add `RepoFilter`: multi-select dropdown with loading skeleton, single-repo static badge, and keyboard support (arrows + Space + Escape)
- Add `api.js`: single fetch wrapper (`getRepos`, `postQuery`) throwing a typed `ApiError` on non-2xx/network failure
- Wire `App.jsx` into a working end-to-end loop: header + `RepoFilter`, `MessageList` state, `ChatInput` submit → loading → answer/error, and an empty state with example-question chips that prefill the input
- Add a README quickstart covering Ollama models, backend/frontend setup, first ingestion, and asking a first question

## Fixes from code review (round 1: components)

- **Spec gap**: `MessageList`'s `AssistantMessage` fell through to `AnswerCard` for *any* unrecognized `type`, not just the intended `"answer"` case. Omitted `type` still defaults to `answer` (matches the spec's `type?: "answer"`), but a genuinely unrecognized value now renders `ErrorCard` with a diagnostic message.
- **Ponytail**: `AnswerCard`/`ErrorCard`/`LoadingCard` each hardcoded the same wrapper classes. Extracted to one `MESSAGE_CARD_BASE` constant.

## Fixes from code review (round 2: api.js/App wiring/README)

- **Real race condition**: `ErrorCard`'s Retry button had no `disabled` wiring anywhere. Two rapid clicks fired overlapping `runQuery` calls that both did "replace last message" array surgery on `messages`, silently dropping one answer and corrupting the list. Grilled the fix approach — Retry now takes a `disabled` prop threaded from `App`'s existing `loading` state through `MessageList` → `AssistantMessage`, mirroring how `ChatInput` already disables during a query.
- **UX dead-end**: `RepoFilter` treated a failed `/repos` fetch identically to "still loading" (permanent skeleton, no way to tell them apart). Grilled whether to fix now vs. defer — fixing now since it touches the same `App.jsx` area. `App` now sets a distinct `'error'` sentinel on fetch failure; `RepoFilter` renders a small "Couldn't load repos" alert instead.
- **Ponytail**: the three `setMessages((prev) => [...prev.slice(0, -1), {...}])` call sites in `App.jsx` collapsed into one `replaceLastMessage()` helper.

## Fix from actually running the app locally

- **Real bug, found only by manual verification**: no CORS middleware on the backend, so every `api.js` fetch from the frontend (a different origin/port) was silently blocked by the browser (`net::ERR_FAILED`) — exactly the gap the "manual `npm run dev` verification wasn't possible" note below was covering for. Added permissive `CORSMiddleware` (safe here: single-user, no-auth, local-only, no credentials ever sent). Confirmed working end-to-end afterward: asking a question against an unindexed corpus correctly rendered the muted "Nothing in the indexed history covers this question" no-answer state, no console errors.

Re-verified after all fixes with a matching Node version (22.19.0): `npm test` 43/43, `npm run lint` clean, `npm run build` succeeds.

## Notes on this round
- `ChatInput` gained an optional `initialValue` prop (small, non-breaking addition) so `App`'s example-question chips can prefill the textarea without making the component fully controlled.
- ~~Manual `npm run dev` verification against a live backend wasn't possible in this environment~~ — done in a later pass (see "Fix from actually running the app locally" above); it surfaced a real bug the mocked tests couldn't catch.