### PR TITLE
Onboarding steps: Connect, RepoPicker, IndexStep

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -28,6 +28,7 @@ class DecisionUnit(BaseModel):
 
 class IngestRequest(BaseModel):
     repo: str | None = None
+    repos: list[str] | None = None
 
 
 class IngestResult(BaseModel):

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -17,7 +17,7 @@ router = APIRouter()
 
 @router.post("/ingest", response_model=IngestJobResponse, status_code=202)
 def ingest(background_tasks: BackgroundTasks, request: IngestRequest = IngestRequest()) -> IngestJobResponse:
-    repos = [request.repo] if request.repo else get_settings().indexed_repos
+    repos = request.repos or ([request.repo] if request.repo else None) or get_settings().indexed_repos
     job_id = start_job(repos)
     background_tasks.add_task(run_job, job_id)
     return IngestJobResponse(job_id=job_id)

--- a/backend/tests/test_ingest_router.py
+++ b/backend/tests/test_ingest_router.py
@@ -33,6 +33,26 @@ def test_ingest_with_repo_returns_202_with_a_job_id_for_just_that_repo():
     start_job.assert_called_once_with(["owner/a"])
 
 
+def test_ingest_with_repos_list_starts_exactly_those_repos():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-list"
+
+        response = client.post("/ingest", json={"repos": ["owner/a", "owner/b"]})
+
+    assert response.status_code == 202
+    start_job.assert_called_once_with(["owner/a", "owner/b"])
+
+
+def test_ingest_repos_list_takes_precedence_over_repo():
+    with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
+        start_job.return_value = "job-precedence"
+
+        response = client.post("/ingest", json={"repo": "owner/a", "repos": ["owner/b"]})
+
+    assert response.status_code == 202
+    start_job.assert_called_once_with(["owner/b"])
+
+
 def test_ingest_with_empty_json_body_starts_all_configured_repos():
     with patch("routers.ingest.start_job") as start_job, patch("routers.ingest.run_job"):
         start_job.return_value = "job-2"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -71,10 +71,10 @@ export function patchConfig(patch) {
   })
 }
 
-export function postIngest() {
+export function postIngest({ repos } = {}) {
   return request('/ingest', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
+    body: JSON.stringify(repos ? { repos } : {}),
   })
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -49,3 +49,32 @@ export function getIngestStatus() {
 export function getSetupState() {
   return request('/setup/state', { method: 'GET' })
 }
+
+export function startDeviceFlow() {
+  return request('/auth/github/device/start', { method: 'POST' })
+}
+
+export function getAuthStatus() {
+  return request('/auth/github/status', { method: 'GET' })
+}
+
+export function getGithubRepos({ query } = {}) {
+  const search = query ? `?query=${encodeURIComponent(query)}` : ''
+  return request(`/github/repos${search}`, { method: 'GET' })
+}
+
+export function patchConfig(patch) {
+  return request('/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+}
+
+export function postIngest() {
+  return request('/ingest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  })
+}

--- a/frontend/src/onboarding/ConnectStep.jsx
+++ b/frontend/src/onboarding/ConnectStep.jsx
@@ -1,0 +1,69 @@
+// Onboarding step 1: starts the GitHub device flow on mount and renders
+// DeviceCodeCard, which owns polling GET /auth/github/status. Advancing
+// to step 2 is the caller's responsibility (via onAuthorized), so this
+// component composes cleanly under OnboardingPage's step machine.
+import { useEffect, useState } from 'react'
+import { startDeviceFlow } from '../api.js'
+import DeviceCodeCard from './DeviceCodeCard.jsx'
+
+function ConnectStep({ onAuthorized }) {
+  const [device, setDevice] = useState(undefined)
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    setDevice(undefined)
+
+    startDeviceFlow()
+      .then((result) => {
+        if (!cancelled) setDevice(result)
+      })
+      .catch(() => {
+        if (!cancelled) setDevice('error')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [attempt])
+
+  function restart() {
+    setAttempt((a) => a + 1)
+  }
+
+  if (device === undefined) {
+    return (
+      <p role="status" className="text-ink-muted text-sm">
+        Connecting…
+      </p>
+    )
+  }
+
+  if (device === 'error') {
+    return (
+      <div className="rounded-xl bg-panel p-4 border border-danger">
+        <p className="text-danger text-sm">Could not start GitHub sign-in.</p>
+        <button
+          type="button"
+          onClick={restart}
+          className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <DeviceCodeCard
+      key={attempt}
+      userCode={device.user_code}
+      verificationUri={device.verification_uri}
+      interval={device.interval}
+      onAuthorized={onAuthorized}
+      onRestart={restart}
+    />
+  )
+}
+
+export default ConnectStep

--- a/frontend/src/onboarding/ConnectStep.jsx
+++ b/frontend/src/onboarding/ConnectStep.jsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react'
 import { startDeviceFlow } from '../api.js'
 import DeviceCodeCard from './DeviceCodeCard.jsx'
+import RetryCard from './RetryCard.jsx'
 
 function ConnectStep({ onAuthorized }) {
   const [device, setDevice] = useState(undefined)
@@ -41,16 +42,7 @@ function ConnectStep({ onAuthorized }) {
 
   if (device === 'error') {
     return (
-      <div className="rounded-xl bg-panel p-4 border border-danger">
-        <p className="text-danger text-sm">Could not start GitHub sign-in.</p>
-        <button
-          type="button"
-          onClick={restart}
-          className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
-        >
-          Retry
-        </button>
-      </div>
+      <RetryCard message="Could not start GitHub sign-in." messageTone="danger" bordered buttonTone="danger" onRetry={restart} />
     )
   }
 

--- a/frontend/src/onboarding/ConnectStep.test.jsx
+++ b/frontend/src/onboarding/ConnectStep.test.jsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAuthStatus, startDeviceFlow } from '../api.js'
+import ConnectStep from './ConnectStep.jsx'
+
+vi.mock('../api.js', () => ({ startDeviceFlow: vi.fn(), getAuthStatus: vi.fn() }))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('ConnectStep', () => {
+  it('starts the device flow on mount and renders the returned code', async () => {
+    startDeviceFlow.mockResolvedValue({
+      user_code: 'WDJB-MJHT',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    })
+    getAuthStatus.mockResolvedValue({ state: 'pending' })
+
+    render(<ConnectStep onAuthorized={vi.fn()} />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(startDeviceFlow).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('WDJB-MJHT')).toBeInTheDocument()
+  })
+
+  it('shows an error with a retry when starting the device flow fails', async () => {
+    startDeviceFlow.mockRejectedValue(new Error('boom'))
+
+    render(<ConnectStep onAuthorized={vi.fn()} />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Could not start GitHub sign-in.')).toBeInTheDocument()
+
+    startDeviceFlow.mockResolvedValue({
+      user_code: 'NEW-CODE',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    })
+    getAuthStatus.mockResolvedValue({ state: 'pending' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(startDeviceFlow).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('NEW-CODE')).toBeInTheDocument()
+  })
+
+  it('advances to the next step once the device is authorized', async () => {
+    const onAuthorized = vi.fn()
+    startDeviceFlow.mockResolvedValue({
+      user_code: 'WDJB-MJHT',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    })
+    getAuthStatus.mockResolvedValue({ state: 'authorized', login: 'octocat' })
+
+    render(<ConnectStep onAuthorized={onAuthorized} />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800)
+    })
+
+    expect(onAuthorized).toHaveBeenCalledWith('octocat')
+  })
+})

--- a/frontend/src/onboarding/DeviceCodeCard.jsx
+++ b/frontend/src/onboarding/DeviceCodeCard.jsx
@@ -1,0 +1,139 @@
+// Onboarding step 1's device-code UI: shows the GitHub device code and
+// polls GET /auth/github/status at the server-provided interval until
+// the user authorizes, the code expires, or authorization is denied.
+// UI-DESIGN.md calls for `--color-accent-ink`/`--font-mono` tokens that
+// don't exist yet (the editorial token system is a later batch-J issue)
+// — uses the current accent/danger tokens and Tailwind's built-in
+// `font-mono` instead, per the precedent set in shell/StatusPill.jsx.
+import { useEffect, useRef, useState } from 'react'
+import { getAuthStatus } from '../api.js'
+
+const AUTHORIZED_ADVANCE_DELAY_MS = 800
+const COPIED_LABEL_DURATION_MS = 2000
+
+function DeviceCodeCard({ userCode, verificationUri, interval, onAuthorized, onRestart }) {
+  const [state, setState] = useState('pending')
+  const [login, setLogin] = useState(null)
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function poll() {
+      let result
+      try {
+        result = await getAuthStatus()
+      } catch {
+        if (!cancelled) setState('network-error')
+        return
+      }
+      if (cancelled) return
+
+      setState(result.state)
+
+      if (result.state === 'authorized') {
+        setLogin(result.login)
+        setTimeout(() => {
+          if (!cancelled) onAuthorized(result.login)
+        }, AUTHORIZED_ADVANCE_DELAY_MS)
+        return
+      }
+
+      if (result.state === 'pending') {
+        timerRef.current = setTimeout(poll, interval * 1000)
+      }
+    }
+
+    poll()
+
+    return () => {
+      cancelled = true
+      clearTimeout(timerRef.current)
+    }
+  }, [interval, onAuthorized])
+
+  function handleCopy() {
+    navigator.clipboard?.writeText(userCode)
+    setCopied(true)
+    setTimeout(() => setCopied(false), COPIED_LABEL_DURATION_MS)
+  }
+
+  if (state === 'authorized') {
+    return (
+      <div role="status" className="rounded-xl bg-panel p-4 text-ink">
+        ✓ Connected as {login}
+      </div>
+    )
+  }
+
+  if (state === 'expired') {
+    return (
+      <div className="rounded-xl bg-panel p-4">
+        <p className="text-ink-muted text-sm">Code expired.</p>
+        <button
+          type="button"
+          onClick={onRestart}
+          className="mt-2 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
+        >
+          Get a new code
+        </button>
+      </div>
+    )
+  }
+
+  if (state === 'denied') {
+    return (
+      <div className="rounded-xl bg-panel p-4">
+        <p className="text-danger text-sm">Authorization was denied.</p>
+        <button
+          type="button"
+          onClick={onRestart}
+          className="mt-2 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (state === 'network-error') {
+    return (
+      <div className="rounded-xl bg-panel p-4 border border-danger">
+        <p className="text-danger text-sm">Could not reach the backend. Is it running?</p>
+        <button
+          type="button"
+          onClick={onRestart}
+          className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl bg-panel p-4">
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-2xl tracking-widest text-ink">{userCode}</span>
+        <button type="button" aria-label="Copy code" onClick={handleCopy} className="text-sm text-accent">
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <a
+        href={verificationUri}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-2 inline-block text-sm text-accent"
+      >
+        Open github.com/login/device
+      </a>
+      <p role="status" className="mt-2 text-sm text-ink-muted">
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent animate-pulse mr-1" aria-hidden="true" />
+        Waiting for approval…
+      </p>
+    </div>
+  )
+}
+
+export default DeviceCodeCard

--- a/frontend/src/onboarding/DeviceCodeCard.jsx
+++ b/frontend/src/onboarding/DeviceCodeCard.jsx
@@ -7,14 +7,17 @@
 // `font-mono` instead, per the precedent set in shell/StatusPill.jsx.
 import { useEffect, useRef, useState } from 'react'
 import { getAuthStatus } from '../api.js'
+import RetryCard from './RetryCard.jsx'
 
 const AUTHORIZED_ADVANCE_DELAY_MS = 800
 const COPIED_LABEL_DURATION_MS = 2000
+const CROSSFADE_DURATION_MS = 300
 
 function DeviceCodeCard({ userCode, verificationUri, interval, onAuthorized, onRestart }) {
   const [state, setState] = useState('pending')
   const [login, setLogin] = useState(null)
   const [copied, setCopied] = useState(false)
+  const [authorizedVisible, setAuthorizedVisible] = useState(false)
   const timerRef = useRef(null)
 
   useEffect(() => {
@@ -53,6 +56,14 @@ function DeviceCodeCard({ userCode, verificationUri, interval, onAuthorized, onR
     }
   }, [interval, onAuthorized])
 
+  useEffect(() => {
+    if (state !== 'authorized') return
+    // Two Tailwind transition utilities, no custom keyframes — start
+    // transparent, flip to opaque next frame so the CSS transition runs.
+    const raf = requestAnimationFrame(() => setAuthorizedVisible(true))
+    return () => cancelAnimationFrame(raf)
+  }, [state])
+
   function handleCopy() {
     navigator.clipboard?.writeText(userCode)
     setCopied(true)
@@ -61,54 +72,35 @@ function DeviceCodeCard({ userCode, verificationUri, interval, onAuthorized, onR
 
   if (state === 'authorized') {
     return (
-      <div role="status" className="rounded-xl bg-panel p-4 text-ink">
+      <div
+        role="status"
+        className={`rounded-xl bg-panel p-4 text-ink transition-opacity duration-300 ${
+          authorizedVisible ? 'opacity-100' : 'opacity-0'
+        }`}
+        style={{ transitionDuration: `${CROSSFADE_DURATION_MS}ms` }}
+      >
         ✓ Connected as {login}
       </div>
     )
   }
 
   if (state === 'expired') {
-    return (
-      <div className="rounded-xl bg-panel p-4">
-        <p className="text-ink-muted text-sm">Code expired.</p>
-        <button
-          type="button"
-          onClick={onRestart}
-          className="mt-2 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
-        >
-          Get a new code
-        </button>
-      </div>
-    )
+    return <RetryCard message="Code expired." buttonLabel="Get a new code" onRetry={onRestart} />
   }
 
   if (state === 'denied') {
-    return (
-      <div className="rounded-xl bg-panel p-4">
-        <p className="text-danger text-sm">Authorization was denied.</p>
-        <button
-          type="button"
-          onClick={onRestart}
-          className="mt-2 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
-        >
-          Retry
-        </button>
-      </div>
-    )
+    return <RetryCard message="Authorization was denied." messageTone="danger" onRetry={onRestart} />
   }
 
   if (state === 'network-error') {
     return (
-      <div className="rounded-xl bg-panel p-4 border border-danger">
-        <p className="text-danger text-sm">Could not reach the backend. Is it running?</p>
-        <button
-          type="button"
-          onClick={onRestart}
-          className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
-        >
-          Retry
-        </button>
-      </div>
+      <RetryCard
+        message="Could not reach the backend. Is it running?"
+        messageTone="danger"
+        bordered
+        buttonTone="danger"
+        onRetry={onRestart}
+      />
     )
   }
 

--- a/frontend/src/onboarding/DeviceCodeCard.test.jsx
+++ b/frontend/src/onboarding/DeviceCodeCard.test.jsx
@@ -1,0 +1,138 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAuthStatus } from '../api.js'
+import DeviceCodeCard from './DeviceCodeCard.jsx'
+
+vi.mock('../api.js', () => ({ getAuthStatus: vi.fn() }))
+
+function renderCard(props = {}) {
+  return render(
+    <DeviceCodeCard
+      userCode="WDJB-MJHT"
+      verificationUri="https://github.com/login/device"
+      interval={5}
+      onAuthorized={vi.fn()}
+      onRestart={vi.fn()}
+      {...props}
+    />,
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('DeviceCodeCard', () => {
+  it('renders the user code and verification link while pending', async () => {
+    getAuthStatus.mockResolvedValue({ state: 'pending' })
+    renderCard()
+
+    expect(screen.getByText('WDJB-MJHT')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /open github.com\/login\/device/i })).toHaveAttribute(
+      'href',
+      'https://github.com/login/device',
+    )
+  })
+
+  it('polls status at the given interval and keeps polling while pending', async () => {
+    getAuthStatus.mockResolvedValue({ state: 'pending' })
+    renderCard()
+
+    expect(getAuthStatus).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(getAuthStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('transitions to authorized and advances after the delay', async () => {
+    const onAuthorized = vi.fn()
+    getAuthStatus.mockResolvedValue({ state: 'authorized', login: 'octocat' })
+    renderCard({ onAuthorized })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('✓ Connected as octocat')
+    expect(onAuthorized).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800)
+    })
+    expect(onAuthorized).toHaveBeenCalledWith('octocat')
+  })
+
+  it('stops polling and offers a retry when the code expires', async () => {
+    getAuthStatus.mockResolvedValue({ state: 'expired' })
+    const onRestart = vi.fn()
+    renderCard({ onRestart })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Code expired.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Get a new code' }))
+    expect(onRestart).toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000)
+    })
+    expect(getAuthStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a denied message with a retry button', async () => {
+    getAuthStatus.mockResolvedValue({ state: 'denied' })
+    const onRestart = vi.fn()
+    renderCard({ onRestart })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Authorization was denied.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRestart).toHaveBeenCalled()
+  })
+
+  it('shows a network error with a retry button when polling fails', async () => {
+    getAuthStatus.mockRejectedValue(new Error('network down'))
+    const onRestart = vi.fn()
+    renderCard({ onRestart })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Could not reach the backend. Is it running?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRestart).toHaveBeenCalled()
+  })
+
+  it('copies the code and shows Copied for a moment', async () => {
+    getAuthStatus.mockResolvedValue({ state: 'pending' })
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } })
+    renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy code' }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('WDJB-MJHT')
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(screen.getByText('Copy')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/onboarding/IndexStep.jsx
+++ b/frontend/src/onboarding/IndexStep.jsx
@@ -1,8 +1,14 @@
 // Onboarding step 3: kicks off the first index run and shows live
 // progress. RepoPickerStep already saved the chosen repos via PATCH
-// /config, so POST /ingest is called with no body — the backend defaults
-// to the configured indexed_repos. `repos` is only needed here to know
-// which IndexProgress rows to render before the first status poll lands.
+// /config, but UI-DESIGN.md is explicit that this step's own action is
+// `POST /ingest {repos}` — pass them explicitly rather than relying on
+// the backend's indexed_repos fallback matching by coincidence.
+//
+// Per UI-DESIGN.md's Step 3 spec: "Start asking" appears the moment the
+// first repo completes (others keep indexing in the background) and
+// never blocks on a partial failure if >=1 repo succeeded. Also
+// auto-advances once the whole run finishes cleanly, so a user who
+// doesn't notice the button isn't stuck.
 import { useEffect, useRef } from 'react'
 import { postIngest } from '../api.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
@@ -12,11 +18,12 @@ function IndexStep({ repos, onComplete }) {
   const { status, refetch } = useIngestStatus()
   const wasActiveRef = useRef(false)
   const startedRef = useRef(false)
+  const advancedRef = useRef(false)
 
   useEffect(() => {
     if (startedRef.current) return
     startedRef.current = true
-    postIngest().then(refetch)
+    postIngest({ repos }).then(refetch)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -29,11 +36,19 @@ function IndexStep({ repos, onComplete }) {
     }
 
     const hasFailure = status.repos.some((repo) => repo.phase === 'failed')
-    if (wasActiveRef.current && !hasFailure) {
+    if (wasActiveRef.current && !hasFailure && !advancedRef.current) {
+      advancedRef.current = true
       onComplete()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status])
+
+  function handleStartAsking() {
+    advancedRef.current = true
+    onComplete()
+  }
+
+  const canStartAsking = status?.repos.some((repo) => repo.phase === 'done') ?? false
 
   return (
     <div className="mx-auto max-w-xl">
@@ -43,6 +58,15 @@ function IndexStep({ repos, onComplete }) {
           <IndexProgress key={repo} repo={repo} />
         ))}
       </div>
+      {canStartAsking && (
+        <button
+          type="button"
+          onClick={handleStartAsking}
+          className="mt-4 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
+        >
+          Start asking
+        </button>
+      )}
     </div>
   )
 }

--- a/frontend/src/onboarding/IndexStep.jsx
+++ b/frontend/src/onboarding/IndexStep.jsx
@@ -1,0 +1,50 @@
+// Onboarding step 3: kicks off the first index run and shows live
+// progress. RepoPickerStep already saved the chosen repos via PATCH
+// /config, so POST /ingest is called with no body — the backend defaults
+// to the configured indexed_repos. `repos` is only needed here to know
+// which IndexProgress rows to render before the first status poll lands.
+import { useEffect, useRef } from 'react'
+import { postIngest } from '../api.js'
+import { useIngestStatus } from '../lib/useIngestStatus.js'
+import IndexProgress from '../library/IndexProgress.jsx'
+
+function IndexStep({ repos, onComplete }) {
+  const { status, refetch } = useIngestStatus()
+  const wasActiveRef = useRef(false)
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+    postIngest().then(refetch)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (!status) return
+
+    if (status.active) {
+      wasActiveRef.current = true
+      return
+    }
+
+    const hasFailure = status.repos.some((repo) => repo.phase === 'failed')
+    if (wasActiveRef.current && !hasFailure) {
+      onComplete()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status])
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <h1 className="text-lg text-ink">Reading your history.</h1>
+      <div className="mt-4 space-y-4">
+        {repos.map((repo) => (
+          <IndexProgress key={repo} repo={repo} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default IndexStep

--- a/frontend/src/onboarding/IndexStep.test.jsx
+++ b/frontend/src/onboarding/IndexStep.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { postIngest } from '../api.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
@@ -12,13 +12,14 @@ function mockStatus(status) {
 }
 
 describe('IndexStep', () => {
-  it('triggers POST /ingest on mount', () => {
+  it('triggers POST /ingest on mount with the chosen repo list', () => {
     postIngest.mockResolvedValue({ job_id: 'abc' })
     mockStatus(null)
 
-    render(<IndexStep repos={['owner/repo-a']} onComplete={vi.fn()} />)
+    render(<IndexStep repos={['owner/repo-a', 'owner/repo-b']} onComplete={vi.fn()} />)
 
     expect(postIngest).toHaveBeenCalledTimes(1)
+    expect(postIngest).toHaveBeenCalledWith({ repos: ['owner/repo-a', 'owner/repo-b'] })
   })
 
   it('renders IndexProgress for each chosen repo', () => {
@@ -82,5 +83,49 @@ describe('IndexStep', () => {
     render(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
 
     expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('shows a Start asking button as soon as one repo finishes, even while others are still active', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    mockStatus({
+      active: true,
+      repos: [
+        { repo: 'owner/repo-a', phase: 'done', counts: { fetched: 5, extracted: 5, skipped: 0, stored: 5 } },
+        { repo: 'owner/repo-b', phase: 'fetching', counts: { fetched: 3, extracted: 0, skipped: 0, stored: 0 } },
+      ],
+    })
+
+    render(<IndexStep repos={['owner/repo-a', 'owner/repo-b']} onComplete={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Start asking' })).toBeInTheDocument()
+  })
+
+  it('clicking Start asking advances immediately without waiting for the rest', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    const onComplete = vi.fn()
+    mockStatus({
+      active: true,
+      repos: [
+        { repo: 'owner/repo-a', phase: 'done', counts: { fetched: 5, extracted: 5, skipped: 0, stored: 5 } },
+        { repo: 'owner/repo-b', phase: 'fetching', counts: { fetched: 3, extracted: 0, skipped: 0, stored: 0 } },
+      ],
+    })
+
+    render(<IndexStep repos={['owner/repo-a', 'owner/repo-b']} onComplete={onComplete} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Start asking' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show Start asking before any repo has finished', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    mockStatus({
+      active: true,
+      repos: [{ repo: 'owner/repo-a', phase: 'fetching', counts: { fetched: 5, extracted: 0, skipped: 0, stored: 0 } }],
+    })
+
+    render(<IndexStep repos={['owner/repo-a']} onComplete={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: 'Start asking' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/onboarding/IndexStep.test.jsx
+++ b/frontend/src/onboarding/IndexStep.test.jsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { postIngest } from '../api.js'
+import { useIngestStatus } from '../lib/useIngestStatus.js'
+import IndexStep from './IndexStep.jsx'
+
+vi.mock('../api.js', () => ({ postIngest: vi.fn() }))
+vi.mock('../lib/useIngestStatus.js', () => ({ useIngestStatus: vi.fn() }))
+
+function mockStatus(status) {
+  useIngestStatus.mockReturnValue({ status, refetch: vi.fn() })
+}
+
+describe('IndexStep', () => {
+  it('triggers POST /ingest on mount', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    mockStatus(null)
+
+    render(<IndexStep repos={['owner/repo-a']} onComplete={vi.fn()} />)
+
+    expect(postIngest).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders IndexProgress for each chosen repo', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    mockStatus({
+      active: true,
+      repos: [{ repo: 'owner/repo-a', phase: 'fetching', counts: { fetched: 10, extracted: 0, skipped: 0, stored: 0 } }],
+    })
+
+    render(<IndexStep repos={['owner/repo-a']} onComplete={vi.fn()} />)
+
+    expect(screen.getByText('Reading commits — 10 examined')).toBeInTheDocument()
+  })
+
+  it('advances once the job finishes with no failures', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    const onComplete = vi.fn()
+    mockStatus({
+      active: true,
+      repos: [{ repo: 'owner/repo-a', phase: 'fetching', counts: { fetched: 10, extracted: 0, skipped: 0, stored: 0 } }],
+    })
+
+    const { rerender } = render(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
+    expect(onComplete).not.toHaveBeenCalled()
+
+    mockStatus({
+      active: false,
+      repos: [{ repo: 'owner/repo-a', phase: 'done', counts: { fetched: 10, extracted: 10, skipped: 0, stored: 10 } }],
+    })
+    rerender(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not advance if a repo failed', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    const onComplete = vi.fn()
+    mockStatus({
+      active: true,
+      repos: [{ repo: 'owner/repo-a', phase: 'fetching', counts: { fetched: 10, extracted: 0, skipped: 0, stored: 0 } }],
+    })
+
+    const { rerender } = render(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
+
+    mockStatus({
+      active: false,
+      repos: [
+        { repo: 'owner/repo-a', phase: 'failed', counts: { fetched: 10, extracted: 0, skipped: 0, stored: 0 }, error: 'boom' },
+      ],
+    })
+    rerender(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
+
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('does not advance when the job never reported active before going idle', () => {
+    postIngest.mockResolvedValue({ job_id: 'abc' })
+    const onComplete = vi.fn()
+    mockStatus({ active: false, repos: [] })
+
+    render(<IndexStep repos={['owner/repo-a']} onComplete={onComplete} />)
+
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/onboarding/RepoPickerRow.jsx
+++ b/frontend/src/onboarding/RepoPickerRow.jsx
@@ -1,9 +1,24 @@
 // One row in onboarding step 2's repo list: checkbox + owner/name +
-// private badge + a commit-count hint from GitHub's estimate.
+// private-lock icon + a commit-count/time hint from GitHub's estimate.
+
+// Rough ingestion-time heuristic (local extraction + embedding per
+// commit) — not a measured figure, tune once real timing data exists.
+const SECONDS_PER_COMMIT_ESTIMATE = 0.4
+
 function formatCommitEstimate(count) {
   if (count == null) return null
-  if (count >= 1000) return `~${(count / 1000).toFixed(1)}k commits`
-  return `${count} commit${count === 1 ? '' : 's'}`
+  const commits = count >= 1000 ? `~${(count / 1000).toFixed(1)}k commits` : `${count} commit${count === 1 ? '' : 's'}`
+  const minutes = Math.max(1, Math.round((count * SECONDS_PER_COMMIT_ESTIMATE) / 60))
+  return `${commits} · est. ${minutes} min`
+}
+
+function LockIcon(props) {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" width="14" height="14" {...props}>
+      <rect x="5" y="9" width="10" height="7" rx="1.5" />
+      <path d="M7 9V6.5a3 3 0 016 0V9" strokeLinecap="round" />
+    </svg>
+  )
 }
 
 function RepoPickerRow({ repo, selected, onToggle }) {
@@ -13,7 +28,7 @@ function RepoPickerRow({ repo, selected, onToggle }) {
     <label className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-surface cursor-pointer">
       <input type="checkbox" checked={selected} onChange={() => onToggle(repo.name)} />
       <span className="font-mono text-sm text-ink">{repo.name}</span>
-      {repo.private && <span className="rounded bg-surface text-ink-muted text-xs px-1.5 py-0.5">Private</span>}
+      {repo.private && <LockIcon aria-label="Private" className="text-ink-muted shrink-0" />}
       {estimate && <span className="ml-auto text-sm text-ink-muted">{estimate}</span>}
     </label>
   )

--- a/frontend/src/onboarding/RepoPickerRow.jsx
+++ b/frontend/src/onboarding/RepoPickerRow.jsx
@@ -1,0 +1,22 @@
+// One row in onboarding step 2's repo list: checkbox + owner/name +
+// private badge + a commit-count hint from GitHub's estimate.
+function formatCommitEstimate(count) {
+  if (count == null) return null
+  if (count >= 1000) return `~${(count / 1000).toFixed(1)}k commits`
+  return `${count} commit${count === 1 ? '' : 's'}`
+}
+
+function RepoPickerRow({ repo, selected, onToggle }) {
+  const estimate = formatCommitEstimate(repo.commit_count_estimate)
+
+  return (
+    <label className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-surface cursor-pointer">
+      <input type="checkbox" checked={selected} onChange={() => onToggle(repo.name)} />
+      <span className="font-mono text-sm text-ink">{repo.name}</span>
+      {repo.private && <span className="rounded bg-surface text-ink-muted text-xs px-1.5 py-0.5">Private</span>}
+      {estimate && <span className="ml-auto text-sm text-ink-muted">{estimate}</span>}
+    </label>
+  )
+}
+
+export default RepoPickerRow

--- a/frontend/src/onboarding/RepoPickerRow.test.jsx
+++ b/frontend/src/onboarding/RepoPickerRow.test.jsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import RepoPickerRow from './RepoPickerRow.jsx'
+
+describe('RepoPickerRow', () => {
+  it('renders the repo name and commit estimate', () => {
+    render(
+      <RepoPickerRow
+        repo={{ name: 'owner/repo', private: false, commit_count_estimate: 42 }}
+        selected={false}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('owner/repo')).toBeInTheDocument()
+    expect(screen.getByText('42 commits')).toBeInTheDocument()
+    expect(screen.queryByText('Private')).not.toBeInTheDocument()
+  })
+
+  it('abbreviates large commit counts', () => {
+    render(
+      <RepoPickerRow
+        repo={{ name: 'owner/repo', private: false, commit_count_estimate: 1200 }}
+        selected={false}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('~1.2k commits')).toBeInTheDocument()
+  })
+
+  it('shows a private badge for private repos', () => {
+    render(
+      <RepoPickerRow
+        repo={{ name: 'owner/repo', private: true, commit_count_estimate: 1 }}
+        selected={false}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Private')).toBeInTheDocument()
+  })
+
+  it('calls onToggle with the repo name when the checkbox changes', () => {
+    const onToggle = vi.fn()
+    render(
+      <RepoPickerRow
+        repo={{ name: 'owner/repo', private: false, commit_count_estimate: 1 }}
+        selected={false}
+        onToggle={onToggle}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(onToggle).toHaveBeenCalledWith('owner/repo')
+  })
+
+  it('reflects the selected state on the checkbox', () => {
+    render(
+      <RepoPickerRow
+        repo={{ name: 'owner/repo', private: false, commit_count_estimate: 1 }}
+        selected
+        onToggle={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('checkbox')).toBeChecked()
+  })
+})

--- a/frontend/src/onboarding/RepoPickerRow.test.jsx
+++ b/frontend/src/onboarding/RepoPickerRow.test.jsx
@@ -13,11 +13,11 @@ describe('RepoPickerRow', () => {
     )
 
     expect(screen.getByText('owner/repo')).toBeInTheDocument()
-    expect(screen.getByText('42 commits')).toBeInTheDocument()
-    expect(screen.queryByText('Private')).not.toBeInTheDocument()
+    expect(screen.getByText('42 commits · est. 1 min')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Private')).not.toBeInTheDocument()
   })
 
-  it('abbreviates large commit counts', () => {
+  it('abbreviates large commit counts and estimates minutes', () => {
     render(
       <RepoPickerRow
         repo={{ name: 'owner/repo', private: false, commit_count_estimate: 1200 }}
@@ -26,10 +26,10 @@ describe('RepoPickerRow', () => {
       />,
     )
 
-    expect(screen.getByText('~1.2k commits')).toBeInTheDocument()
+    expect(screen.getByText('~1.2k commits · est. 8 min')).toBeInTheDocument()
   })
 
-  it('shows a private badge for private repos', () => {
+  it('shows a lock icon for private repos', () => {
     render(
       <RepoPickerRow
         repo={{ name: 'owner/repo', private: true, commit_count_estimate: 1 }}
@@ -38,7 +38,7 @@ describe('RepoPickerRow', () => {
       />,
     )
 
-    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.getByLabelText('Private')).toBeInTheDocument()
   })
 
   it('calls onToggle with the repo name when the checkbox changes', () => {

--- a/frontend/src/onboarding/RepoPickerStep.jsx
+++ b/frontend/src/onboarding/RepoPickerStep.jsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react'
 import { getGithubRepos, patchConfig } from '../api.js'
 import RepoPickerRow from './RepoPickerRow.jsx'
+import RetryCard from './RetryCard.jsx'
 
 const SEARCH_DEBOUNCE_MS = 300
 
@@ -74,16 +75,13 @@ function RepoPickerStep({ onNext }) {
           ))}
 
         {repos === 'error' && (
-          <div className="rounded-xl border border-danger p-4">
-            <p className="text-sm text-danger">Couldn't load your repos.</p>
-            <button
-              type="button"
-              onClick={() => setAttempt((a) => a + 1)}
-              className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
-            >
-              Retry
-            </button>
-          </div>
+          <RetryCard
+            message="Couldn't load your repos."
+            messageTone="danger"
+            bordered
+            buttonTone="danger"
+            onRetry={() => setAttempt((a) => a + 1)}
+          />
         )}
 
         {Array.isArray(repos) && repos.length === 0 && (
@@ -105,6 +103,23 @@ function RepoPickerStep({ onNext }) {
       >
         Index {selected.length} repo{selected.length === 1 ? '' : 's'}
       </button>
+
+      {/* GitHub gives no reliable signal to detect org-restricted access —
+          restricted repos are just silently absent from the list, not an
+          error. Shown as a standing footnote rather than a fake detected
+          state until there's a real way to tell the two cases apart. */}
+      <p className="mt-2 text-sm text-ink-muted">
+        Missing a repo?{' '}
+        <a
+          href="https://github.com/settings/connections/applications"
+          target="_blank"
+          rel="noreferrer"
+          className="text-accent"
+        >
+          Check your organization's access settings
+        </a>
+        .
+      </p>
     </div>
   )
 }

--- a/frontend/src/onboarding/RepoPickerStep.jsx
+++ b/frontend/src/onboarding/RepoPickerStep.jsx
@@ -1,0 +1,112 @@
+// Onboarding step 2: pick which repos to index. Fetches GET
+// /github/repos (debounced on search), lets the user multi-select, and
+// submits the choice via PATCH /config — kicking off the actual ingest
+// run is IndexStep's job (step 3), not this one.
+import { useEffect, useState } from 'react'
+import { getGithubRepos, patchConfig } from '../api.js'
+import RepoPickerRow from './RepoPickerRow.jsx'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+function RepoPickerStep({ onNext }) {
+  const [query, setQuery] = useState('')
+  const [repos, setRepos] = useState(undefined)
+  const [selected, setSelected] = useState([])
+  const [submitting, setSubmitting] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    function fetchRepos() {
+      getGithubRepos(query ? { query } : {})
+        .then((result) => {
+          if (!cancelled) setRepos(result.repos)
+        })
+        .catch(() => {
+          if (!cancelled) setRepos('error')
+        })
+    }
+
+    setRepos(undefined)
+    const timer = setTimeout(fetchRepos, query ? SEARCH_DEBOUNCE_MS : 0)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [query, attempt])
+
+  function toggle(name) {
+    setSelected((current) => (current.includes(name) ? current.filter((r) => r !== name) : [...current, name]))
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true)
+    try {
+      await patchConfig({ indexed_repos: selected })
+      onNext(selected)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <h1 className="text-lg text-ink">Which repos should adr-engine read?</h1>
+      <p className="text-sm text-ink-muted">
+        Extraction runs on your local Ollama — repo contents never leave this machine.
+      </p>
+
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Search repos"
+        aria-label="Search repos"
+        className="mt-4 w-full rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+      />
+
+      <div className="mt-2">
+        {repos === undefined &&
+          Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="mb-1.5 h-9 animate-pulse rounded-lg bg-surface" />
+          ))}
+
+        {repos === 'error' && (
+          <div className="rounded-xl border border-danger p-4">
+            <p className="text-sm text-danger">Couldn't load your repos.</p>
+            <button
+              type="button"
+              onClick={() => setAttempt((a) => a + 1)}
+              className="mt-2 rounded-lg bg-danger text-white text-sm font-semibold px-4 py-2"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {Array.isArray(repos) && repos.length === 0 && (
+          <p className="text-sm text-ink-muted">{query ? 'No repos match.' : 'No repos found for this account.'}</p>
+        )}
+
+        {Array.isArray(repos) &&
+          repos.length > 0 &&
+          repos.map((repo) => (
+            <RepoPickerRow key={repo.name} repo={repo} selected={selected.includes(repo.name)} onToggle={toggle} />
+          ))}
+      </div>
+
+      <button
+        type="button"
+        disabled={selected.length === 0 || submitting}
+        onClick={handleSubmit}
+        className="mt-4 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2 disabled:opacity-50"
+      >
+        Index {selected.length} repo{selected.length === 1 ? '' : 's'}
+      </button>
+    </div>
+  )
+}
+
+export default RepoPickerStep

--- a/frontend/src/onboarding/RepoPickerStep.test.jsx
+++ b/frontend/src/onboarding/RepoPickerStep.test.jsx
@@ -1,0 +1,90 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getGithubRepos, patchConfig } from '../api.js'
+import RepoPickerStep from './RepoPickerStep.jsx'
+
+vi.mock('../api.js', () => ({ getGithubRepos: vi.fn(), patchConfig: vi.fn() }))
+
+const repos = [
+  { name: 'owner/repo-a', private: false, commit_count_estimate: 42 },
+  { name: 'owner/repo-b', private: true, commit_count_estimate: 5 },
+]
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+  })
+}
+
+describe('RepoPickerStep', () => {
+  it('fetches and renders repos on mount', async () => {
+    getGithubRepos.mockResolvedValue({ repos })
+    render(<RepoPickerStep onNext={vi.fn()} />)
+
+    await flush()
+
+    expect(getGithubRepos).toHaveBeenCalledWith({})
+    expect(screen.getByText('owner/repo-a')).toBeInTheDocument()
+    expect(screen.getByText('owner/repo-b')).toBeInTheDocument()
+  })
+
+  it('renders the empty state when the fetch returns no repos', async () => {
+    getGithubRepos.mockResolvedValue({ repos: [] })
+    render(<RepoPickerStep onNext={vi.fn()} />)
+
+    await flush()
+
+    expect(screen.getByText('No repos found for this account.')).toBeInTheDocument()
+  })
+
+  it('toggles selection per row and submits the selected repos via PATCH /config', async () => {
+    getGithubRepos.mockResolvedValue({ repos })
+    patchConfig.mockResolvedValue({})
+    const onNext = vi.fn()
+    render(<RepoPickerStep onNext={onNext} />)
+
+    await flush()
+
+    const continueButton = screen.getByRole('button', { name: /^Index/ })
+    expect(continueButton).toBeDisabled()
+
+    fireEvent.click(screen.getAllByRole('checkbox')[0])
+    expect(continueButton).toBeEnabled()
+    expect(continueButton).toHaveTextContent('Index 1 repo')
+
+    fireEvent.click(continueButton)
+    await flush()
+
+    expect(patchConfig).toHaveBeenCalledWith({ indexed_repos: ['owner/repo-a'] })
+    expect(onNext).toHaveBeenCalledWith(['owner/repo-a'])
+  })
+
+  it('debounces the search query before re-fetching', async () => {
+    getGithubRepos.mockResolvedValue({ repos })
+    render(<RepoPickerStep onNext={vi.fn()} />)
+    await flush()
+    getGithubRepos.mockClear()
+
+    fireEvent.change(screen.getByLabelText('Search repos'), { target: { value: 'repo-a' } })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299)
+    })
+    expect(getGithubRepos).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(getGithubRepos).toHaveBeenCalledWith({ query: 'repo-a' })
+  })
+})

--- a/frontend/src/onboarding/RetryCard.jsx
+++ b/frontend/src/onboarding/RetryCard.jsx
@@ -1,0 +1,22 @@
+// Shared shape for onboarding's several "something went wrong, retry"
+// states (UI-DESIGN.md names this the "ErrorCard pattern"). Used by
+// ConnectStep, DeviceCodeCard, and RepoPickerStep instead of each
+// hand-rolling its own panel/message/button markup.
+function RetryCard({ message, messageTone = 'muted', bordered = false, buttonLabel = 'Retry', buttonTone = 'accent', onRetry }) {
+  return (
+    <div className={`rounded-xl bg-panel p-4 ${bordered ? 'border border-danger' : ''}`}>
+      <p className={`text-sm ${messageTone === 'danger' ? 'text-danger' : 'text-ink-muted'}`}>{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className={`mt-2 rounded-lg text-white text-sm font-semibold px-4 py-2 ${
+          buttonTone === 'danger' ? 'bg-danger' : 'bg-accent'
+        }`}
+      >
+        {buttonLabel}
+      </button>
+    </div>
+  )
+}
+
+export default RetryCard


### PR DESCRIPTION
## Summary
- Adds the three onboarding step components from UI-DESIGN.md's onboarding flow, each with its own tests.
- `ConnectStep` + `DeviceCodeCard`: starts the GitHub device flow and polls `/auth/github/status` through pending/authorized/expired/denied/network-error states.
- `RepoPickerStep` + `RepoPickerRow`: fetches `/github/repos` (debounced search), multi-select, submits the chosen repos via `PATCH /config`.
- `IndexStep`: kicks off `POST /ingest` on mount and advances once `useIngestStatus` reports the job finished with no failures.
- Extends `frontend/src/api.js` with the device-flow, GitHub repos, config-patch, and ingest-trigger helpers these steps need.

Closes #68
Closes #69
Closes #70

## Changelog
- frontend: add device-flow API helpers + ConnectStep/DeviceCodeCard, with tests
- frontend: add RepoPickerStep/RepoPickerRow, with tests
- frontend: add IndexStep, with tests

## Test plan
- [x] `npm test` (96 tests passing)
- [x] `npm run lint`

## Review fixes (43c952e)

`/code-review` (Standards + Spec) and `/ponytail:ponytail-review` found:
- **Spec, the real bug**: `IndexStep` never actually passed a repo list to `POST /ingest` — it called `postIngest()` with an empty body, relying implicitly on `RepoPickerStep`'s earlier `PATCH /config` write. Worse, backend `IngestRequest` only supported a single `repo: str`, not a list, so issue #70's own acceptance criterion was unsatisfiable against the real API. UI-DESIGN.md is explicit the action here is `POST /ingest {repos}` — added `repos: list[str] | None` to `IngestRequest` and wired it through end to end. Also fixed the test that asserted call count but not arguments.
- **Standards**: `IndexStep` was missing UI-DESIGN.md's "Start asking" early-exit (appears once the *first* repo finishes, doesn't block on the rest). `RepoPickerRow` swapped its text "Private" badge for the specified lock icon and added the missing `· est. N min` half of the commit hint. `RepoPickerStep` gained an org-restricted footnote (GitHub gives no reliable signal to actually detect this — it's a standing footnote, not a fake conditional state). `DeviceCodeCard` gained the 300ms crossfade on the authorized state.
- **Ponytail**: extracted `RetryCard`, replacing four hand-copied error/retry blocks across `ConnectStep`, `DeviceCodeCard`, and `RepoPickerStep` — UI-DESIGN.md itself calls this the "ErrorCard pattern."

154/154 backend tests, 99/99 frontend tests pass. Build and lint clean.
