### PR TITLE
Phase 2 backend: config store, GET/PATCH /config, GET /github/repos, docs restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ chroma_data/
 
 # OS
 .DS_Store
+
+# Local tooling state
+.claude/
+.impeccable/

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,67 @@
+# Product
+
+## Register
+
+product
+
+## Platform
+
+web
+
+## Users
+
+Developers — solo maintainers and small-team engineers — running adr-engine
+locally against repos they work on. They arrive mid-task: about to refactor
+something old, reviewing an unfamiliar module, or onboarding onto a codebase
+whose decisions predate them. They are fluent in tools like Linear, GitHub,
+and their IDE, and they judge product quality quickly.
+
+## Product Purpose
+
+adr-engine answers "why is this built this way?" with prose cited back to
+the exact commit or PR where the decision happened, mined automatically
+from GitHub history — no one has to remember to write an ADR. Success in
+Phase 2: a new user goes from launch to their first cited answer in
+minutes without touching a config file, and the app keeps earning return
+visits before every dive into old code.
+
+## Positioning
+
+Ask your codebase why — and get an answer cited to the commit where it was
+decided, without your code ever leaving your machine.
+
+## Brand Personality
+
+Archival, precise, calm. The product is a reading room for a codebase's
+memory: answers read like well-typeset annotated pages, not chat bubbles.
+Interface chrome stays quiet and crisp; the identity lives in the reading
+surface — a serif reading voice, careful citation typography, unhurried
+microcopy that reports exactly what the system examined and knows.
+
+## Anti-references
+
+- Terminal-native dev-tool aesthetics (Warp/Raycast lane): monospace-led,
+  dense, neon-on-black. The saturated reflex for developer tools.
+- Stock Tailwind chat templates and ChatGPT-clone chat UIs — the current
+  Phase 1 look this redesign explicitly replaces.
+- SaaS dashboard grammar: hero metrics, card grids, gradient accents.
+
+## Design Principles
+
+1. **Citations are the product.** Every claim traceable; sources always one
+   glance away, never buried behind a click.
+2. **Answers are read, not skimmed.** The reading surface gets typographic
+   care (measure, serif voice, rhythm); chrome defers to it.
+3. **Honest state.** Indexing progress, degraded modes, and failures say
+   precisely what the system did and knows — never a bare spinner.
+4. **Earn the privacy claim on-screen.** What runs locally and what leaves
+   the machine is visible in the moments it matters, not just in a README.
+5. **Familiar chrome, distinctive reading surface.** Navigation, forms, and
+   controls disappear into the task; personality concentrates where users
+   read.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA: ≥4.5:1 body text contrast, full keyboard operability with
+visible focus, correct semantics on all components, and a
+reduced-motion alternative for every animation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,10 @@ RAG applied to a team's *living decision history*, not static documents.
 Ask "why is auth done this way?" and get a cited answer pointing back to
 the commit or PR where that decision actually happened.
 
-Design docs: [SYSTEM-DESIGN.md](docs/SYSTEM-DESIGN.md) ·
-[ARCHITECTURE.md](docs/ARCHITECTURE.md) · [UI-DESIGN.md](docs/UI-DESIGN.md)
+Design docs: [PRODUCT.md](PRODUCT.md) ·
+[SYSTEM-DESIGN.md](docs/SYSTEM-DESIGN.md) ·
+[ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
+[UI-DESIGN.md](docs/UI-DESIGN.md)
 
 ## Delivery model (how work lands here)
 
@@ -43,45 +45,85 @@ without a human merging anything:
   closes the completed issues and resets the cycle. Groom `needs-triage`
   into `daily-task` (or close) during ideation sessions.
 
-## Phase 1 — MVP: GitHub only (current)
+## Phase 1 — MVP: GitHub only (complete, pending final polish)
 
-Goal: ask a question about the indexed repos in the React UI and get a
-correctly cited answer, end to end, locally.
+Goal reached: ask a question about the indexed repos in the React UI and
+get a correctly cited answer, end to end, locally. All batches (A–F)
+delivered; remaining loose ends: #39 (.env reconciliation), #40
+(ingestion CLI entry point) — both fold naturally into Phase 2's config
+work.
 
-Batches (each batch = several one-PR-sized issues, in dependency order):
+## Phase 2 — Productization (current)
 
-- **A. Foundation** — config module, typed models, Chroma store layer,
-  test fixtures scaffolding. *(Backend scaffold + health check already
-  landed via PR #12.)*
-- **B. GitHub ingestion** — client (commits, then PRs, then pagination/
-  rate-limit handling as separate issues), cursor persistence.
-- **C. Extraction & embedding** — extraction prompt + JSON parsing +
-  skip signal, malformed-output handling, embedding wrapper, ingestion
-  orchestrator, `/ingest` endpoint.
-- **D. Retrieval & synthesis** — search with relevance floor + repo
-  filter, `/retrieve`, `GET /repos`, synthesis prompt + citation
-  parsing, `/query`, golden-questions eval file.
-- **E. Frontend** — Vite+Tailwind scaffold, tokens, then one component
-  per issue (ChatInput, CitationCard, AnswerCard, MessageList,
-  Loading/Error cards, RepoFilter), api.js, wiring, empty state.
-- **F. Polish & docs** — README quickstart, .env reconciliation,
-  ingestion CLI entry point.
+A stranger can run adr-engine without touching a config file. Form
+factor locked by [PRODUCT.md](PRODUCT.md): **local-first product** — no
+user accounts, no hosting; "login" is GitHub authorization via OAuth
+device flow. Full UX/visual spec: [docs/UI-DESIGN.md](docs/UI-DESIGN.md)
+(binding); API contracts: [docs/SYSTEM-DESIGN.md](docs/SYSTEM-DESIGN.md).
 
-## Phase 2 — Jira
-Ticket descriptions + comments as a new DecisionUnit `kind`, linked to
-commits/PRs via branch/PR references. Scoped when Phase 1 ships.
+Success: launch → first cited answer in minutes, zero file editing; the
+UI stops looking like a stock chat template (editorial/archival
+identity, WCAG 2.1 AA).
 
-## Phase 3 — Slack (opt-in per channel)
-Privacy-sensitive; needs its own scoping pass.
+Batches (dependency order, each = several one-PR-sized issues):
+
+- **G. Config store & GitHub auth (backend)** — UI-managed local config
+  store (`.env` demoted to dev override), `GET/PATCH /config`, GitHub
+  device-flow endpoints, `GET /setup/state`, `GET /github/repos`.
+  Absorbs #39/#40.
+- **H. Background ingestion** — `POST /ingest` → 202 + job state,
+  `GET /ingest/status` with per-repo phase and live counts; frontend
+  `useIngestStatus` hook + StatusPill in the shell.
+- **I. App shell & onboarding (frontend)** — react-router, shell with
+  top nav, onboarding flow: Connect (device code) → Choose repos →
+  Indexing, optional Gemini key step; setup gate.
+- **J. The reading room** — editorial identity: new tokens/fonts,
+  AnswerPassage + inline citation markers + SourceCards, degraded
+  sources-only mode (`/query` `mode` field, backend), signature motion.
+- **K. Library & Settings** — repo rows with live status, re-index /
+  remove, add-repos; settings sections (GitHub, Gemini, models, data).
+- **L. Hardening pass** — responsive/mobile fixes, a11y verification
+  (contrast, keyboard, reduced motion), state-coverage sweep.
+
+## Phase 3 — The living archive
+
+What makes the product returned-to, not just usable:
+
+- **Question history + follow-ups** — persisted threads; follow-up
+  questions carry prior citations into retrieval.
+- **Decision browser** — a browsable, filterable timeline of every
+  extracted decision per repo; adds file-path metadata at ingestion,
+  enabling path-scoped questions ("why is `backend/auth.py` like this?").
+- **Markdown export** — copy any answer with citations, ready for PR
+  descriptions and docs.
+- **Scheduled re-indexing** — interval-based auto-refresh keeping the
+  index alive; reuses the Phase 2 job/status machinery.
+
+## Phase 4 — The decision inbox
+
+The differentiator: after each index run, newly extracted decisions land
+in a review queue — confirm / edit / discard, with confirmed units
+boosted in retrieval. The system writes the ADRs; you approve them.
+Scoped when Phase 3 ships.
+
+## Later / parking lot
+
+- **Editor & CLI integration** (`adr why "..."`, VS Code) — meet the
+  question where it arises. Deliberately parked until the web product
+  proves the core loop.
+- **Phase J+ sources: Jira, then Slack (opt-in per channel)** — pushed
+  until GitHub is fully proven; same DecisionUnit model, new `kind`s.
 
 ## Evaluation
 
-No automated eval harness in Phase 1 (see SYSTEM-DESIGN.md). Quality is
-checked manually against [docs/eval-questions.md](docs/eval-questions.md),
-a running list of golden questions with their expected cited source —
-run each through `/query` after a retrieval or extraction change and
-watch for drift.
+No automated eval harness yet (see SYSTEM-DESIGN.md). Quality is checked
+manually against [docs/eval-questions.md](docs/eval-questions.md) — run
+each question through `/query` after a retrieval or extraction change
+and watch for drift.
 
-## Non-goals (for now)
-Hosted/multi-user deployment, auth, real-time ingestion, fine-tuning,
-TypeScript migration.
+## Non-goals (still)
+
+Hosted/multi-user deployment, user accounts, real-time ingestion,
+fine-tuning, TypeScript migration. GitHub *authorization* is in scope
+(Phase 2); *accounts* are not — adr-engine remains a single-user,
+local-first tool whose index never leaves the machine.

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,14 +1,18 @@
 """Application settings.
 
-The only place environment variables are read. Every other module
-imports `get_settings()` instead of touching `os.environ` directly.
+The only place environment variables are read directly. Every other
+module imports `get_settings()` instead of touching `os.environ` or
+`config_store` itself. Values not provided by env/`.env` fall back to
+the `config_store` (Phase 2) — env always wins when both are set.
 """
 
 from functools import lru_cache
 from typing import Annotated
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+import config_store
 
 
 class Settings(BaseSettings):
@@ -26,6 +30,18 @@ class Settings(BaseSettings):
     github_request_timeout_seconds: float = 10
     ollama_request_timeout_seconds: float = 60
     gemini_request_timeout_seconds: float = 30
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fill_from_config_store(cls, data: dict) -> dict:
+        if not isinstance(data, dict):
+            return data
+
+        stored = config_store.load()
+        for key, value in stored.items():
+            if value and key not in data:
+                data[key] = value
+        return data
 
     @field_validator("indexed_repos", mode="before")
     @classmethod

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
 
         stored = config_store.load()
         for key, value in stored.items():
-            if value and key not in data:
+            if value is not None and key not in data:
                 data[key] = value
         return data
 

--- a/backend/config_store.py
+++ b/backend/config_store.py
@@ -1,0 +1,54 @@
+"""Local JSON config store: `{CHROMA_DATA_DIR}/config.json`.
+
+Phase 2's source of truth for GitHub token, Gemini key, indexed repos,
+and model settings once the UI manages them via `GET/PATCH /config`
+(#52). `config.Settings` layers env-var overrides on top of this store
+(env wins when set) so existing `.env` setups keep working.
+
+Reads `CHROMA_DATA_DIR` directly from the environment rather than via
+`config.Settings`, matching `chroma_client.py`'s pattern — `config.py`
+itself reads this store, so going through `Settings` here would be
+circular.
+"""
+
+import json
+import os
+from pathlib import Path
+
+DEFAULT_CHROMA_DATA_DIR = "./chroma_data"
+
+DEFAULTS = {
+    "github_token": None,
+    "gemini_api_key": None,
+    "indexed_repos": [],
+    "ollama_host": "http://localhost:11434",
+    "ollama_extraction_model": None,
+    "ollama_embedding_model": None,
+    "gemini_model": "gemini-2.5-flash",
+}
+
+
+def _config_path() -> Path:
+    data_dir = os.getenv("CHROMA_DATA_DIR", DEFAULT_CHROMA_DATA_DIR)
+    return Path(data_dir) / "config.json"
+
+
+def load() -> dict:
+    path = _config_path()
+    if not path.exists():
+        return dict(DEFAULTS)
+
+    stored = json.loads(path.read_text())
+    return {**DEFAULTS, **stored}
+
+
+def save(partial: dict) -> dict:
+    """Merge `partial` into the stored config and persist the result."""
+    current = load()
+    current.update(partial)
+
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(current, indent=2))
+
+    return current

--- a/backend/config_store.py
+++ b/backend/config_store.py
@@ -27,6 +27,12 @@ DEFAULTS = {
     "gemini_model": "gemini-2.5-flash",
 }
 
+_SECRET_FIELDS = {"github_token", "gemini_api_key"}
+
+
+class ConfigValidationError(ValueError):
+    """Raised when a PATCH value fails store-level validation."""
+
 
 def _config_path() -> Path:
     data_dir = os.getenv("CHROMA_DATA_DIR", DEFAULT_CHROMA_DATA_DIR)
@@ -43,7 +49,11 @@ def load() -> dict:
 
 
 def save(partial: dict) -> dict:
-    """Merge `partial` into the stored config and persist the result."""
+    """Validate, merge `partial` into the stored config, and persist it."""
+    for key, value in partial.items():
+        if isinstance(value, str) and not value.strip():
+            raise ConfigValidationError(f"{key} must not be empty")
+
     current = load()
     current.update(partial)
 
@@ -52,3 +62,16 @@ def save(partial: dict) -> dict:
     path.write_text(json.dumps(current, indent=2))
 
     return current
+
+
+def _mask_value(value: str | None) -> str | None:
+    if not value:
+        return value
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:4]}…{value[-4:]}"
+
+
+def mask(raw: dict) -> dict:
+    """Return a copy of `raw` with secret fields masked for API responses."""
+    return {key: _mask_value(value) if key in _SECRET_FIELDS else value for key, value in raw.items()}

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -6,6 +6,7 @@ and fails clearly on rate-limit exhaustion rather than hanging a run.
 """
 
 import time
+import urllib.parse
 
 import httpx
 from pydantic import BaseModel
@@ -20,6 +21,10 @@ class GitHubError(Exception):
         self.status_code = status_code
         self.message = message
         super().__init__(f"GitHub API error {status_code}: {message}")
+
+
+class GitHubAuthError(GitHubError):
+    """Raised when GitHub rejects the stored token as invalid/expired."""
 
 
 class GitHubRateLimitError(GitHubError):
@@ -52,6 +57,12 @@ class PullRequestRef(BaseModel):
     author: str
     merged_at: str | None
     review_comments: list[str]
+
+
+class RepoSummary(BaseModel):
+    name: str
+    private: bool
+    commit_count_estimate: int
 
 
 class _RateLimiter:
@@ -110,6 +121,8 @@ def _get(url: str, rate_limiter: _RateLimiter, params: dict | None = None) -> ht
             message = response.json().get("message", response.text)
         except ValueError:
             message = response.text
+        if response.status_code == 401:
+            raise GitHubAuthError(response.status_code, message)
         raise GitHubError(response.status_code, message)
 
     return response
@@ -172,3 +185,44 @@ def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
         )
         for item in data
     ]
+
+
+def _estimate_commit_count(repo: str, rate_limiter: _RateLimiter) -> int:
+    # GitHub has no direct "commit count" field. The documented trick: ask
+    # for one commit per page and read the last page number off the Link
+    # header, avoiding a full commit fetch just to size a repo picker row.
+    try:
+        response = _get(
+            f"{GITHUB_API_URL}/repos/{repo}/commits",
+            rate_limiter,
+            params={"per_page": 1},
+        )
+    except GitHubError:
+        return 0
+
+    last_url = response.links.get("last", {}).get("url")
+    if last_url is None:
+        return len(response.json())
+
+    last_page = urllib.parse.parse_qs(urllib.parse.urlparse(last_url).query)["page"][0]
+    return int(last_page)
+
+
+def list_repos(query: str | None = None) -> list[RepoSummary]:
+    rate_limiter = _RateLimiter()
+    data = _paginate("/user/repos", rate_limiter, params={"per_page": 100})
+
+    repos = [
+        RepoSummary(
+            name=item["full_name"],
+            private=item["private"],
+            commit_count_estimate=_estimate_commit_count(item["full_name"], rate_limiter),
+        )
+        for item in data
+    ]
+
+    if query:
+        needle = query.lower()
+        repos = [repo for repo in repos if needle in repo.name.lower()]
+
+    return repos

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from chroma_client import get_chroma_client
+from routers.config import router as config_router
 from routers.github import router as github_router
 from routers.ingest import router as ingest_router
 from routers.query import router as query_router
@@ -28,6 +29,7 @@ app.include_router(retrieve_router)
 app.include_router(query_router)
 app.include_router(repos_router)
 app.include_router(github_router)
+app.include_router(config_router)
 
 
 @app.get("/health")

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from chroma_client import get_chroma_client
+from routers.github import router as github_router
 from routers.ingest import router as ingest_router
 from routers.query import router as query_router
 from routers.repos import router as repos_router
@@ -26,6 +27,7 @@ app.include_router(ingest_router)
 app.include_router(retrieve_router)
 app.include_router(query_router)
 app.include_router(repos_router)
+app.include_router(github_router)
 
 
 @app.get("/health")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 """FastAPI app entrypoint."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from chroma_client import get_chroma_client
 from routers.ingest import router as ingest_router
@@ -9,6 +10,18 @@ from routers.repos import router as repos_router
 from routers.retrieve import router as retrieve_router
 
 app = FastAPI(title="adr-engine")
+
+# Single-user, no-auth, local-only tool per SYSTEM-DESIGN.md — the frontend
+# and backend run on different localhost ports, which are different origins
+# to a browser. No credentials are ever sent, so a permissive origin policy
+# doesn't expose anything a same-origin policy would otherwise protect.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(ingest_router)
 app.include_router(retrieve_router)
 app.include_router(query_router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -83,3 +83,23 @@ class GitHubRepoInfo(BaseModel):
 
 class GitHubReposResponse(BaseModel):
     repos: list[GitHubRepoInfo]
+
+
+class ConfigResponse(BaseModel):
+    github_token: str | None = None
+    gemini_api_key: str | None = None
+    indexed_repos: list[str] = []
+    ollama_host: str
+    ollama_extraction_model: str | None = None
+    ollama_embedding_model: str | None = None
+    gemini_model: str
+
+
+class ConfigPatchRequest(BaseModel):
+    github_token: str | None = None
+    gemini_api_key: str | None = None
+    indexed_repos: list[str] | None = None
+    ollama_host: str | None = None
+    ollama_extraction_model: str | None = None
+    ollama_embedding_model: str | None = None
+    gemini_model: str | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from ingestion.github_client import RepoSummary
+
 
 class DecisionUnit(BaseModel):
     id: str
@@ -75,14 +77,8 @@ class ReposResponse(BaseModel):
     repos: list[RepoInfo]
 
 
-class GitHubRepoInfo(BaseModel):
-    name: str
-    private: bool
-    commit_count_estimate: int
-
-
 class GitHubReposResponse(BaseModel):
-    repos: list[GitHubRepoInfo]
+    repos: list[RepoSummary]
 
 
 class ConfigResponse(BaseModel):
@@ -95,11 +91,9 @@ class ConfigResponse(BaseModel):
     gemini_model: str
 
 
-class ConfigPatchRequest(BaseModel):
-    github_token: str | None = None
-    gemini_api_key: str | None = None
-    indexed_repos: list[str] | None = None
+class ConfigPatchRequest(ConfigResponse):
+    """Same shape as ConfigResponse, but every field is optional (a PATCH
+    only ever sends the fields being changed)."""
+
     ollama_host: str | None = None
-    ollama_extraction_model: str | None = None
-    ollama_embedding_model: str | None = None
     gemini_model: str | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -73,3 +73,13 @@ class RepoInfo(BaseModel):
 
 class ReposResponse(BaseModel):
     repos: list[RepoInfo]
+
+
+class GitHubRepoInfo(BaseModel):
+    name: str
+    private: bool
+    commit_count_estimate: int
+
+
+class GitHubReposResponse(BaseModel):
+    repos: list[GitHubRepoInfo]

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -2,8 +2,9 @@
 
 Talks to `config_store` directly rather than `config.Settings` — the
 whole point of this endpoint is to let the UI bootstrap configuration
-before any Settings-dependent (required-field) endpoint can run. Per
-ARCHITECTURE.md, secrets are masked in every response.
+before any Settings-dependent (required-field) endpoint can run.
+Masking and validation are `config_store`'s job; this router only
+parses the request, calls the store, and shapes the response.
 """
 
 from fastapi import APIRouter, HTTPException
@@ -13,35 +14,17 @@ from models import ConfigPatchRequest, ConfigResponse
 
 router = APIRouter()
 
-_SECRET_FIELDS = {"github_token", "gemini_api_key"}
-
-
-def _mask(value: str | None) -> str | None:
-    if not value:
-        return value
-    if len(value) <= 8:
-        return "…"
-    return f"{value[:4]}…{value[-4:]}"
-
-
-def _to_response(raw: dict) -> ConfigResponse:
-    masked = {
-        key: _mask(value) if key in _SECRET_FIELDS else value for key, value in raw.items()
-    }
-    return ConfigResponse(**masked)
-
 
 @router.get("/config", response_model=ConfigResponse)
 def get_config() -> ConfigResponse:
-    return _to_response(config_store.load())
+    return ConfigResponse(**config_store.mask(config_store.load()))
 
 
 @router.patch("/config", response_model=ConfigResponse)
 def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
-    partial = patch.model_dump(exclude_unset=True)
-    for key, value in partial.items():
-        if isinstance(value, str) and not value.strip():
-            raise HTTPException(status_code=422, detail=f"{key} must not be empty")
+    try:
+        updated = config_store.save(patch.model_dump(exclude_unset=True))
+    except config_store.ConfigValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    updated = config_store.save(partial)
-    return _to_response(updated)
+    return ConfigResponse(**config_store.mask(updated))

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -1,0 +1,47 @@
+"""GET/PATCH /config: HTTP surface over config_store (#51).
+
+Talks to `config_store` directly rather than `config.Settings` — the
+whole point of this endpoint is to let the UI bootstrap configuration
+before any Settings-dependent (required-field) endpoint can run. Per
+ARCHITECTURE.md, secrets are masked in every response.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+import config_store
+from models import ConfigPatchRequest, ConfigResponse
+
+router = APIRouter()
+
+_SECRET_FIELDS = {"github_token", "gemini_api_key"}
+
+
+def _mask(value: str | None) -> str | None:
+    if not value:
+        return value
+    if len(value) <= 8:
+        return "…"
+    return f"{value[:4]}…{value[-4:]}"
+
+
+def _to_response(raw: dict) -> ConfigResponse:
+    masked = {
+        key: _mask(value) if key in _SECRET_FIELDS else value for key, value in raw.items()
+    }
+    return ConfigResponse(**masked)
+
+
+@router.get("/config", response_model=ConfigResponse)
+def get_config() -> ConfigResponse:
+    return _to_response(config_store.load())
+
+
+@router.patch("/config", response_model=ConfigResponse)
+def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
+    partial = patch.model_dump(exclude_unset=True)
+    for key, value in partial.items():
+        if isinstance(value, str) and not value.strip():
+            raise HTTPException(status_code=422, detail=f"{key} must not be empty")
+
+    updated = config_store.save(partial)
+    return _to_response(updated)

--- a/backend/routers/github.py
+++ b/backend/routers/github.py
@@ -9,7 +9,7 @@ to routers specifically.
 from fastapi import APIRouter, HTTPException
 
 from ingestion.github_client import GitHubAuthError, GitHubError, list_repos
-from models import GitHubRepoInfo, GitHubReposResponse
+from models import GitHubReposResponse
 
 router = APIRouter()
 
@@ -23,13 +23,4 @@ def github_repos(query: str | None = None) -> GitHubReposResponse:
     except GitHubError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
-    return GitHubReposResponse(
-        repos=[
-            GitHubRepoInfo(
-                name=repo.name,
-                private=repo.private,
-                commit_count_estimate=repo.commit_count_estimate,
-            )
-            for repo in repos
-        ]
-    )
+    return GitHubReposResponse(repos=repos)

--- a/backend/routers/github.py
+++ b/backend/routers/github.py
@@ -1,0 +1,35 @@
+"""GET /github/repos: thin wiring from HTTP to github_client.list_repos.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. The only addition beyond that is the
+HTTP-status translation ARCHITECTURE.md's error-handling section assigns
+to routers specifically.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from ingestion.github_client import GitHubAuthError, GitHubError, list_repos
+from models import GitHubRepoInfo, GitHubReposResponse
+
+router = APIRouter()
+
+
+@router.get("/github/repos", response_model=GitHubReposResponse)
+def github_repos(query: str | None = None) -> GitHubReposResponse:
+    try:
+        repos = list_repos(query=query)
+    except GitHubAuthError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    except GitHubError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return GitHubReposResponse(
+        repos=[
+            GitHubRepoInfo(
+                name=repo.name,
+                private=repo.private,
+                commit_count_estimate=repo.commit_count_estimate,
+            )
+            for repo in repos
+        ]
+    )

--- a/backend/tests/fixtures/github_repo.json
+++ b/backend/tests/fixtures/github_repo.json
@@ -1,0 +1,14 @@
+{
+  "id": 1296269,
+  "name": "Hello-World",
+  "full_name": "octocat/Hello-World",
+  "private": false,
+  "owner": {
+    "login": "octocat",
+    "id": 1
+  },
+  "html_url": "https://github.com/octocat/Hello-World",
+  "description": "This your first repo!",
+  "fork": false,
+  "url": "https://api.github.com/repos/octocat/Hello-World"
+}

--- a/backend/tests/test_config_router.py
+++ b/backend/tests/test_config_router.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+
+def test_get_config_on_empty_store_returns_defaults():
+    response = client.get("/config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "github_token": None,
+        "gemini_api_key": None,
+        "indexed_repos": [],
+        "ollama_host": "http://localhost:11434",
+        "ollama_extraction_model": None,
+        "ollama_embedding_model": None,
+        "gemini_model": "gemini-2.5-flash",
+    }
+
+
+def test_patch_persists_and_is_reflected_in_a_subsequent_get():
+    patch_response = client.patch("/config", json={"indexed_repos": ["owner/repo"]})
+    assert patch_response.status_code == 200
+    assert patch_response.json()["indexed_repos"] == ["owner/repo"]
+
+    get_response = client.get("/config")
+    assert get_response.json()["indexed_repos"] == ["owner/repo"]
+
+
+def test_patch_only_updates_the_provided_fields():
+    client.patch("/config", json={"gemini_model": "gemini-2.5-pro"})
+    response = client.patch("/config", json={"indexed_repos": ["owner/repo"]})
+
+    assert response.json()["gemini_model"] == "gemini-2.5-pro"
+    assert response.json()["indexed_repos"] == ["owner/repo"]
+
+
+def test_secrets_are_masked_in_patch_and_get_responses():
+    token = "ghp_1234567890abcdef"
+
+    patch_response = client.patch("/config", json={"github_token": token})
+    get_response = client.get("/config")
+
+    for response in (patch_response, get_response):
+        body = response.json()
+        assert body["github_token"] == "ghp_…cdef"
+        assert token not in response.text
+
+
+def test_patch_rejects_an_empty_string_field():
+    response = client.patch("/config", json={"github_token": "   "})
+
+    assert response.status_code == 422
+
+
+def test_patch_can_clear_indexed_repos_without_touching_other_fields():
+    client.patch("/config", json={"gemini_api_key": "gk_1234567890abcdef"})
+
+    response = client.patch("/config", json={"indexed_repos": []})
+
+    assert response.status_code == 200
+    assert response.json()["gemini_api_key"] == "gk_1…cdef"
+    assert response.json()["indexed_repos"] == []

--- a/backend/tests/test_config_store.py
+++ b/backend/tests/test_config_store.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import config
+import config_store
+
+
+def test_load_on_missing_file_returns_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    assert config_store.load() == config_store.DEFAULTS
+
+
+def test_save_and_load_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.save({"github_token": "ghp_abc"})
+
+    assert config_store.load()["github_token"] == "ghp_abc"
+
+
+def test_save_merges_rather_than_replaces(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.save({"indexed_repos": ["owner/repo"]})
+    config_store.save({"ollama_host": "http://custom:11434"})
+
+    stored = config_store.load()
+    assert stored["indexed_repos"] == ["owner/repo"]
+    assert stored["ollama_host"] == "http://custom:11434"
+
+
+def test_save_returns_the_merged_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.save({"gemini_api_key": "gk_1"})
+    result = config_store.save({"gemini_model": "gemini-2.5-pro"})
+
+    assert result["gemini_api_key"] == "gk_1"
+    assert result["gemini_model"] == "gemini-2.5-pro"
+
+
+def test_env_var_overrides_a_stored_value_when_both_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    config_store.save({"github_token": "ghp_from_store"})
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_from_env")
+    config.get_settings.cache_clear()
+
+    settings = config.Settings()
+
+    assert settings.github_token == "ghp_from_env"
+    config.get_settings.cache_clear()
+
+
+def test_stored_value_used_when_env_var_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    config_store.save({"gemini_api_key": "gk_from_store"})
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    config.get_settings.cache_clear()
+
+    settings = config.Settings()
+
+    assert settings.gemini_api_key == "gk_from_store"
+    config.get_settings.cache_clear()

--- a/backend/tests/test_github_repos.py
+++ b/backend/tests/test_github_repos.py
@@ -1,0 +1,153 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from ingestion.github_client import GitHubAuthError, GitHubError, RepoSummary, list_repos
+from main import app
+
+client = TestClient(app)
+
+
+def _commits_response(*, last_page: int | None = None, count: int = 1) -> httpx.Response:
+    headers = {}
+    if last_page is not None:
+        headers["Link"] = (
+            f'<https://api.github.com/repositories/1/commits?per_page=1&page={last_page}>; '
+            f'rel="last"'
+        )
+    return httpx.Response(200, json=[{"sha": "x"}] * count, headers=headers)
+
+
+def test_list_repos_returns_typed_repo_summaries(load_fixture):
+    repo = load_fixture("github_repo.json")
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/commits"):
+            return _commits_response(last_page=42)
+        return httpx.Response(200, json=[repo])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        repos = list_repos()
+
+    assert repos == [
+        RepoSummary(name="octocat/Hello-World", private=False, commit_count_estimate=42)
+    ]
+
+
+def test_list_repos_follows_pagination_to_completion(load_fixture):
+    repo = load_fixture("github_repo.json")
+    base_url = "https://api.github.com/user/repos"
+    page2_url = f"{base_url}?page=2"
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/commits"):
+            return _commits_response(count=1)
+        if url == page2_url:
+            return httpx.Response(200, json=[repo])
+        return httpx.Response(
+            200, json=[repo], headers={"Link": f'<{page2_url}>; rel="next"'}
+        )
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get) as mock_get:
+        repos = list_repos()
+
+    assert len(repos) == 2
+    assert mock_get.call_args_list[0].args[0] == base_url
+
+
+def test_list_repos_filters_by_query_substring(load_fixture):
+    repo = load_fixture("github_repo.json")
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/commits"):
+            return _commits_response(count=1)
+        return httpx.Response(200, json=[repo])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        assert len(list_repos(query="hello")) == 1
+        assert list_repos(query="nonexistent") == []
+
+
+def test_list_repos_raises_github_auth_error_on_401():
+    with patch("ingestion.github_client.httpx.get") as mock_get:
+        mock_get.return_value = httpx.Response(401, json={"message": "Bad credentials"})
+
+        with pytest.raises(GitHubAuthError) as exc_info:
+            list_repos()
+
+    assert exc_info.value.status_code == 401
+
+
+def test_list_repos_commit_count_falls_back_to_page_length_with_no_last_link(load_fixture):
+    repo = load_fixture("github_repo.json")
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/commits"):
+            return _commits_response(count=1)
+        return httpx.Response(200, json=[repo])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        repos = list_repos()
+
+    assert repos[0].commit_count_estimate == 1
+
+
+def test_list_repos_commit_count_defaults_to_zero_on_empty_repo(load_fixture):
+    repo = load_fixture("github_repo.json")
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/commits"):
+            return httpx.Response(409, json={"message": "Git Repository is empty."})
+        return httpx.Response(200, json=[repo])
+
+    with patch("ingestion.github_client.httpx.get", side_effect=fake_get):
+        repos = list_repos()
+
+    assert repos[0].commit_count_estimate == 0
+
+
+def test_github_repos_router_returns_repo_list():
+    with patch("routers.github.list_repos") as mock_list_repos:
+        mock_list_repos.return_value = [
+            RepoSummary(name="octocat/Hello-World", private=False, commit_count_estimate=42)
+        ]
+
+        response = client.get("/github/repos")
+
+    assert response.status_code == 200
+    mock_list_repos.assert_called_once_with(query=None)
+    assert response.json() == {
+        "repos": [
+            {"name": "octocat/Hello-World", "private": False, "commit_count_estimate": 42}
+        ]
+    }
+
+
+def test_github_repos_router_passes_query_through():
+    with patch("routers.github.list_repos") as mock_list_repos:
+        mock_list_repos.return_value = []
+
+        client.get("/github/repos", params={"query": "hello"})
+
+    mock_list_repos.assert_called_once_with(query="hello")
+
+
+def test_github_repos_router_translates_auth_error_to_401():
+    with patch("routers.github.list_repos") as mock_list_repos:
+        mock_list_repos.side_effect = GitHubAuthError(401, "Bad credentials")
+
+        response = client.get("/github/repos")
+
+    assert response.status_code == 401
+    assert "Bad credentials" in response.json()["detail"]
+
+
+def test_github_repos_router_translates_other_github_error_to_502():
+    with patch("routers.github.list_repos") as mock_list_repos:
+        mock_list_repos.side_effect = GitHubError(500, "server error")
+
+        response = client.get("/github/repos")
+
+    assert response.status_code == 502

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,8 +11,13 @@ shapes.
 backend/
   main.py               # FastAPI app assembly + /health only
   config.py             # pydantic-settings Settings; ALL env reads live here
+  config_store.py       # Phase 2: local JSON config store; env overrides win
   chroma_client.py      # PersistentClient factory (cached)
   models.py             # DecisionUnit + API request/response models (pydantic)
+  auth/
+    device_flow.py      # Phase 2: GitHub OAuth device flow (start/poll/persist)
+  jobs/
+    ingest_job.py       # Phase 2: background ingestion task + in-process job state
   ingestion/
     github_client.py    # GitHub REST → typed models; pagination; rate-limit aware
     extract.py          # commit/PR text → DecisionUnit | NotADecision (Ollama)
@@ -23,18 +28,28 @@ backend/
     search.py           # query embedding + top-k + relevance floor
   synthesis/
     answer.py           # retrieved units → Gemini prompt → parsed answer+citations
-  routers/
-    ingest.py           # POST /ingest  (thin: parse, call ingestion.run, shape response)
-    retrieve.py         # POST /retrieve (thin: parse, call retrieval.search)
-    query.py            # POST /query   (thin: retrieval + synthesis)
+  routers/              # ALL thin: parse, call one service, shape response
+    ingest.py           # POST /ingest (202) + GET /ingest/status
+    retrieve.py         # POST /retrieve
+    query.py            # POST /query
+    auth.py             # Phase 2: /auth/github/* device flow
+    config.py           # Phase 2: GET/PATCH /config
+    setup.py            # Phase 2: GET /setup/state
   tests/
     fixtures/           # canned GitHub API payloads, canned Ollama/Gemini outputs
     ...
 frontend/
   src/
     api.js              # single fetch wrapper for all backend calls
-    components/         # presentational components (see UI-DESIGN.md)
-    App.jsx
+    shell/              # AppShell, TopNav, StatusPill (Phase 2)
+    onboarding/         # device-flow connect, repo picker, index step (Phase 2)
+    ask/                # the reading room: AnswerPassage, SourceCard, SourcesView…
+    library/            # repo rows, IndexProgress (Phase 2)
+    settings/           # per-section settings components (Phase 2)
+    lib/
+      useIngestStatus.js  # THE single ingest-status poll hook (context-shared)
+    components/         # remaining shared presentational pieces
+    App.jsx             # router + shell + setup gate only (Phase 2)
 docs/                   # this file + SYSTEM-DESIGN.md + UI-DESIGN.md + eval-questions.md
 ```
 
@@ -42,13 +57,16 @@ docs/                   # this file + SYSTEM-DESIGN.md + UI-DESIGN.md + eval-que
 
 - `routers/*` are thin: parse request → call one service function →
   shape response. No business logic in routers.
-- `ingestion/`, `retrieval/`, `synthesis/` may import `models`, `config`,
-  `chroma_client` — never `routers` and never each other, with one
-  exception: `synthesis` may call `retrieval`.
+- `ingestion/`, `retrieval/`, `synthesis/`, `auth/`, `jobs/` may import
+  `models`, `config`, `config_store`, `chroma_client` — never `routers`
+  and never each other, with two exceptions: `synthesis` may call
+  `retrieval`, and `jobs` may call `ingestion` (it orchestrates it).
 - `github_client` returns typed models only; GitHub's raw JSON schema
-  must not leak past that module.
-- All environment access goes through `config.Settings`. No `os.getenv`
-  scattered in modules.
+  must not leak past that module. Same rule for `auth/device_flow`.
+- All configuration reads go through `config.Settings`, which resolves
+  env overrides on top of `config_store` (Phase 2). No `os.getenv` and
+  no direct store reads scattered in modules. Secrets are masked in
+  every API response.
 - LLM calls are isolated in exactly three places: `extract.py` (local),
   `embed.py` (local), `answer.py` (cloud). Nothing else talks to a model.
 
@@ -80,5 +98,12 @@ docs/                   # this file + SYSTEM-DESIGN.md + UI-DESIGN.md + eval-que
 
 - Plain React + Tailwind, JavaScript (no TypeScript — matches BuFin).
 - All backend calls go through `src/api.js`; components never `fetch`.
-- Components are presentational; state lives in `App.jsx` (single page,
-  no router, no global state library in Phase 1).
+- Routing via `react-router-dom` (Phase 2 supersedes Phase 1's "no
+  router" rule): `/` Ask, `/library`, `/settings`, `/onboarding`, with
+  the setup gate in `App.jsx`. Still no global state library — page
+  state lives in each page component; the one cross-page piece of state
+  (ingest status) lives in the `useIngestStatus` context hook, and
+  there is never more than one active status poller.
+- Components are presentational; fonts are bundled via `@fontsource`
+  (no CDN — local-first). Visual system, tokens, and per-surface specs:
+  [UI-DESIGN.md](UI-DESIGN.md) (binding).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,6 +67,11 @@ docs/                   # this file + SYSTEM-DESIGN.md + UI-DESIGN.md + eval-que
   env overrides on top of `config_store` (Phase 2). No `os.getenv` and
   no direct store reads scattered in modules. Secrets are masked in
   every API response.
+- Exception: `config_store.py` and `chroma_client.py` read
+  `CHROMA_DATA_DIR` via `os.getenv` directly, not through
+  `config.Settings` — `Settings` itself reads `config_store`, so routing
+  the store's own bootstrap path through `Settings` would be circular.
+  This is the only sanctioned `os.getenv` outside `config.py`.
 - LLM calls are isolated in exactly three places: `extract.py` (local),
   `embed.py` (local), `answer.py` (cloud). Nothing else talks to a model.
 

--- a/docs/SYSTEM-DESIGN.md
+++ b/docs/SYSTEM-DESIGN.md
@@ -12,7 +12,11 @@
 - React chat UI with clickable citation cards.
 
 **Non-functional**
-- Single user, self-hosted, no auth in Phase 1.
+- Single user, self-hosted. No user accounts ever (see PRODUCT.md's
+  form factor); GitHub access is authorized via OAuth device flow in
+  Phase 2, with the token stored locally.
+- Phase 2 onboarding bar: launch → first cited answer in minutes,
+  without editing a config file.
 - Privacy: indexed content (commit bodies, diffs, PR text) never leaves
   the machine at index time. Only retrieved top-k snippets go to a cloud
   model, and only at query time.
@@ -90,10 +94,18 @@ run. Losing it is safe (re-ingestion is idempotent), it only costs time.
 | Endpoint | In | Out |
 |---|---|---|
 | `GET /health` | — | `{status, chroma: "ok"\|"unreachable"}` |
-| `GET /repos` | — | `{repos: [{repo: str, indexed_units: int}]}` — the configured repos, for the UI filter |
-| `POST /ingest` | `{repo?: str}` (default: all configured) | `{repos: [{repo, fetched, extracted, skipped, stored}]}` — synchronous in Phase 1 |
+| `GET /setup/state` | — | `{github_connected, repos_selected, first_index_done, gemini_key_set}` — drives the onboarding gate |
+| `POST /auth/github/device/start` | — | `{user_code, verification_uri, expires_in, interval}` |
+| `GET /auth/github/status` | — | `{state: "pending"\|"authorized"\|"expired"\|"denied", login?}` |
+| `DELETE /auth/github` | — | disconnects; token removed from the config store |
+| `GET /github/repos` | `?query=` | repos visible to the token (name, private, commit-count estimate) — for the picker |
+| `GET /config` | — | current config, secrets masked (`ghp_…4f2a`) |
+| `PATCH /config` | partial config (gemini key, models, indexed repos…) | updated masked config; key/model changes validated live |
+| `GET /repos` | — | `{repos: [{repo: str, indexed_units: int}]}` — indexed counts, for the UI filter |
+| `POST /ingest` | `{repos?: [str]}` (default: all configured) | **202** `{job_id}` — ingestion runs as a background task (Phase 2; was synchronous in Phase 1) |
+| `GET /ingest/status` | — | `{active: bool, repos: [{repo, phase: "queued"\|"fetching"\|"extracting"\|"embedding"\|"done"\|"failed", counts: {fetched, extracted, skipped, stored}, error?}]}` |
 | `POST /retrieve` | `{query: str, k?: int=5, repos?: [str]}` | `{results: [{unit: DecisionUnit, score: float}]}` |
-| `POST /query` | `{question: str, repos?: [str]}` | `{answer: str, citations: [DecisionUnit], retrieved_count: int}` |
+| `POST /query` | `{question: str, repos?: [str]}` | `{answer: str\|null, citations: [DecisionUnit], retrieved_count: int, mode: "synthesized"\|"sources_only"}` |
 
 `repos` filters retrieval to the named repos via a Chroma metadata filter;
 omitted or empty means all indexed repos.
@@ -101,7 +113,33 @@ omitted or empty means all indexed repos.
 `/query` calls the same retrieval logic as `/retrieve`, then synthesizes.
 If nothing clears the relevance threshold, it returns an explicit
 "no relevant decisions found" answer with empty citations — it must never
-fabricate.
+fabricate. When no Gemini key is configured, it skips synthesis and
+returns `mode: "sources_only"` with `answer: null` — the UI renders the
+retrieved units directly (degraded mode is a product state, not an
+error).
+
+## Configuration, auth, and jobs (Phase 2)
+
+**Config store.** A local JSON file at `{CHROMA_DATA_DIR}/config.json`
+becomes the source of truth for GitHub token, Gemini key, indexed repos,
+and model settings, managed via `GET/PATCH /config`. Environment
+variables remain as dev-time overrides (env wins when set), so existing
+`.env` setups keep working. Secrets are masked in every API response and
+never leave the machine.
+
+**GitHub auth.** OAuth device flow: the backend proxies GitHub's device
+endpoints (client ID ships in code; device flow needs no secret), polls
+for the grant at GitHub's stated interval, and persists the resulting
+token in the config store. No user accounts — this is authorization,
+not identity.
+
+**Ingestion jobs.** One in-process background task (FastAPI
+`BackgroundTasks`-level machinery; no queue infrastructure for a
+single-user app) with a module-level job state the status endpoint
+reads. Per-repo phase transitions and counts update as the pipeline
+runs; failure captures the boundary error message per repo without
+killing the other repos' progress. The cursor rules from Phase 1 are
+unchanged: written only after a repo completes successfully.
 
 ## Deep-dive decisions
 
@@ -159,9 +197,11 @@ visible.
 
 - **Chroma over pgvector/Qdrant:** zero infra, file-based, fine for
   ≤100k units. Revisit if multi-repo indexing grows past that.
-- **Synchronous `/ingest` over a job queue:** simplest thing that works
-  for a single user; a long ingestion blocks one HTTP call. Revisit with
-  background tasks (FastAPI `BackgroundTasks`) if repos are large.
+- **In-process background ingestion over a real job queue:** Phase 2
+  moves `/ingest` off the blocking call (the Phase 1 trade-off, now
+  paid down) but deliberately stops at one background task + polled
+  status — Celery/RQ-grade infrastructure buys nothing for a
+  single-user local app.
 - **Local extraction quality < cloud quality:** accepted for privacy.
   Mitigated by the golden-questions eval and by keeping `source_excerpt`
   so weak extractions can be re-run later with a better local model.
@@ -170,9 +210,11 @@ visible.
 
 ## What we'd revisit as it grows
 
-- Background/queued ingestion with progress reporting.
 - Hybrid keyword+vector retrieval (BM25 + embeddings) if pure vector
   retrieval misses exact identifiers ("Redis", "JWT").
-- Jira (Phase 2) and Slack (Phase 3) sources — same DecisionUnit model,
-  new `kind` values.
-- Multi-user/auth if this ever becomes a team tool.
+- File-path metadata on DecisionUnits (Phase 3's decision browser)
+  enabling path-scoped retrieval.
+- Jira and Slack sources — parked until GitHub is fully proven (see
+  ROADMAP.md); same DecisionUnit model, new `kind` values.
+- Multi-user/accounts if this ever becomes a team tool (explicitly not
+  planned).

--- a/docs/UI-DESIGN.md
+++ b/docs/UI-DESIGN.md
@@ -1,119 +1,304 @@
-# UI Design — adr-engine (Phase 1)
+# UI Design — adr-engine (Phase 2: productization)
 
-Single-page chat interface: ask a question about the indexed repos'
-decision history, get a cited answer. No auth, no routing, no history
-persistence in Phase 1. Built with React + Tailwind 4.
+Engineering handoff spec for the Phase 2 redesign. Binding for the daily
+agent, per ARCHITECTURE.md. Supersedes the Phase 1 single-page spec.
+Strategic context: [../PRODUCT.md](../PRODUCT.md). Scope and phasing:
+[../ROADMAP.md](../ROADMAP.md).
+
+The product becomes four surfaces in an app shell — **Onboarding** (gates
+first run), **Ask** (the reading room, primary), **Library** (repos &
+indexing), **Settings** — with an editorial/archival identity: quiet
+chrome, a serif reading surface, citations treated as first-class
+typography. Anchors: Readwise Reader's reading calm, Are.na's archival
+restraint, Linear's interaction crispness. Anti-references: terminal-dark
+dev-tool clichés, stock chat-template look, SaaS dashboard grammar.
 
 ## Design tokens
 
-Defined once as Tailwind theme values in `frontend/src/index.css`
-(`@theme`). Components use these tokens only — no hardcoded hex values or
-arbitrary spacing in component files.
+Defined in `frontend/src/index.css` (`@theme` + dark override at `:root`
+under `@media (prefers-color-scheme: dark)` — the existing mechanism is
+unchanged; components never use `dark:` classes). All colors OKLCH.
+Values below are the committed starting points; **every issue that
+applies them must verify ≥4.5:1 body / ≥3:1 large-text contrast** (AA)
+and may nudge L to pass, keeping hue/chroma.
 
-| Token | Value | Use |
+| Token | Light | Dark | Use |
+|---|---|---|---|
+| `--color-surface` | `oklch(0.985 0.004 70)` | `oklch(0.185 0.008 70)` | page background |
+| `--color-panel` | `oklch(1 0 0)` | `oklch(0.23 0.01 70)` | cards, bars, inputs |
+| `--color-ink` | `oklch(0.24 0.01 70)` | `oklch(0.93 0.005 70)` | primary text |
+| `--color-ink-muted` | `oklch(0.47 0.015 70)` | `oklch(0.70 0.015 70)` | metadata, secondary |
+| `--color-accent` | `oklch(0.52 0.11 60)` | `oklch(0.75 0.10 65)` | actions, selection, focus, citation markers |
+| `--color-accent-ink` | `oklch(0.99 0.005 70)` | `oklch(0.17 0.02 65)` | text on accent fills |
+| `--color-highlight` | accent at 12% alpha | accent at 16% alpha | linked-source hover wash, marks |
+| `--color-danger` | `oklch(0.50 0.19 27)` | `oklch(0.70 0.17 25)` | errors only |
+
+The bronze accent replaces stock indigo everywhere. `--color-highlight`
+is derived (`color-mix(in oklch, var(--color-accent) 12%, transparent)`),
+not hand-picked per theme.
+
+### Typography
+
+| Token | Stack | Use |
 |---|---|---|
-| `--color-surface` | zinc-50 / zinc-900 (dark) | page background |
-| `--color-panel` | white / zinc-800 (dark) | cards, input bar |
-| `--color-ink` | zinc-900 / zinc-100 (dark) | primary text |
-| `--color-ink-muted` | zinc-500 / zinc-400 (dark) | metadata, timestamps |
-| `--color-accent` | indigo-600 / indigo-400 (dark) | links, send button, focus rings |
-| `--color-danger` | red-600 / red-400 (dark) | error states |
-| Radius | `rounded-xl` cards, `rounded-lg` buttons/inputs | |
-| Spacing | Tailwind scale only; card padding `p-4`, section gaps `gap-4` | |
-| Type scale | `text-sm` metadata, `text-base` body, `text-lg` semibold headings | |
+| `--font-reading` | `"Source Serif 4", Georgia, serif` (bundled via `@fontsource-variable/source-serif-4`; no CDN — local-first) | answer prose, onboarding display lines, empty-state prompts |
+| `--font-ui` | `system-ui, -apple-system, "Segoe UI", sans-serif` | all chrome: nav, buttons, forms, labels, cards |
+| `--font-mono` | `ui-monospace, "SF Mono", Menlo, monospace` | SHAs, `owner/repo` names, device codes — only where content is code-like |
 
-Dark mode: the tokens above are CSS custom properties, redefined at
-`:root` under a single `@media (prefers-color-scheme: dark)` block in
-`index.css` (not per-component Tailwind `dark:` classes). Every
-component that uses a token (`bg-surface`, `text-ink`, etc.) re-themes
-automatically — no `dark:` class is ever needed in component markup.
-Both themes must still be verified in the same commit as any new
-component; there's just one place the values live, not one class per
-component.
+Fixed rem scale (no fluid type): `text-sm` 0.875 / `text-base` 1 /
+`text-lg` 1.125 semibold (section heads) / `text-2xl` 1.5 (onboarding
+display, `--font-reading`). Reading prose: `--font-reading` at
+1.0625rem, line-height 1.7, `max-width: 70ch`. Chrome stays `--font-ui`;
+never display type in buttons/labels.
 
-## Layout
+### Spacing, radius, elevation
 
-```
-┌──────────────────────────────────────────┐
-│ Header: wordmark ······ RepoFilter ▾     │  h-14, panel bg
-├──────────────────────────────────────────┤
-│                                          │
-│  MessageList (scrolls, max-w-3xl,        │
-│   centered)                              │
-│    ┌─ user question (right-aligned) ─┐   │
-│    └─ AnswerCard (left-aligned)      │   │
-│         └─ CitationCard row          │   │
-│                                          │
-├──────────────────────────────────────────┤
-│ ChatInput (sticky bottom, panel bg)      │
-└──────────────────────────────────────────┘
-```
+Tailwind scale only. Cards `rounded-xl`, controls `rounded-lg`. Card
+padding `p-4`; section gaps `gap-4`; page gutters `px-4` (mobile) /
+`px-6` (≥640px). One shadow level for floating elements (dropdown,
+toast): `shadow-md`; flat panels otherwise. Z-scale (semantic, no
+arbitrary values): `--z-dropdown: 10`, `--z-sticky: 20`, `--z-toast: 30`.
 
-Empty state (no messages yet): centered prompt — "Ask why something in
-your codebase is the way it is" — plus 3 example-question chips that
-fill the input when clicked.
+### Motion
 
-## Components
-
-### ChatInput
-| | |
+| Token | Value |
 |---|---|
-| Props | `onSubmit(question)`, `disabled` |
-| States | default; focused (accent ring); disabled while a query is in flight; empty submit is a no-op |
-| Keyboard | Enter submits, Shift+Enter newline |
-| A11y | `<form>` with labeled textarea; submit button `aria-label="Ask"` |
+| `--ease-out` | `cubic-bezier(0.22, 1, 0.36, 1)` |
+| `--dur-state` | `150ms` (hover, focus, toggles) |
+| `--dur-surface` | `220ms` (panels, route transitions, cards entering) |
 
-### MessageList
-| | |
+Motion conveys state only — no page-load choreography. **One** signature
+moment (Ask § below). Every animation ships its
+`@media (prefers-reduced-motion: reduce)` alternative: crossfade ≤150ms
+or instant.
+
+## App shell
+
+New files: `frontend/src/shell/AppShell.jsx`, `TopNav.jsx`,
+`StatusPill.jsx`. Routing via `react-router-dom` (new dependency —
+ARCHITECTURE.md's "no router" rule is superseded in Phase 2): `/`
+(Ask), `/library`, `/settings`, `/onboarding`. `GET /setup/state`
+decides the gate: incomplete setup redirects everything to
+`/onboarding`; complete setup redirects `/onboarding` away.
+
+Layout: slim top bar, `h-14`, `bg-panel`, full-width; content area
+`max-w-5xl mx-auto`. Left: wordmark (`--font-reading`, 1.125rem,
+semibold — the one serif element in chrome, as brand signature). Center:
+nothing. Right: nav links Ask · Library · Settings (`--font-ui` text-sm;
+active = `--color-accent` text + 2px underline offset 6px; inactive =
+`--color-ink-muted`, hover → `--color-ink`) and StatusPill.
+
+**StatusPill** — visible only while `GET /ingest/status` reports an
+active job. `rounded-lg bg-highlight text-accent text-sm px-3 py-1`,
+content: pulsing 6px dot + `Indexing owner/repo…` (repo currently in
+progress; if >1 queued: `Indexing 2 repos…`). Click → `/library`. On
+job completion: pill swaps to `✓ Indexed` for 4s, then fades out
+(`--dur-surface`); on failure: danger dot + `Indexing failed`, persists
+until visited. A11y: `role="status"`, `aria-live="polite"`.
+
+Responsive: <640px nav collapses to icons with `aria-label`s
+(Ask=quill, Library=archive-box, Settings=gear; inline SVG, 20px,
+`stroke-current`), StatusPill collapses to its dot. No hamburger.
+
+## Onboarding (`/onboarding`)
+
+Full-screen flow, no app shell. Three steps + optional key step; state
+machine driven by `GET /setup/state`, resumable (refresh returns to the
+furthest incomplete step). Progress: three quiet dots top-center
+(`--color-ink-muted`; current = `--color-accent`), not a numbered
+stepper. Files: `frontend/src/onboarding/OnboardingPage.jsx`,
+`ConnectStep.jsx`, `DeviceCodeCard.jsx`, `RepoPickerStep.jsx`,
+`RepoPickerRow.jsx`, `IndexStep.jsx`, `GeminiKeyStep.jsx`.
+
+### Step 1 — Welcome + Connect (the one Committed-color surface)
+
+Full-bleed `--color-accent` background, `--color-accent-ink` text.
+Wordmark large in `--font-reading` (text-2xl), one line of purpose copy
+("Ask your codebase why. Answers cited to the commit where it was
+decided — your code never leaves this machine."), one button: **Connect
+GitHub** (`bg-panel text-ink` — inverted on the accent surface).
+
+Click → `POST /auth/github/device/start` → **DeviceCodeCard**: the
+`user_code` in `--font-mono` text-2xl, letter-spaced, with a Copy
+button (`aria-label="Copy code"`; on copy: label → "Copied" 2s); link
+"Open github.com/login/device" (opens new tab, the only external link);
+caption "Waiting for approval…" with pulsing dot while the app polls
+`GET /auth/github/status` at the server-provided interval.
+
+| State | Behavior |
 |---|---|
-| Props | `messages: [{role: "user"\|"assistant", ...}]` |
-| Behavior | auto-scrolls to newest; renders QuestionBubble, AnswerCard, LoadingCard, ErrorCard by message type |
+| pending | card as described, poll continues |
+| authorized | card swaps to `✓ Connected as {login}` (300ms crossfade), auto-advance to Step 2 after 800ms |
+| expired | code area greys, caption "Code expired." + **Get a new code** button (restarts flow) |
+| denied | caption in `--color-danger`: "Authorization was denied." + retry button |
+| network error | ErrorCard pattern inline, retry re-calls start |
 
-### AnswerCard
-| | |
+### Step 2 — Choose repos
+
+Panel card, `max-w-xl` centered, on plain `--color-surface` (Committed
+moment is over). Heading (`--font-reading` text-lg): "Which repos should
+adr-engine read?" Search input filters `GET /github/repos?query=`
+(debounced 300ms). List: **RepoPickerRow** = checkbox + `owner/name`
+(`--font-mono` text-sm) + private-lock icon when private + right-aligned
+size hint (`--color-ink-muted` text-sm: "~1.2k commits · est. 8 min" —
+from the API's commit-count estimate; omit when unknown). Privacy line
+pinned under the heading (`text-sm text-ink-muted`): "Extraction runs on
+your local Ollama — repo contents never leave this machine."
+
+States: loading = 5 skeleton rows (`animate-pulse bg-highlight`
+rounded-lg h-9); empty search = "No repos match."; API error = inline
+ErrorCard + retry; org-restricted = footnote linking GitHub's org-access
+settings page. Continue button disabled until ≥1 selected; label
+"Index N repo(s)". Click → `POST /ingest {repos}` → Step 3.
+
+### Step 3 — Indexing
+
+Reuses **IndexProgress** (Library § below) as its body — same component,
+same poll. Heading: "Reading your history." Sub-line rotates honest
+per-phase copy from status (§ Library). The moment the **first repo
+completes**, a **Start asking** button appears (accent fill) — indexing
+continues in background; remaining repos keep progressing (StatusPill
+takes over after leaving). "Some failed" shows per-repo retry but never
+blocks Start asking if ≥1 repo succeeded.
+
+### Optional — Gemini key (inline card below Step 3 progress)
+
+Quiet panel: "Add a Gemini key to get synthesized answers (optional)" +
+masked input + Save + **Skip for now** link. Copy under input: "Only the
+retrieved snippets you ask about are ever sent to Gemini." Save →
+`PATCH /config` with live validation (§ Settings states). Skipping sets
+nothing; Ask runs in sources-only mode.
+
+## Ask (`/`) — the reading room
+
+The Phase 1 chat becomes an editorial surface. Files: existing
+components move to `frontend/src/ask/` (`AskPage.jsx` owns state —
+extracted from `App.jsx`, which shrinks to shell+router):
+`AnswerPassage.jsx` (replaces `AnswerCard`), `CitationMarker.jsx`,
+`SourceCard.jsx` (evolved `CitationCard`), `SourcesView.jsx` (degraded
+mode), restyled `ChatInput` / `MessageList` / `LoadingCard` /
+`ErrorCard` in place.
+
+Layout unchanged in skeleton (scrolling thread, `max-w-3xl` centered,
+sticky bottom input on `bg-panel`) — the redesign is in the pieces:
+
+- **User question**: compact bubble, right-aligned, `bg-highlight
+  text-ink` (no more solid accent slab), `rounded-xl p-3`, text-sm.
+- **AnswerPassage**: no card chrome — prose set directly on surface.
+  `--font-reading`, 1.0625rem/1.7, `max-width: 70ch`. Inline
+  **CitationMarker**s: superscript `¹ ²` in `--color-accent`,
+  `--font-ui` text-xs, `cursor-pointer`, rendered from `[unit-id]`
+  citations in the answer text (parse order of first appearance → 1..n).
+  Hover/focus on a marker → linked SourceCard gets `--color-highlight`
+  wash (`--dur-state`); click → card scrolls into view + 1.2s wash.
+- **Sources row**: beneath the passage, label "Sources" (`text-sm
+  text-ink-muted`), horizontal wrap of **SourceCard**s: `w-64 bg-panel
+  rounded-xl p-4 border border-transparent transition-colors
+  hover:border-accent`, containing marker number + kind badge
+  (`PR #42` / `commit a1b2c3d` in `--font-mono` text-xs on
+  `bg-highlight` rounded), title (2-line clamp, `--font-ui`), author ·
+  relative date · repo (`text-sm text-ink-muted`). Whole card one `<a>`
+  to `unit.url` (unchanged a11y name format).
+- **SourcesView** (degraded, `mode: "sources_only"` from `/query`):
+  passage slot instead shows serif lead-in "N decisions found —" then a
+  vertical list of SourceCards **expanded**: extracted `decision` text
+  as card body (serif, 3-line clamp) with `rationale` below it muted.
+  Quiet banner above thread (dismissible per session): "Add a Gemini
+  key in Settings to get synthesized answers." — `bg-highlight`, not
+  danger.
+- **LoadingCard**: keeps three-dot pulse; status line now reports the
+  real stage when a first-token wait is long ("Searching decision
+  history…" → "Reading 5 sources…"). Same `role="status"`.
+- **Empty state**: serif prompt line + 3 example chips **generated from
+  indexed repos** (template: "Why does {repo-short} use {topic}?" is
+  Phase 3 polish — Phase 2 keeps 3 static-but-relevant questions built
+  from indexed repo names); chips `bg-panel hover:border-accent`.
+- **ErrorCard**: unchanged behavior (message + Retry, `disabled` while
+  in flight); restyled: `bg-panel`, 1px `--color-danger` full border,
+  danger text, plain-text detail from the server.
+
+**Signature moment** (the one): on answer arrival, passage fades up 8px
+(`--dur-surface`, `--ease-out`), then markers "ink in" — opacity 0→1
+staggered 60ms each starting 180ms after passage settle; SourceCards
+follow as one group (+90ms). Reduced-motion: single crossfade, no
+stagger, no translate.
+
+Repo filter chip (existing RepoFilter) stays on this page, right of the
+thread header — not in global chrome.
+
+## Library (`/library`)
+
+Files: `frontend/src/library/LibraryPage.jsx`, `RepoRow.jsx`,
+`IndexProgress.jsx`, shared hook `frontend/src/lib/useIngestStatus.js`
+(single poll loop: 2s while a job is active, stopped otherwise —
+StatusPill, Library, and Onboarding Step 3 all consume this one hook via
+context; never two concurrent pollers).
+
+Page: heading "Library" (`--font-reading` text-lg) + **Add repos**
+button (opens the RepoPicker in a panel — reuses `RepoPickerStep`
+internals). One **RepoRow** per configured repo: `bg-panel rounded-xl
+p-4`, grid: `owner/name` (`--font-mono`) + status line + right-aligned
+actions (Re-index, Remove — text buttons, `text-sm`).
+
+| Row state | Status line (all `text-sm text-ink-muted`) |
 |---|---|
-| Props | `answer: string`, `citations: DecisionUnit[]` |
-| States | default; **no-answer** variant when citations are empty ("Nothing in the indexed history covers this") styled muted, not as an error |
-| Layout | answer text, then a horizontal wrap of CitationCards |
+| idle, indexed | "312 decisions · indexed 2 days ago" |
+| queued | "Queued…" |
+| fetching | "Reading commits — 214 examined" (live counts) |
+| extracting | "Extracting decisions — 37 recorded of 214" + thin progress bar (`h-1 rounded bg-highlight`, fill `bg-accent`, width = extracted/fetched) |
+| embedding | "Embedding 37 decisions…" |
+| failed | danger text: exact server error + **Retry** |
+| stale (>30 days) | idle line + " · consider re-indexing" |
 
-### CitationCard
-| | |
+Empty state (no repos): serif prompt "Nothing in the library yet." +
+Add repos button. Remove asks inline confirmation (row swaps to
+"Remove owner/repo and its N indexed decisions? **Remove** / Cancel" —
+no modal), then `PATCH /config` + index cleanup.
+
+## Settings (`/settings`)
+
+Files: `frontend/src/settings/SettingsPage.jsx` + one component per
+section (`GitHubSection.jsx`, `GeminiSection.jsx`, `ModelsSection.jsx`,
+`DataSection.jsx`). Single column `max-w-xl`, each section a `bg-panel
+rounded-xl p-4` group with `text-lg` head. All reads from `GET /config`
+(secrets masked server-side: `ghp_…4f2a`), writes via `PATCH /config`
+with per-field save + inline result (no global Save).
+
+| Section | Contents | States |
+|---|---|---|
+| GitHub | connected account (`login`, avatar 20px), scopes note, **Reconnect** (restarts device flow inline), **Disconnect** (inline confirm; warns indexing stops working) | token revoked/expired: section shows danger banner "GitHub connection expired" + Reconnect (this state also triggers a global quiet banner on Ask) |
+| Gemini key | masked input, Save; explainer line ("Only retrieved snippets are sent — never your code.") | on save: validate with a 1-token ping; invalid → danger inline "Key rejected by Gemini"; valid → "✓ Synthesized answers on"; removing key → confirm, app returns to sources-only |
+| Models | Ollama host, extraction model, embedding model (text inputs, `--font-mono`); "Advanced" summary/details collapse | save pings Ollama `/api/tags`; model missing → warning with `ollama pull` command shown in mono |
+| Data | index location (read-only path, mono), decision count, **Clear index** (danger text button, inline confirm "Clear N indexed decisions? This cannot be undone.") | — |
+
+## Responsive behavior
+
+| Breakpoint | Changes |
 |---|---|
-| Props | `unit: DecisionUnit` |
-| Content | kind badge (`PR #42` / `commit a1b2c3d`), title (truncated 2 lines), author, date (relative), repo name |
-| States | default; hover (border → accent, cursor pointer) |
-| Behavior | opens `unit.url` on GitHub in a new tab |
-| A11y | whole card is one `<a>`; announced as "Citation: {title}, {kind} in {repo}" |
+| ≥1024px | shell `max-w-5xl`; Ask thread `max-w-3xl`; Settings/pickers `max-w-xl` |
+| 640–1024px | same structure, gutters `px-6` → `px-4` |
+| <640px | nav → icons; StatusPill → dot; SourceCards full-width stacked (`w-full`, not `w-64`); RepoRow wraps to two lines (name+actions / status); onboarding cards full-width `mx-4`; **fix the Phase 1 mobile input-bar clipping**: input bar `p-3`, textarea `text-base`, no fixed heights |
 
-### RepoFilter
-| | |
-|---|---|
-| Props | `repos: [{repo, indexed_units}]`, `selected: string[]`, `onChange` |
-| Behavior | multi-select dropdown in the header; default = all repos selected ("All repos" summary label); selection is passed as `repos` on `/query` and `/retrieve` |
-| States | closed; open (panel with checkboxes); loading (skeleton while `GET /repos` resolves); single-repo installs render as a static badge, not a dropdown |
-| A11y | `<button aria-haspopup="listbox">`; arrow keys + Space toggle; Escape closes |
+## Accessibility (WCAG 2.1 AA — binding)
 
-### LoadingCard
-Assistant-side placeholder while `/query` is in flight: three-dot pulse
-plus rotating status text ("Searching decision history…"). Replaced
-in-place by AnswerCard or ErrorCard.
+- Contrast verified per issue (tokens above are starting points).
+- Full keyboard paths: onboarding is Tab-completable end to end; citation
+  markers are `<button>`s in tab order (focus = same highlight as hover);
+  RepoPicker rows toggle on Space; roving focus in RepoFilter unchanged.
+- Focus visible always: 2px `--color-accent` ring, `outline-offset: 2px`.
+- Live regions: StatusPill and per-repo status lines `aria-live="polite"`;
+  device-code state changes announced; answer arrival announced via the
+  existing `role="status"` → content swap.
+- Never color-only: failed states pair danger color with text; markers
+  are numbered, not color-coded.
+- Reduced motion: every animation above lists its fallback.
 
-### ErrorCard
-| | |
-|---|---|
-| Props | `message`, `onRetry` |
-| Variants | backend unreachable; upstream model error (surfaces server-provided message) |
-| Behavior | Retry re-submits the same question |
-
-## Do / Don't
+## Do / Don't (Phase 2)
 
 | ✅ Do | ❌ Don't |
 |---|---|
-| Style light and dark in the same change | Ship a component light-only |
-| Use tokens/Tailwind scale | Hardcode colors or px values |
-| Render "no answer" as a calm state | Dress no-answer up as an error |
-| Keep components presentational; state in `App.jsx` | Fetch from inside components |
-
-## Deferred past Phase 1
-Question history sidebar, streaming answers, answer feedback (👍/👎),
-mobile-specific layout work beyond responsive defaults.
+| Serif for reading, sans for chrome, mono only when content is code-like | Display/serif type in buttons, labels, or data |
+| One accent, semantic states, `--color-highlight` for washes | Solid accent slabs on large surfaces (except Onboarding step 1) |
+| Honest progress with real counts from the status endpoint | Bare spinners or fake percentages |
+| Inline confirmations (row swap) | Modals as first resort |
+| Both themes in the same commit; tokens only | `dark:` classes, hardcoded hex, cream/parchment body tints |


### PR DESCRIPTION
Rolling PR accumulating unattended daily-agent work on `agent/rolling`.

Closes #55
Closes #51
Closes #52

## Changelog

- `PRODUCT.md` (new) + rewritten `docs/UI-DESIGN.md`: Phase 2 productization decisions and the engineering handoff spec for the redesign (tokens, onboarding flow, reading room, Library, Settings).
- `ROADMAP.md` / `docs/ARCHITECTURE.md` / `docs/SYSTEM-DESIGN.md`: restructured for Phase 2-4 (config store + device-flow auth, background ingestion, onboarding, reading room, living archive, decision inbox).
- `backend/main.py`: permissive CORS middleware, needed for the frontend (different origin) to reach the backend locally — single-user, no-auth, local-only tool, so this doesn't expose anything a same-origin policy would otherwise protect.
- `backend/ingestion/github_client.py`: `list_repos()` — paginates `GET /user/repos`, estimates each repo's commit count via the Link-header last-page trick, supports substring filtering; new `GitHubAuthError` distinguishes a bad/expired token (401) from other GitHub failures.
- `backend/routers/github.py` (new): `GET /github/repos` wiring `list_repos()` to the picker-facing response shape, with `?query=` filtering and 401/502 error translation.
- `backend/config_store.py` (new): local JSON config store at `{CHROMA_DATA_DIR}/config.json` — `load()`/`save(partial)`, merge-on-save, defaults on first run.
- `backend/config.py`: `Settings` now falls back to `config_store` for any field env/`.env` didn't already provide; env still wins when both are set.
- `backend/routers/config.py` (new): `GET/PATCH /config`, talking to `config_store` directly (not `Settings`) so the UI can bootstrap configuration before any Settings-dependent endpoint can run. Secrets (`github_token`, `gemini_api_key`) are masked in every response (`ghp_…4f2a` style); `PATCH` validates non-empty strings and merges partial updates.

## Notes

- #53 (device-flow auth module) is blocked on a missing credential: the GitHub OAuth device flow needs a client ID from a registered GitHub OAuth App, which doesn't exist anywhere in this repo yet and isn't something the agent can fabricate safely. Commented on the issue with what's needed and labeled `needs-input` rather than guessing. #54 (device-flow auth routers) and #56 (`GET /setup/state`) remain blocked behind it in turn.
- This sandbox's unattended run doesn't have approval to execute `python`/`pytest` (interactive approval required, not available here), so all new tests (`test_config_store.py`, `test_config_router.py`, and the earlier `test_github_repos.py`) were verified by reading the code paths end to end rather than a live run — worth a `pytest` sanity check during review.

## Review fixes (99813f4)

`/code-review` (Standards + Spec) and `/ponytail-review` found:
- **Standards hard violation**: `routers/config.py` had masking + PATCH validation logic directly in the router, violating ARCHITECTURE.md's "routers are thin" rule. Moved into `config_store.mask()`/`config_store.save()`.
- **Standards hard violation (documentation gap)**: `config_store.py`'s direct `os.getenv("CHROMA_DATA_DIR")` read wasn't a documented exception. Added it to ARCHITECTURE.md's dependency rules alongside `chroma_client.py`'s existing use of the same pattern.
- **Ponytail finding**: `GitHubRepoInfo` in `models.py` duplicated `ingestion.github_client.RepoSummary` field-for-field just to cross the router boundary. Deleted; `GitHubReposResponse` now reuses `RepoSummary` directly.
- **Standards smell**: `ConfigPatchRequest` redeclared all 7 `ConfigResponse` fields by hand. Now inherits from `ConfigResponse`, overriding only the 2 fields that differ (required -> optional).
- **Spec edge case**: `Settings._fill_from_config_store` used `if value and ...`, which skipped falsy-but-real stored values — an explicitly cleared `indexed_repos: []` in the store could never satisfy `indexed_repos`' required-field construction. Changed to `if value is not None and ...`.
- **Minor**: short secrets (≤8 chars) now mask to a length-matched `"****"` instead of collapsing to a single `"…"`.

All 113 backend tests pass (`pytest` run locally with the local dev `.env` removed, matching CI's no-`.env` condition).
