### PR TITLE
Backend foundation + background ingestion status/hook/UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
-# GitHub API access for ingestion (repo:read scope is sufficient)
+# Dev-time override only. Phase 2's source of truth is the local config
+# store ({CHROMA_DATA_DIR}/config.json), managed via GET/PATCH /config —
+# any value set here wins over the store when both are set.
+
+# GitHub API access for ingestion (repo:read scope is sufficient); also
+# settable via GET/PATCH /config once GitHub device-flow auth completes
 GITHUB_TOKEN=
 
 # Comma-separated list of repos to index, e.g. anubhab-m02/BuFin,anubhab-m02/adr-engine
+# also settable via GET/PATCH /config
 INDEXED_REPOS=
 
 # Max seconds to wait out a GitHub rate-limit reset before failing loudly
@@ -13,12 +19,13 @@ GITHUB_REQUEST_TIMEOUT_SECONDS=10
 # Per-request timeout (seconds) for outbound Ollama calls (extraction/embedding)
 OLLAMA_REQUEST_TIMEOUT_SECONDS=60
 
-# Local Ollama
+# Local Ollama; also settable via GET/PATCH /config
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_EXTRACTION_MODEL=phi4-mini
 OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
-# Cloud model for synthesis/citation (only retrieved snippets are sent, not full corpus)
+# Cloud model for synthesis/citation (only retrieved snippets are sent, not
+# full corpus); also settable via GET/PATCH /config
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-2.5-flash
 

--- a/backend/auth/device_flow.py
+++ b/backend/auth/device_flow.py
@@ -7,6 +7,7 @@ ARCHITECTURE.md.
 """
 
 import time
+from typing import Literal
 
 import httpx
 from pydantic import BaseModel
@@ -35,7 +36,7 @@ class DeviceCodeResponse(BaseModel):
 
 
 class PollResult(BaseModel):
-    state: str  # "authorized" | "expired" | "denied"
+    state: Literal["pending", "authorized", "expired", "denied"]
     login: str | None = None
 
 
@@ -103,30 +104,48 @@ def _fetch_login(token: str) -> str | None:
     return response.json().get("login")
 
 
+def _interpret_token_response(data: dict) -> tuple[PollResult | None, int | None]:
+    """Returns `(result, retry_interval)`. `result` is `None` while GitHub
+    is still waiting on the user (caller should retry, after
+    `retry_interval` seconds if GitHub asked to slow down). On
+    `authorized`, persists the token to the config store."""
+    if "access_token" in data:
+        token = data["access_token"]
+        config_store.save({"github_token": token})
+        return PollResult(state="authorized", login=_fetch_login(token)), None
+
+    error = data.get("error")
+    if error == "authorization_pending":
+        return None, None
+    if error == "slow_down":
+        return None, data.get("interval")
+    if error == "expired_token":
+        return PollResult(state="expired"), None
+    if error == "access_denied":
+        return PollResult(state="denied"), None
+
+    raise GitHubAuthError(f"unexpected GitHub device flow response: {data}")
+
+
 def poll_for_token(device_code: str, interval: int) -> PollResult:
     """Poll GitHub's access-token endpoint, sleeping `interval` seconds
     (GitHub's stated cadence, possibly extended via `slow_down`) between
-    attempts, until a definitive state is reached. On `authorized`,
-    persists the token to the config store before returning."""
+    attempts, until a definitive state is reached. For CLI/script use —
+    an HTTP endpoint should use `check_token_once` instead, since this
+    blocks for however long the user takes to authorize."""
     while True:
-        data = _fetch_token(device_code)
+        result, retry_interval = _interpret_token_response(_fetch_token(device_code))
+        if result is not None:
+            return result
+        if retry_interval is not None:
+            interval = retry_interval
+        time.sleep(interval)
 
-        if "access_token" in data:
-            token = data["access_token"]
-            config_store.save({"github_token": token})
-            return PollResult(state="authorized", login=_fetch_login(token))
 
-        error = data.get("error")
-        if error == "authorization_pending":
-            time.sleep(interval)
-            continue
-        if error == "slow_down":
-            interval = data.get("interval", interval + 5)
-            time.sleep(interval)
-            continue
-        if error == "expired_token":
-            return PollResult(state="expired")
-        if error == "access_denied":
-            return PollResult(state="denied")
-
-        raise GitHubAuthError(f"unexpected GitHub device flow response: {data}")
+def check_token_once(device_code: str) -> PollResult:
+    """A single, non-blocking attempt against GitHub's access-token
+    endpoint — for `GET /auth/github/status`, which the frontend re-polls
+    on its own interval. Never sleeps; still-pending is a real, expected
+    result here, not something to wait out."""
+    result, _ = _interpret_token_response(_fetch_token(device_code))
+    return result if result is not None else PollResult(state="pending")

--- a/backend/auth/device_flow.py
+++ b/backend/auth/device_flow.py
@@ -1,0 +1,132 @@
+"""GitHub OAuth device flow: start + poll against GitHub's device endpoints.
+
+The client ID ships in code — device flow needs no client secret, per
+SYSTEM-DESIGN.md's GitHub auth section, so this is not a secret and is
+safe to hardcode. GitHub's raw JSON must not leak past this module, per
+ARCHITECTURE.md.
+"""
+
+import time
+
+import httpx
+from pydantic import BaseModel
+
+import config_store
+
+GITHUB_OAUTH_CLIENT_ID = "Ov23li76dVynkk5L7OsK"
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_DEVICE_FLOW_SCOPE = "repo"
+GITHUB_USER_URL = "https://api.github.com/user"
+
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+class GitHubAuthError(Exception):
+    """Raised on boundary failures talking to GitHub's device-flow endpoints."""
+
+
+class DeviceCodeResponse(BaseModel):
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+
+class PollResult(BaseModel):
+    state: str  # "authorized" | "expired" | "denied"
+    login: str | None = None
+
+
+def start_device_flow() -> DeviceCodeResponse:
+    try:
+        response = httpx.post(
+            GITHUB_DEVICE_CODE_URL,
+            data={"client_id": GITHUB_OAUTH_CLIENT_ID, "scope": GITHUB_DEVICE_FLOW_SCOPE},
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException as exc:
+        raise GitHubAuthError(f"request to GitHub timed out: {exc}") from exc
+
+    if response.is_error:
+        raise GitHubAuthError(f"GitHub device code request failed: {response.status_code} {response.text}")
+
+    data = response.json()
+    if "error" in data:
+        raise GitHubAuthError(f"GitHub device code request failed: {data.get('error_description', data['error'])}")
+
+    return DeviceCodeResponse(
+        device_code=data["device_code"],
+        user_code=data["user_code"],
+        verification_uri=data["verification_uri"],
+        expires_in=data["expires_in"],
+        interval=data["interval"],
+    )
+
+
+def _fetch_token(device_code: str) -> dict:
+    try:
+        response = httpx.post(
+            GITHUB_ACCESS_TOKEN_URL,
+            data={
+                "client_id": GITHUB_OAUTH_CLIENT_ID,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+            headers={"Accept": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException as exc:
+        raise GitHubAuthError(f"request to GitHub timed out: {exc}") from exc
+
+    if response.is_error:
+        raise GitHubAuthError(f"GitHub access token request failed: {response.status_code} {response.text}")
+
+    return response.json()
+
+
+def _fetch_login(token: str) -> str | None:
+    try:
+        response = httpx.get(
+            GITHUB_USER_URL,
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException:
+        return None
+
+    if response.is_error:
+        return None
+
+    return response.json().get("login")
+
+
+def poll_for_token(device_code: str, interval: int) -> PollResult:
+    """Poll GitHub's access-token endpoint, sleeping `interval` seconds
+    (GitHub's stated cadence, possibly extended via `slow_down`) between
+    attempts, until a definitive state is reached. On `authorized`,
+    persists the token to the config store before returning."""
+    while True:
+        data = _fetch_token(device_code)
+
+        if "access_token" in data:
+            token = data["access_token"]
+            config_store.save({"github_token": token})
+            return PollResult(state="authorized", login=_fetch_login(token))
+
+        error = data.get("error")
+        if error == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if error == "slow_down":
+            interval = data.get("interval", interval + 5)
+            time.sleep(interval)
+            continue
+        if error == "expired_token":
+            return PollResult(state="expired")
+        if error == "access_denied":
+            return PollResult(state="denied")
+
+        raise GitHubAuthError(f"unexpected GitHub device flow response: {data}")

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,46 @@
+"""Ingestion CLI entry point, for scripting/cron use outside the API.
+
+Usage: python -m backend.cli ingest [--repos owner/repo,owner/other]
+
+Run from the repo root. Inserts `backend/` onto `sys.path` so it can
+import sibling modules (`config`, `ingestion.run`) the same flat way
+`main.py` and the test suite do; `backend` itself has no `__init__.py`
+and isn't a real package.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from config import get_settings  # noqa: E402
+from ingestion.run import run_ingestion  # noqa: E402
+
+
+def _target_repos(cli_repos: str | None) -> list[str]:
+    if cli_repos:
+        return [repo.strip() for repo in cli_repos.split(",") if repo.strip()]
+    return get_settings().indexed_repos
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="python -m backend.cli")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ingest_parser = subparsers.add_parser("ingest", help="run ingestion for one or more repos")
+    ingest_parser.add_argument("--repos", help="comma-separated repos; default: all configured repos")
+
+    args = parser.parse_args(argv)
+
+    repos = _target_repos(args.repos)
+    for repo in repos:
+        result = run_ingestion(repo)
+        print(
+            f"{result.repo}: fetched={result.fetched} extracted={result.extracted} "
+            f"skipped={result.skipped} stored={result.stored}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/ingestion/run.py
+++ b/backend/ingestion/run.py
@@ -81,11 +81,18 @@ def _ingest_items(
     return extracted, skipped, units
 
 
-def run_ingestion(repo: str) -> IngestResult:
+def run_ingestion(repo: str, on_phase: Callable[[str], None] | None = None) -> IngestResult:
+    """`on_phase`, if given, is called once with `"extracting"` when
+    fetching finishes and the extract/embed/store loop begins — the only
+    real phase boundary this per-item pipeline has (extraction and
+    embedding happen interleaved per item, not as separate passes)."""
     cursor = store.get_cursor(repo)
 
     commits = github_client.list_commits(repo, since=cursor.get("last_commit_date"))
     prs = github_client.list_prs(repo, since=cursor.get("last_pr_updated_at"))
+
+    if on_phase:
+        on_phase("extracting")
 
     commit_extracted, commit_skipped, commit_units = _ingest_items(
         commits,

--- a/backend/jobs/ingest_job.py
+++ b/backend/jobs/ingest_job.py
@@ -1,6 +1,6 @@
 """In-process background ingestion job: one job per `POST /ingest` call,
-module-level state read by `GET /ingest/status` (next issue). No queue
-infra, per SYSTEM-DESIGN.md's ingestion-jobs section — right-sized for a
+module-level state read by `GET /ingest/status`. No queue infra, per
+SYSTEM-DESIGN.md's ingestion-jobs section — right-sized for a
 single-user app. `jobs` may call `ingestion` directly, per
 ARCHITECTURE.md's stated exception (it orchestrates it).
 """
@@ -29,16 +29,26 @@ class Job(BaseModel):
 
 
 _jobs: dict[str, Job] = {}
+_latest_job_id: str | None = None
 
 
 def start_job(repos: list[str]) -> str:
+    global _latest_job_id
     job_id = str(uuid.uuid4())
     _jobs[job_id] = Job(id=job_id, repos={repo: RepoJobState(repo=repo) for repo in repos})
+    _latest_job_id = job_id
     return job_id
 
 
 def get_job(job_id: str) -> Job | None:
     return _jobs.get(job_id)
+
+
+def get_latest_job() -> Job | None:
+    """The most recently started job, regardless of whether it's still
+    active — `GET /ingest/status` has no job_id param and needs the last
+    known state even after completion."""
+    return _jobs.get(_latest_job_id) if _latest_job_id else None
 
 
 def run_job(job_id: str) -> None:

--- a/backend/jobs/ingest_job.py
+++ b/backend/jobs/ingest_job.py
@@ -1,0 +1,68 @@
+"""In-process background ingestion job: one job per `POST /ingest` call,
+module-level state read by `GET /ingest/status` (next issue). No queue
+infra, per SYSTEM-DESIGN.md's ingestion-jobs section — right-sized for a
+single-user app. `jobs` may call `ingestion` directly, per
+ARCHITECTURE.md's stated exception (it orchestrates it).
+"""
+
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel
+
+from ingestion.run import run_ingestion
+
+Phase = Literal["queued", "fetching", "extracting", "embedding", "done", "failed"]
+
+
+class RepoJobState(BaseModel):
+    repo: str
+    phase: Phase = "queued"
+    counts: dict[str, int] = {"fetched": 0, "extracted": 0, "skipped": 0, "stored": 0}
+    error: str | None = None
+
+
+class Job(BaseModel):
+    id: str
+    active: bool = True
+    repos: dict[str, RepoJobState]
+
+
+_jobs: dict[str, Job] = {}
+
+
+def start_job(repos: list[str]) -> str:
+    job_id = str(uuid.uuid4())
+    _jobs[job_id] = Job(id=job_id, repos={repo: RepoJobState(repo=repo) for repo in repos})
+    return job_id
+
+
+def get_job(job_id: str) -> Job | None:
+    return _jobs.get(job_id)
+
+
+def run_job(job_id: str) -> None:
+    """Run every repo in the job, isolating failures per repo so one
+    repo's boundary error doesn't stop the others' progress (the
+    per-item fault-tolerant rule extended across repos, per
+    SYSTEM-DESIGN.md's ingestion-jobs section)."""
+    job = _jobs[job_id]
+
+    for repo, state in job.repos.items():
+        state.phase = "fetching"
+        try:
+            result = run_ingestion(repo)
+        except Exception as exc:  # per-repo isolation boundary; see docstring
+            state.phase = "failed"
+            state.error = str(exc)
+            continue
+
+        state.phase = "done"
+        state.counts = {
+            "fetched": result.fetched,
+            "extracted": result.extracted,
+            "skipped": result.skipped,
+            "stored": result.stored,
+        }
+
+    job.active = False

--- a/backend/jobs/ingest_job.py
+++ b/backend/jobs/ingest_job.py
@@ -6,19 +6,20 @@ ARCHITECTURE.md's stated exception (it orchestrates it).
 """
 
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel
 
+from ingestion.embed import EmbeddingError
+from ingestion.extract import ExtractionError
+from ingestion.github_client import GitHubError
 from ingestion.run import run_ingestion
-
-Phase = Literal["queued", "fetching", "extracting", "embedding", "done", "failed"]
+from models import IngestCounts, IngestPhase
 
 
 class RepoJobState(BaseModel):
     repo: str
-    phase: Phase = "queued"
-    counts: dict[str, int] = {"fetched": 0, "extracted": 0, "skipped": 0, "stored": 0}
+    phase: IngestPhase = "queued"
+    counts: IngestCounts = IngestCounts()
     error: str | None = None
 
 
@@ -40,10 +41,6 @@ def start_job(repos: list[str]) -> str:
     return job_id
 
 
-def get_job(job_id: str) -> Job | None:
-    return _jobs.get(job_id)
-
-
 def get_latest_job() -> Job | None:
     """The most recently started job, regardless of whether it's still
     active — `GET /ingest/status` has no job_id param and needs the last
@@ -61,18 +58,18 @@ def run_job(job_id: str) -> None:
     for repo, state in job.repos.items():
         state.phase = "fetching"
         try:
-            result = run_ingestion(repo)
-        except Exception as exc:  # per-repo isolation boundary; see docstring
+            result = run_ingestion(repo, on_phase=lambda phase: setattr(state, "phase", phase))
+        except (GitHubError, ExtractionError, EmbeddingError) as exc:
             state.phase = "failed"
             state.error = str(exc)
             continue
 
         state.phase = "done"
-        state.counts = {
-            "fetched": result.fetched,
-            "extracted": result.extracted,
-            "skipped": result.skipped,
-            "stored": result.stored,
-        }
+        state.counts = IngestCounts(
+            fetched=result.fetched,
+            extracted=result.extracted,
+            skipped=result.skipped,
+            stored=result.stored,
+        )
 
     job.active = False

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,12 +4,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from chroma_client import get_chroma_client
+from routers.auth import router as auth_router
 from routers.config import router as config_router
 from routers.github import router as github_router
 from routers.ingest import router as ingest_router
 from routers.query import router as query_router
 from routers.repos import router as repos_router
 from routers.retrieve import router as retrieve_router
+from routers.setup import router as setup_router
 
 app = FastAPI(title="adr-engine")
 
@@ -30,6 +32,8 @@ app.include_router(query_router)
 app.include_router(repos_router)
 app.include_router(github_router)
 app.include_router(config_router)
+app.include_router(auth_router)
+app.include_router(setup_router)
 
 
 @app.get("/health")

--- a/backend/models.py
+++ b/backend/models.py
@@ -42,6 +42,10 @@ class IngestResponse(BaseModel):
     repos: list[IngestResult]
 
 
+class IngestJobResponse(BaseModel):
+    job_id: str
+
+
 class RetrieveRequest(BaseModel):
     query: str
     k: int = 5

--- a/backend/models.py
+++ b/backend/models.py
@@ -46,10 +46,20 @@ class IngestJobResponse(BaseModel):
     job_id: str
 
 
+IngestPhase = Literal["queued", "fetching", "extracting", "embedding", "done", "failed"]
+
+
+class IngestCounts(BaseModel):
+    fetched: int = 0
+    extracted: int = 0
+    skipped: int = 0
+    stored: int = 0
+
+
 class IngestStatusRepo(BaseModel):
     repo: str
-    phase: Literal["queued", "fetching", "extracting", "embedding", "done", "failed"]
-    counts: dict[str, int]
+    phase: IngestPhase
+    counts: IngestCounts
     error: str | None = None
 
 
@@ -113,3 +123,22 @@ class ConfigPatchRequest(ConfigResponse):
 
     ollama_host: str | None = None
     gemini_model: str | None = None
+
+
+class DeviceStartResponse(BaseModel):
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+
+class AuthStatusResponse(BaseModel):
+    state: Literal["pending", "authorized", "expired", "denied"]
+    login: str | None = None
+
+
+class SetupStateResponse(BaseModel):
+    github_connected: bool
+    repos_selected: bool
+    first_index_done: bool
+    gemini_key_set: bool

--- a/backend/models.py
+++ b/backend/models.py
@@ -46,6 +46,18 @@ class IngestJobResponse(BaseModel):
     job_id: str
 
 
+class IngestStatusRepo(BaseModel):
+    repo: str
+    phase: Literal["queued", "fetching", "extracting", "embedding", "done", "failed"]
+    counts: dict[str, int]
+    error: str | None = None
+
+
+class IngestStatusResponse(BaseModel):
+    active: bool
+    repos: list[IngestStatusRepo]
+
+
 class RetrieveRequest(BaseModel):
     query: str
     k: int = 5

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,54 @@
+"""GitHub device-flow HTTP surface: POST /auth/github/device/start,
+GET /auth/github/status, DELETE /auth/github.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. The in-flight device code is kept as
+module-level state (mirrors jobs/ingest_job.py's pattern) — a
+single-user app has at most one device flow running at a time.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+import config_store
+from auth.device_flow import DeviceCodeResponse, check_token_once, start_device_flow
+from models import AuthStatusResponse, DeviceStartResponse
+
+router = APIRouter()
+
+_pending: DeviceCodeResponse | None = None
+
+
+@router.post("/auth/github/device/start", response_model=DeviceStartResponse)
+def start() -> DeviceStartResponse:
+    global _pending
+    _pending = start_device_flow()
+    return DeviceStartResponse(
+        user_code=_pending.user_code,
+        verification_uri=_pending.verification_uri,
+        expires_in=_pending.expires_in,
+        interval=_pending.interval,
+    )
+
+
+@router.get("/auth/github/status", response_model=AuthStatusResponse)
+def status() -> AuthStatusResponse:
+    if _pending is None:
+        if config_store.load()["github_token"]:
+            return AuthStatusResponse(state="authorized")
+        raise HTTPException(status_code=400, detail="no device flow in progress")
+
+    result = check_token_once(_pending.device_code)
+    if result.state != "pending":
+        _clear_pending()
+    return AuthStatusResponse(state=result.state, login=result.login)
+
+
+@router.delete("/auth/github")
+def disconnect() -> None:
+    _clear_pending()
+    config_store.save({"github_token": None})
+
+
+def _clear_pending() -> None:
+    global _pending
+    _pending = None

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,19 +1,23 @@
-"""POST /ingest: thin wiring from HTTP to ingestion.run.run_ingestion.
+"""POST /ingest: launches ingestion as a background job and returns
+immediately; the caller polls GET /ingest/status (next issue) for
+per-repo progress.
 
 Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
 service function, shape response. No business logic here.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 
 from config import get_settings
-from ingestion.run import run_ingestion
-from models import IngestRequest, IngestResponse
+from jobs.ingest_job import run_job, start_job
+from models import IngestJobResponse, IngestRequest
 
 router = APIRouter()
 
 
-@router.post("/ingest", response_model=IngestResponse)
-def ingest(request: IngestRequest = IngestRequest()) -> IngestResponse:
+@router.post("/ingest", response_model=IngestJobResponse, status_code=202)
+def ingest(background_tasks: BackgroundTasks, request: IngestRequest = IngestRequest()) -> IngestJobResponse:
     repos = [request.repo] if request.repo else get_settings().indexed_repos
-    return IngestResponse(repos=[run_ingestion(repo) for repo in repos])
+    job_id = start_job(repos)
+    background_tasks.add_task(run_job, job_id)
+    return IngestJobResponse(job_id=job_id)

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,6 +1,6 @@
 """POST /ingest: launches ingestion as a background job and returns
-immediately; the caller polls GET /ingest/status (next issue) for
-per-repo progress.
+immediately; GET /ingest/status lets the caller poll per-repo progress
+for the most recently started job.
 
 Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
 service function, shape response. No business logic here.
@@ -9,8 +9,8 @@ service function, shape response. No business logic here.
 from fastapi import APIRouter, BackgroundTasks
 
 from config import get_settings
-from jobs.ingest_job import run_job, start_job
-from models import IngestJobResponse, IngestRequest
+from jobs.ingest_job import get_latest_job, run_job, start_job
+from models import IngestJobResponse, IngestRequest, IngestStatusRepo, IngestStatusResponse
 
 router = APIRouter()
 
@@ -21,3 +21,18 @@ def ingest(background_tasks: BackgroundTasks, request: IngestRequest = IngestReq
     job_id = start_job(repos)
     background_tasks.add_task(run_job, job_id)
     return IngestJobResponse(job_id=job_id)
+
+
+@router.get("/ingest/status", response_model=IngestStatusResponse)
+def ingest_status() -> IngestStatusResponse:
+    job = get_latest_job()
+    if job is None:
+        return IngestStatusResponse(active=False, repos=[])
+
+    return IngestStatusResponse(
+        active=job.active,
+        repos=[
+            IngestStatusRepo(repo=state.repo, phase=state.phase, counts=state.counts, error=state.error)
+            for state in job.repos.values()
+        ],
+    )

--- a/backend/routers/setup.py
+++ b/backend/routers/setup.py
@@ -1,0 +1,28 @@
+"""GET /setup/state: drives the onboarding gate in App.jsx.
+
+Reads config_store directly rather than config.Settings — same reason
+as routers/config.py: this endpoint has to answer truthfully on a
+completely fresh install, before Settings' required fields could even
+be satisfied.
+"""
+
+from fastapi import APIRouter
+
+import config_store
+from ingestion.store import count_units
+from models import SetupStateResponse
+
+router = APIRouter()
+
+
+@router.get("/setup/state", response_model=SetupStateResponse)
+def setup_state() -> SetupStateResponse:
+    cfg = config_store.load()
+    indexed_repos = cfg["indexed_repos"]
+
+    return SetupStateResponse(
+        github_connected=bool(cfg["github_token"]),
+        repos_selected=bool(indexed_repos),
+        first_index_done=any(count_units(repo) > 0 for repo in indexed_repos),
+        gemini_key_set=bool(cfg["gemini_api_key"]),
+    )

--- a/backend/tests/test_auth_router.py
+++ b/backend/tests/test_auth_router.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import routers.auth as auth_router_module
+from auth.device_flow import DeviceCodeResponse, PollResult
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    auth_router_module._pending = None
+
+
+def test_start_returns_the_device_code_payload():
+    payload = DeviceCodeResponse(
+        device_code="devcode123",
+        user_code="WDJB-MJHT",
+        verification_uri="https://github.com/login/device",
+        expires_in=900,
+        interval=5,
+    )
+
+    with patch("routers.auth.start_device_flow", return_value=payload):
+        response = client.post("/auth/github/device/start")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://github.com/login/device",
+        "expires_in": 900,
+        "interval": 5,
+    }
+    assert "device_code" not in response.text
+
+
+def test_status_without_a_started_flow_or_existing_token_returns_400():
+    response = client.get("/auth/github/status")
+
+    assert response.status_code == 400
+
+
+def test_status_reflects_pending_authorized_expired_and_denied():
+    payload = DeviceCodeResponse(
+        device_code="devcode123",
+        user_code="WDJB-MJHT",
+        verification_uri="https://github.com/login/device",
+        expires_in=900,
+        interval=5,
+    )
+    with patch("routers.auth.start_device_flow", return_value=payload):
+        client.post("/auth/github/device/start")
+
+    with patch("routers.auth.check_token_once", return_value=PollResult(state="pending")):
+        response = client.get("/auth/github/status")
+    assert response.json() == {"state": "pending", "login": None}
+
+    with patch("routers.auth.check_token_once", return_value=PollResult(state="authorized", login="octocat")):
+        response = client.get("/auth/github/status")
+    assert response.json() == {"state": "authorized", "login": "octocat"}
+
+
+def test_status_falls_back_to_authorized_when_a_token_already_exists():
+    import config_store
+
+    config_store.save({"github_token": "ghp_existing"})
+
+    response = client.get("/auth/github/status")
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "authorized"
+
+
+def test_delete_clears_the_stored_token():
+    import config_store
+
+    config_store.save({"github_token": "ghp_existing"})
+
+    response = client.delete("/auth/github")
+
+    assert response.status_code == 200
+    assert config_store.load()["github_token"] is None

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import cli
+from models import IngestResult
+
+
+def _fake_result(repo: str) -> IngestResult:
+    return IngestResult(repo=repo, fetched=1, extracted=1, skipped=0, stored=1)
+
+
+def test_ingest_with_explicit_repos_calls_orchestrator_for_each():
+    with patch("cli.run_ingestion", side_effect=_fake_result) as mock_run:
+        cli.main(["ingest", "--repos", "owner/a,owner/b"])
+
+    assert [call.args[0] for call in mock_run.call_args_list] == ["owner/a", "owner/b"]
+
+
+def test_ingest_without_repos_flag_defaults_to_configured_repos():
+    with patch("cli.run_ingestion", side_effect=_fake_result) as mock_run:
+        cli.main(["ingest"])
+
+    assert [call.args[0] for call in mock_run.call_args_list] == ["owner/repo"]
+
+
+def test_ingest_strips_whitespace_around_comma_separated_repos():
+    with patch("cli.run_ingestion", side_effect=_fake_result) as mock_run:
+        cli.main(["ingest", "--repos", " owner/a , owner/b "])
+
+    assert [call.args[0] for call in mock_run.call_args_list] == ["owner/a", "owner/b"]
+
+
+def test_ingest_prints_a_summary_line_per_repo(capsys):
+    with patch("cli.run_ingestion", side_effect=_fake_result):
+        cli.main(["ingest", "--repos", "owner/a"])
+
+    out = capsys.readouterr().out
+    assert "owner/a: fetched=1 extracted=1 skipped=0 stored=1" in out

--- a/backend/tests/test_device_flow.py
+++ b/backend/tests/test_device_flow.py
@@ -1,0 +1,121 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import httpx
+import pytest
+
+import config_store
+from auth.device_flow import (
+    DeviceCodeResponse,
+    GitHubAuthError,
+    PollResult,
+    poll_for_token,
+    start_device_flow,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+
+def test_start_device_flow_returns_typed_response():
+    payload = {
+        "device_code": "devcode123",
+        "user_code": "WDJB-MJHT",
+        "verification_uri": "https://github.com/login/device",
+        "expires_in": 900,
+        "interval": 5,
+    }
+
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json=payload)
+
+        result = start_device_flow()
+
+    assert result == DeviceCodeResponse(**payload)
+
+
+def test_start_device_flow_raises_on_error_body():
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(
+            200, json={"error": "unauthorized_client", "error_description": "bad client id"}
+        )
+
+        with pytest.raises(GitHubAuthError):
+            start_device_flow()
+
+
+def test_start_device_flow_raises_on_non_2xx():
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(500, text="server error")
+
+        with pytest.raises(GitHubAuthError):
+            start_device_flow()
+
+
+def test_poll_for_token_success_persists_token_and_returns_login():
+    def fake_post(url, data=None, headers=None, timeout=None):
+        if url.endswith("/oauth/access_token"):
+            return httpx.Response(200, json={"access_token": "ghp_newtoken", "token_type": "bearer"})
+        raise AssertionError(f"unexpected POST {url}")
+
+    with patch("auth.device_flow.httpx.post", side_effect=fake_post), patch(
+        "auth.device_flow.httpx.get"
+    ) as mock_get:
+        mock_get.return_value = httpx.Response(200, json={"login": "octocat"})
+
+        result = poll_for_token("devcode123", interval=0)
+
+    assert result == PollResult(state="authorized", login="octocat")
+    assert config_store.load()["github_token"] == "ghp_newtoken"
+
+
+def test_poll_for_token_retries_on_authorization_pending_then_succeeds():
+    responses = iter(
+        [
+            httpx.Response(200, json={"error": "authorization_pending"}),
+            httpx.Response(200, json={"access_token": "ghp_newtoken"}),
+        ]
+    )
+
+    with patch("auth.device_flow.httpx.post", side_effect=lambda *a, **k: next(responses)), patch(
+        "auth.device_flow.httpx.get"
+    ) as mock_get, patch("auth.device_flow.time.sleep") as mock_sleep:
+        mock_get.return_value = httpx.Response(200, json={"login": "octocat"})
+
+        result = poll_for_token("devcode123", interval=5)
+
+    assert result.state == "authorized"
+    mock_sleep.assert_called_once_with(5)
+
+
+def test_poll_for_token_returns_expired_state_without_raising():
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"error": "expired_token"})
+
+        result = poll_for_token("devcode123", interval=0)
+
+    assert result == PollResult(state="expired")
+    assert config_store.load()["github_token"] is None
+
+
+def test_poll_for_token_returns_denied_state_without_raising():
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"error": "access_denied"})
+
+        result = poll_for_token("devcode123", interval=0)
+
+    assert result == PollResult(state="denied")
+    assert config_store.load()["github_token"] is None
+
+
+def test_poll_for_token_raises_on_unexpected_error():
+    with patch("auth.device_flow.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(200, json={"error": "incorrect_client_credentials"})
+
+        with pytest.raises(GitHubAuthError):
+            poll_for_token("devcode123", interval=0)

--- a/backend/tests/test_device_flow.py
+++ b/backend/tests/test_device_flow.py
@@ -12,6 +12,7 @@ from auth.device_flow import (
     DeviceCodeResponse,
     GitHubAuthError,
     PollResult,
+    check_token_once,
     poll_for_token,
     start_device_flow,
 )
@@ -119,3 +120,28 @@ def test_poll_for_token_raises_on_unexpected_error():
 
         with pytest.raises(GitHubAuthError):
             poll_for_token("devcode123", interval=0)
+
+
+def test_check_token_once_returns_pending_without_sleeping():
+    with patch("auth.device_flow.httpx.post") as mock_post, patch(
+        "auth.device_flow.time.sleep"
+    ) as mock_sleep:
+        mock_post.return_value = httpx.Response(200, json={"error": "authorization_pending"})
+
+        result = check_token_once("devcode123")
+
+    assert result == PollResult(state="pending")
+    mock_sleep.assert_not_called()
+
+
+def test_check_token_once_returns_authorized_and_persists_token():
+    with patch("auth.device_flow.httpx.post") as mock_post, patch(
+        "auth.device_flow.httpx.get"
+    ) as mock_get:
+        mock_post.return_value = httpx.Response(200, json={"access_token": "ghp_newtoken"})
+        mock_get.return_value = httpx.Response(200, json={"login": "octocat"})
+
+        result = check_token_once("devcode123")
+
+    assert result == PollResult(state="authorized", login="octocat")
+    assert config_store.load()["github_token"] == "ghp_newtoken"

--- a/backend/tests/test_ingest_job.py
+++ b/backend/tests/test_ingest_job.py
@@ -4,7 +4,7 @@ import pytest
 
 from ingestion.extract import ExtractionResult
 from ingestion.github_client import CommitRef, GitHubError
-from jobs.ingest_job import get_job, run_job, start_job
+from jobs.ingest_job import get_job, get_latest_job, run_job, start_job
 
 DECISION = ExtractionResult(is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=[])
 
@@ -105,3 +105,22 @@ def test_run_job_marks_the_job_inactive_once_every_repo_finishes(mocks):
     run_job(job_id)
 
     assert get_job(job_id).active is False
+
+
+def test_get_latest_job_returns_the_most_recently_started_job():
+    start_job(["owner/first"])
+    second_id = start_job(["owner/second"])
+
+    assert get_latest_job().id == second_id
+
+
+def test_get_latest_job_keeps_returning_the_job_after_it_completes(mocks):
+    mocks["list_commits"].return_value = []
+    mocks["extract_decision"].return_value = None
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    latest = get_latest_job()
+    assert latest.id == job_id
+    assert latest.active is False

--- a/backend/tests/test_ingest_job.py
+++ b/backend/tests/test_ingest_job.py
@@ -1,0 +1,107 @@
+from unittest.mock import patch
+
+import pytest
+
+from ingestion.extract import ExtractionResult
+from ingestion.github_client import CommitRef, GitHubError
+from jobs.ingest_job import get_job, run_job, start_job
+
+DECISION = ExtractionResult(is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=[])
+
+
+def _commit(sha="abc123", date="2026-01-01T00:00:00Z"):
+    return CommitRef(
+        sha=sha,
+        message="Switch to sessions",
+        author="octocat",
+        date=date,
+        url=f"https://github.com/owner/repo/commit/{sha}",
+    )
+
+
+@pytest.fixture
+def mocks():
+    with patch("ingestion.run.github_client.list_commits") as list_commits, \
+            patch("ingestion.run.github_client.list_prs") as list_prs, \
+            patch("ingestion.run.extract.extract_decision") as extract_decision, \
+            patch("ingestion.run.embed.embed_text") as embed_text, \
+            patch("ingestion.run.store.get_cursor") as get_cursor, \
+            patch("ingestion.run.store.set_cursor") as set_cursor, \
+            patch("ingestion.run.store.upsert_units") as upsert_units:
+        get_cursor.return_value = {}
+        list_prs.return_value = []
+        embed_text.return_value = [0.1, 0.2]
+        yield {
+            "list_commits": list_commits,
+            "list_prs": list_prs,
+            "extract_decision": extract_decision,
+            "get_cursor": get_cursor,
+            "set_cursor": set_cursor,
+            "upsert_units": upsert_units,
+        }
+
+
+def test_start_job_initializes_every_repo_as_queued():
+    job_id = start_job(["owner/a", "owner/b"])
+
+    job = get_job(job_id)
+    assert job.active is True
+    assert job.repos["owner/a"].phase == "queued"
+    assert job.repos["owner/b"].phase == "queued"
+
+
+def test_run_job_marks_a_successful_repo_done_with_counts(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["extract_decision"].return_value = DECISION
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    state = get_job(job_id).repos["owner/repo"]
+    assert state.phase == "done"
+    assert state.counts == {"fetched": 1, "extracted": 1, "skipped": 0, "stored": 1}
+    assert state.error is None
+    mocks["set_cursor"].assert_called_once()
+
+
+def test_run_job_captures_the_boundary_error_without_stopping_other_repos(mocks):
+    def list_commits_side_effect(repo, since=None):
+        if repo == "owner/bad":
+            raise GitHubError(403, "rate limited")
+        return [_commit()]
+
+    mocks["list_commits"].side_effect = list_commits_side_effect
+    mocks["extract_decision"].return_value = None
+
+    job_id = start_job(["owner/bad", "owner/good"])
+    run_job(job_id)
+
+    job = get_job(job_id)
+    assert job.repos["owner/bad"].phase == "failed"
+    assert "rate limited" in job.repos["owner/bad"].error
+    assert job.repos["owner/good"].phase == "done"
+
+
+def test_run_job_only_writes_the_cursor_for_the_successful_repo(mocks):
+    def list_commits_side_effect(repo, since=None):
+        if repo == "owner/bad":
+            raise GitHubError(403, "rate limited")
+        return [_commit()]
+
+    mocks["list_commits"].side_effect = list_commits_side_effect
+    mocks["extract_decision"].return_value = None
+
+    job_id = start_job(["owner/bad", "owner/good"])
+    run_job(job_id)
+
+    mocks["set_cursor"].assert_called_once_with("owner/good", {"last_commit_date": "2026-01-01T00:00:00Z"})
+
+
+def test_run_job_marks_the_job_inactive_once_every_repo_finishes(mocks):
+    mocks["list_commits"].return_value = []
+    mocks["extract_decision"].return_value = None
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    assert get_job(job_id).active is False

--- a/backend/tests/test_ingest_job.py
+++ b/backend/tests/test_ingest_job.py
@@ -4,7 +4,8 @@ import pytest
 
 from ingestion.extract import ExtractionResult
 from ingestion.github_client import CommitRef, GitHubError
-from jobs.ingest_job import get_job, get_latest_job, run_job, start_job
+from jobs.ingest_job import get_latest_job, run_job, start_job
+from models import IngestCounts
 
 DECISION = ExtractionResult(is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=[])
 
@@ -42,9 +43,9 @@ def mocks():
 
 
 def test_start_job_initializes_every_repo_as_queued():
-    job_id = start_job(["owner/a", "owner/b"])
+    start_job(["owner/a", "owner/b"])
 
-    job = get_job(job_id)
+    job = get_latest_job()
     assert job.active is True
     assert job.repos["owner/a"].phase == "queued"
     assert job.repos["owner/b"].phase == "queued"
@@ -57,11 +58,33 @@ def test_run_job_marks_a_successful_repo_done_with_counts(mocks):
     job_id = start_job(["owner/repo"])
     run_job(job_id)
 
-    state = get_job(job_id).repos["owner/repo"]
+    state = get_latest_job().repos["owner/repo"]
     assert state.phase == "done"
-    assert state.counts == {"fetched": 1, "extracted": 1, "skipped": 0, "stored": 1}
+    assert state.counts == IngestCounts(fetched=1, extracted=1, skipped=0, stored=1)
     assert state.error is None
     mocks["set_cursor"].assert_called_once()
+
+
+def test_run_job_passes_through_the_extracting_phase(mocks):
+    """The real spec gap the code review flagged: the job used to jump
+    straight from `fetching` to `done`/`failed` with no observable
+    transition in between, even though `extracting`/`embedding` are part
+    of the documented Phase contract."""
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["extract_decision"].return_value = DECISION
+
+    seen_phases = []
+
+    def record_phase(*args, **kwargs):
+        seen_phases.append(get_latest_job().repos["owner/repo"].phase)
+        return DECISION
+
+    mocks["extract_decision"].side_effect = record_phase
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    assert "extracting" in seen_phases
 
 
 def test_run_job_captures_the_boundary_error_without_stopping_other_repos(mocks):
@@ -76,7 +99,7 @@ def test_run_job_captures_the_boundary_error_without_stopping_other_repos(mocks)
     job_id = start_job(["owner/bad", "owner/good"])
     run_job(job_id)
 
-    job = get_job(job_id)
+    job = get_latest_job()
     assert job.repos["owner/bad"].phase == "failed"
     assert "rate limited" in job.repos["owner/bad"].error
     assert job.repos["owner/good"].phase == "done"
@@ -104,7 +127,7 @@ def test_run_job_marks_the_job_inactive_once_every_repo_finishes(mocks):
     job_id = start_job(["owner/repo"])
     run_job(job_id)
 
-    assert get_job(job_id).active is False
+    assert get_latest_job().active is False
 
 
 def test_get_latest_job_returns_the_most_recently_started_job():

--- a/backend/tests/test_ingest_router.py
+++ b/backend/tests/test_ingest_router.py
@@ -1,11 +1,10 @@
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 import config
 from main import app
-from models import IngestResult
 
 
 @pytest.fixture(autouse=True)
@@ -23,48 +22,50 @@ def _multi_repo_env(monkeypatch):
 client = TestClient(app)
 
 
-def _result(repo: str) -> IngestResult:
-    return IngestResult(repo=repo, fetched=1, extracted=1, skipped=0, stored=1)
-
-
-def test_ingest_with_repo_runs_just_that_repo():
-    with patch("routers.ingest.run_ingestion") as run_ingestion:
-        run_ingestion.return_value = _result("owner/a")
+def test_ingest_with_repo_returns_202_with_a_job_id_for_just_that_repo():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-1"
 
         response = client.post("/ingest", json={"repo": "owner/a"})
 
-    assert response.status_code == 200
-    run_ingestion.assert_called_once_with("owner/a")
-    assert response.json() == {"repos": [_result("owner/a").model_dump()]}
+    assert response.status_code == 202
+    assert response.json() == {"job_id": "job-1"}
+    start_job.assert_called_once_with(["owner/a"])
 
 
-def test_ingest_with_empty_json_body_runs_all_configured_repos():
-    with patch("routers.ingest.run_ingestion") as run_ingestion:
-        run_ingestion.side_effect = _result
+def test_ingest_with_empty_json_body_starts_all_configured_repos():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-2"
 
         response = client.post("/ingest", json={})
 
-    assert response.status_code == 200
-    assert run_ingestion.call_args_list == [call("owner/a"), call("owner/b")]
-    assert [r["repo"] for r in response.json()["repos"]] == ["owner/a", "owner/b"]
+    assert response.status_code == 202
+    start_job.assert_called_once_with(["owner/a", "owner/b"])
 
 
-def test_ingest_with_no_body_at_all_runs_all_configured_repos():
-    with patch("routers.ingest.run_ingestion") as run_ingestion:
-        run_ingestion.side_effect = _result
+def test_ingest_with_no_body_at_all_starts_all_configured_repos():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-3"
 
         response = client.post("/ingest")
 
-    assert response.status_code == 200
-    assert run_ingestion.call_args_list == [call("owner/a"), call("owner/b")]
+    assert response.status_code == 202
+    start_job.assert_called_once_with(["owner/a", "owner/b"])
 
 
-def test_ingest_response_matches_ingest_response_shape():
-    with patch("routers.ingest.run_ingestion") as run_ingestion:
-        run_ingestion.return_value = _result("owner/a")
+def test_ingest_schedules_the_job_as_a_background_task():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job") as run_job:
+        start_job.return_value = "job-4"
+
+        client.post("/ingest", json={"repo": "owner/a"})
+
+    run_job.assert_called_once_with("job-4")
+
+
+def test_ingest_response_matches_ingest_job_response_shape():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-5"
 
         response = client.post("/ingest", json={"repo": "owner/a"})
 
-    body = response.json()
-    assert set(body.keys()) == {"repos"}
-    assert set(body["repos"][0].keys()) == {"repo", "fetched", "extracted", "skipped", "stored"}
+    assert set(response.json().keys()) == {"job_id"}

--- a/backend/tests/test_ingest_status_router.py
+++ b/backend/tests/test_ingest_status_router.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from jobs.ingest_job import Job, RepoJobState
+from main import app
+
+client = TestClient(app)
+
+
+def test_status_with_no_job_ever_started_is_inactive_with_no_repos():
+    with patch("routers.ingest.get_latest_job", return_value=None):
+        response = client.get("/ingest/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"active": False, "repos": []}
+
+
+def test_status_during_a_run_matches_the_job_state_exactly():
+    job = Job(
+        id="job-1",
+        active=True,
+        repos={
+            "owner/a": RepoJobState(
+                repo="owner/a",
+                phase="extracting",
+                counts={"fetched": 5, "extracted": 2, "skipped": 1, "stored": 0},
+            )
+        },
+    )
+
+    with patch("routers.ingest.get_latest_job", return_value=job):
+        response = client.get("/ingest/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "active": True,
+        "repos": [
+            {
+                "repo": "owner/a",
+                "phase": "extracting",
+                "counts": {"fetched": 5, "extracted": 2, "skipped": 1, "stored": 0},
+                "error": None,
+            }
+        ],
+    }
+
+
+def test_status_after_completion_flips_active_false_and_keeps_final_counts():
+    job = Job(
+        id="job-2",
+        active=False,
+        repos={
+            "owner/a": RepoJobState(
+                repo="owner/a",
+                phase="done",
+                counts={"fetched": 3, "extracted": 3, "skipped": 0, "stored": 3},
+            )
+        },
+    )
+
+    with patch("routers.ingest.get_latest_job", return_value=job):
+        response = client.get("/ingest/status")
+
+    body = response.json()
+    assert body["active"] is False
+    assert body["repos"][0]["phase"] == "done"
+    assert body["repos"][0]["counts"] == {"fetched": 3, "extracted": 3, "skipped": 0, "stored": 3}
+
+
+def test_status_surfaces_a_per_repo_error_on_failure():
+    job = Job(
+        id="job-3",
+        active=False,
+        repos={"owner/bad": RepoJobState(repo="owner/bad", phase="failed", error="rate limited")},
+    )
+
+    with patch("routers.ingest.get_latest_job", return_value=job):
+        response = client.get("/ingest/status")
+
+    repo_status = response.json()["repos"][0]
+    assert repo_status["phase"] == "failed"
+    assert repo_status["error"] == "rate limited"
+
+
+def test_status_reflects_multiple_repos_in_the_job():
+    job = Job(
+        id="job-4",
+        active=True,
+        repos={
+            "owner/a": RepoJobState(repo="owner/a", phase="done"),
+            "owner/b": RepoJobState(repo="owner/b", phase="fetching"),
+        },
+    )
+
+    with patch("routers.ingest.get_latest_job", return_value=job):
+        response = client.get("/ingest/status")
+
+    repos_by_name = {r["repo"]: r for r in response.json()["repos"]}
+    assert repos_by_name["owner/a"]["phase"] == "done"
+    assert repos_by_name["owner/b"]["phase"] == "fetching"

--- a/backend/tests/test_setup_router.py
+++ b/backend/tests/test_setup_router.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+
+def test_all_false_on_a_fresh_config_store():
+    response = client.get("/setup/state")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "github_connected": False,
+        "repos_selected": False,
+        "first_index_done": False,
+        "gemini_key_set": False,
+    }
+
+
+def test_github_connected_flips_once_a_token_is_stored():
+    import config_store
+
+    config_store.save({"github_token": "ghp_abc"})
+
+    assert client.get("/setup/state").json()["github_connected"] is True
+
+
+def test_repos_selected_flips_once_repos_are_configured():
+    import config_store
+
+    config_store.save({"indexed_repos": ["owner/repo"]})
+
+    assert client.get("/setup/state").json()["repos_selected"] is True
+
+
+def test_gemini_key_set_flips_once_a_key_is_stored():
+    import config_store
+
+    config_store.save({"gemini_api_key": "gk_abc"})
+
+    assert client.get("/setup/state").json()["gemini_key_set"] is True
+
+
+def test_first_index_done_flips_once_a_configured_repo_has_indexed_units():
+    import config_store
+
+    config_store.save({"indexed_repos": ["owner/repo"]})
+
+    with patch("routers.setup.count_units", return_value=3):
+        response = client.get("/setup/state")
+
+    assert response.json()["first_index_done"] is True
+
+
+def test_first_index_done_stays_false_when_configured_repos_have_no_units():
+    import config_store
+
+    config_store.save({"indexed_repos": ["owner/repo"]})
+
+    with patch("routers.setup.count_units", return_value=0):
+        response = client.get("/setup/state")
+
+    assert response.json()["first_index_done"] is False

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -41,3 +41,7 @@ export function postQuery({ question, repos }) {
     body: JSON.stringify({ question, repos }),
   })
 }
+
+export function getIngestStatus() {
+  return request('/ingest/status', { method: 'GET' })
+}

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiError, getRepos, postQuery } from './api.js'
+import { ApiError, getIngestStatus, getRepos, postQuery } from './api.js'
 
 function mockFetchOnce(response) {
   vi.stubGlobal(
@@ -44,6 +44,21 @@ describe('postQuery', () => {
     expect(options.method).toBe('POST')
     expect(options.headers['Content-Type']).toBe('application/json')
     expect(JSON.parse(options.body)).toEqual({ question: 'Why Redis?', repos: ['owner/repo-a'] })
+    expect(result).toEqual(body)
+  })
+})
+
+describe('getIngestStatus', () => {
+  it('GETs /ingest/status and resolves with the parsed body', async () => {
+    const body = { active: true, repos: [] }
+    mockFetchOnce({ body })
+
+    const result = await getIngestStatus()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [url, options] = fetch.mock.calls[0]
+    expect(url).toMatch(/\/ingest\/status$/)
+    expect(options.method).toBe('GET')
     expect(result).toEqual(body)
   })
 })

--- a/frontend/src/lib/useIngestStatus.js
+++ b/frontend/src/lib/useIngestStatus.js
@@ -1,0 +1,50 @@
+// The single context-shared poller for GET /ingest/status. Per
+// ARCHITECTURE.md's binding rule, there is never more than one active
+// status poller — Onboarding's IndexStep, Library's rows, and the
+// shell's StatusPill all consume this one hook instead of each mounting
+// their own interval.
+import { createContext, createElement, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { getIngestStatus } from '../api.js'
+
+const POLL_INTERVAL_MS = 2000
+
+const IngestStatusContext = createContext(null)
+
+export function IngestStatusProvider({ children }) {
+  const [status, setStatus] = useState(null)
+  const timerRef = useRef(null)
+
+  const fetchStatus = useCallback(async () => {
+    const result = await getIngestStatus()
+    setStatus(result)
+    return result
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function poll() {
+      const result = await fetchStatus()
+      if (!cancelled && result.active) {
+        timerRef.current = setTimeout(poll, POLL_INTERVAL_MS)
+      }
+    }
+
+    poll()
+
+    return () => {
+      cancelled = true
+      clearTimeout(timerRef.current)
+    }
+  }, [fetchStatus])
+
+  return createElement(IngestStatusContext.Provider, { value: { status, refetch: fetchStatus } }, children)
+}
+
+export function useIngestStatus() {
+  const context = useContext(IngestStatusContext)
+  if (!context) {
+    throw new Error('useIngestStatus must be used within an IngestStatusProvider')
+  }
+  return context
+}

--- a/frontend/src/lib/useIngestStatus.test.jsx
+++ b/frontend/src/lib/useIngestStatus.test.jsx
@@ -1,0 +1,107 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IngestStatusProvider, useIngestStatus } from './useIngestStatus.js'
+
+function mockFetchSequence(bodies) {
+  const fetchMock = vi.fn()
+  bodies.forEach((body) => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(body) })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function Consumer({ label }) {
+  const { status } = useIngestStatus()
+  return <div data-testid={label}>{status ? (status.active ? 'active' : 'idle') : 'loading'}</div>
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('IngestStatusProvider', () => {
+  it('polls again after the interval while a job is active', async () => {
+    const activeBody = { active: true, repos: [] }
+    const fetchMock = mockFetchSequence([activeBody, activeBody, { active: false, repos: [] }])
+
+    render(
+      <IngestStatusProvider>
+        <Consumer label="a" />
+      </IngestStatusProvider>,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops polling once active flips false', async () => {
+    const fetchMock = mockFetchSequence([{ active: false, repos: [] }])
+
+    render(
+      <IngestStatusProvider>
+        <Consumer label="a" />
+      </IngestStatusProvider>,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('a')).toHaveTextContent('idle')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares a single poll loop across multiple consumers', async () => {
+    const activeBody = { active: true, repos: [] }
+    const fetchMock = mockFetchSequence([activeBody, { active: false, repos: [] }])
+
+    render(
+      <IngestStatusProvider>
+        <Consumer label="a" />
+        <Consumer label="b" />
+      </IngestStatusProvider>,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('a')).toHaveTextContent('active')
+    expect(screen.getByTestId('b')).toHaveTextContent('active')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('a')).toHaveTextContent('idle')
+    expect(screen.getByTestId('b')).toHaveTextContent('idle')
+  })
+
+  it('throws when used outside the provider', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    function Lonely() {
+      useIngestStatus()
+      return null
+    }
+
+    expect(() => render(<Lonely />)).toThrow('useIngestStatus must be used within an IngestStatusProvider')
+  })
+})

--- a/frontend/src/library/IndexProgress.jsx
+++ b/frontend/src/library/IndexProgress.jsx
@@ -1,0 +1,47 @@
+// Per-repo ingestion progress line, reused verbatim by Onboarding's Step
+// 3 and the Library page (UI-DESIGN.md). Presentational only — reads the
+// shared useIngestStatus poller, no local polling of its own.
+import { useIngestStatus } from '../lib/useIngestStatus.js'
+
+const PHASE_LABELS = {
+  queued: () => 'Queued…',
+  fetching: (counts) => `Reading commits — ${counts.fetched} examined`,
+  extracting: (counts) => `Extracting decisions — ${counts.extracted} recorded of ${counts.fetched}`,
+  embedding: (counts) => `Embedding ${counts.extracted} decisions…`,
+  done: (counts) => `Indexed ${counts.stored} decisions`,
+}
+
+function extractProgressPercent(counts) {
+  if (!counts.fetched) return 0
+  return Math.min(100, (counts.extracted / counts.fetched) * 100)
+}
+
+function IndexProgress({ repo }) {
+  const { status } = useIngestStatus()
+  const repoState = status?.repos.find((r) => r.repo === repo)
+
+  if (!repoState) return null
+
+  if (repoState.phase === 'failed') {
+    return (
+      <p className="text-sm text-danger" role="status">
+        {repoState.error}
+      </p>
+    )
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-ink-muted" role="status">
+        {PHASE_LABELS[repoState.phase](repoState.counts)}
+      </p>
+      {repoState.phase === 'extracting' && (
+        <div className="h-1 rounded bg-surface">
+          <div className="h-1 rounded bg-accent" style={{ width: `${extractProgressPercent(repoState.counts)}%` }} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default IndexProgress

--- a/frontend/src/library/IndexProgress.test.jsx
+++ b/frontend/src/library/IndexProgress.test.jsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useIngestStatus } from '../lib/useIngestStatus.js'
+import IndexProgress from './IndexProgress.jsx'
+
+vi.mock('../lib/useIngestStatus.js', () => ({ useIngestStatus: vi.fn() }))
+
+function mockStatus(repoState) {
+  useIngestStatus.mockReturnValue({
+    status: { active: true, repos: repoState ? [repoState] : [] },
+    refetch: vi.fn(),
+  })
+}
+
+describe('IndexProgress', () => {
+  it('renders nothing when the status has no entry for this repo', () => {
+    mockStatus(null)
+    const { container } = render(<IndexProgress repo="owner/repo" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the status hook has no data yet', () => {
+    useIngestStatus.mockReturnValue({ status: null, refetch: vi.fn() })
+    const { container } = render(<IndexProgress repo="owner/repo" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the queued state', () => {
+    mockStatus({ repo: 'owner/repo', phase: 'queued', counts: { fetched: 0, extracted: 0, skipped: 0, stored: 0 } })
+    render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('Queued…')).toBeInTheDocument()
+  })
+
+  it('renders the fetching state with live counts', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'fetching',
+      counts: { fetched: 214, extracted: 0, skipped: 0, stored: 0 },
+    })
+    render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('Reading commits — 214 examined')).toBeInTheDocument()
+  })
+
+  it('renders the extracting state with a progress bar', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'extracting',
+      counts: { fetched: 214, extracted: 37, skipped: 0, stored: 0 },
+    })
+    const { container } = render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('Extracting decisions — 37 recorded of 214')).toBeInTheDocument()
+    const fill = container.querySelector('.bg-accent')
+    expect(fill).toHaveStyle({ width: `${(37 / 214) * 100}%` })
+  })
+
+  it('renders the embedding state', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'embedding',
+      counts: { fetched: 214, extracted: 37, skipped: 0, stored: 0 },
+    })
+    render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('Embedding 37 decisions…')).toBeInTheDocument()
+  })
+
+  it('renders the done state', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'done',
+      counts: { fetched: 214, extracted: 37, skipped: 5, stored: 37 },
+    })
+    render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('Indexed 37 decisions')).toBeInTheDocument()
+  })
+
+  it('renders the failed state with the server error message', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'failed',
+      counts: { fetched: 0, extracted: 0, skipped: 0, stored: 0 },
+      error: 'GitHub rate limited',
+    })
+    render(<IndexProgress repo="owner/repo" />)
+    expect(screen.getByText('GitHub rate limited')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- GitHub OAuth device flow module (`backend/auth/device_flow.py`): starts and polls GitHub's device endpoints, persisting the resulting token to the config store.
- Ingestion CLI entry point (`backend/cli.py`, `python -m backend.cli ingest`) plus `.env.example` precedence notes for the config-store-backed fields.
- Background ingestion job (`backend/jobs/ingest_job.py`); `POST /ingest` now returns `202 {job_id}` immediately instead of blocking, isolating per-repo failures.
- `GET /ingest/status`: exposes the latest job's per-repo phase/counts/error, keyed off the most recently started job so the frontend can poll without a job_id.
- `useIngestStatus` frontend hook: single context-shared poller (2s while a job is active, stopped otherwise) for `GET /ingest/status`.
- `IndexProgress` component: per-repo phase + counts line, reused by Onboarding and the Library page.

Closes #53
Closes #57
Closes #62
Closes #63
Closes #64
Closes #65
Closes #54
Closes #56

## Changelog
- backend: add GitHub OAuth device flow module
- backend: add ingestion CLI entry point + .env.example precedence notes
- backend: add background ingestion job module
- backend: POST /ingest launches the background job, returns 202
- backend: track latest ingest job + add ingest-status response models
- backend: add GET /ingest/status endpoint
- backend: add GET /ingest/status router tests
- frontend: add getIngestStatus to api client
- frontend: add useIngestStatus poll hook + provider
- frontend: add useIngestStatus tests
- frontend: add IndexProgress component
- frontend: add IndexProgress tests

## Test plan
- [x] `pytest` passes locally from `backend/` (138 passed)
- [x] `npm test` passes locally from `frontend/` (56 passed)


## Review fixes + #54/#56 implementation (8f9c5a7)

`/code-review` (Standards + Spec) and `/ponytail-review` found:
- **Standards hard violation**: `jobs/ingest_job.py` caught bare `Exception` to keep the per-repo loop alive. Now catches `GitHubError`/`ExtractionError`/`EmbeddingError` explicitly.
- **Spec gap**: the job never actually transitioned through `extracting`/`embedding` — it jumped straight from `fetching` to `done`/`failed`, so `IndexProgress`'s handling of those phases was dead code against the real backend. `ingestion.run.run_ingestion` now takes an optional `on_phase` callback, fired once when fetching completes and the extract/embed/store loop begins (the only real phase boundary this per-item pipeline has). Added a test covering the transition.
- **Standards smells**: `Phase`/counts-dict duplication between `models.py` and `jobs/ingest_job.py` collapsed into a single `IngestPhase`/`IngestCounts` source of truth in `models.py`. `PollResult.state` is now a `Literal` instead of a bare `str`.
- **Ponytail**: deleted the unused `get_job()`. Kept `_fetch_login`/`PollResult.login` — flagged as speculative for #53 alone, but it's exactly what #54's status endpoint needs, so it's implemented here rather than deferred.

Also implemented #54 and #56, previously `needs-input` (blocked on #51/#53, both now merged):
- `backend/routers/auth.py`: `POST /auth/github/device/start`, `GET /auth/github/status`, `DELETE /auth/github`. Added `check_token_once` — a single non-blocking poll attempt — since the existing `poll_for_token` sleeps internally in a loop and would block an HTTP request for however long the user takes to authorize; the status endpoint uses the non-blocking version and lets the frontend re-poll on its own interval.
- `backend/routers/setup.py`: `GET /setup/state`, reading `config_store` directly (not `config.Settings`, whose required fields can't be satisfied on a fresh install) plus `ingestion.store.count_units` for `first_index_done`.

152/152 backend tests pass (.env removed locally to match CI's no-`.env` condition).