### PR TITLE
Onboarding Gemini step, editorial tokens, citation components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/source-serif-4": "^5.3.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.1"
@@ -323,6 +324,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/source-serif-4": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.3.0.tgz",
+      "integrity": "sha512-9vch9WqxjaaA+1o9Ur8pOgIGbCYLjRReOUel23A6lOpD1syptgjtkORevvNmldJ5kGXQL29onQUqI5Ltz0s3bQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fontsource-variable/source-serif-4": "^5.3.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1"

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -11,28 +11,27 @@ function parseAnswer(answer, citations) {
   const numberById = new Map()
   const parts = []
   let lastIndex = 0
-  let key = 0
   let match
 
   CITATION_PATTERN.lastIndex = 0
   while ((match = CITATION_PATTERN.exec(answer)) !== null) {
     if (match.index > lastIndex) {
-      parts.push({ type: 'text', key: key++, value: answer.slice(lastIndex, match.index) })
+      parts.push({ type: 'text', key: parts.length, value: answer.slice(lastIndex, match.index) })
     }
 
     const unitId = match[1]
     if (!knownIds.has(unitId)) {
-      parts.push({ type: 'text', key: key++, value: match[0] })
+      parts.push({ type: 'text', key: parts.length, value: match[0] })
     } else {
       if (!numberById.has(unitId)) numberById.set(unitId, numberById.size + 1)
-      parts.push({ type: 'marker', key: key++, number: numberById.get(unitId), unitId })
+      parts.push({ type: 'marker', key: parts.length, number: numberById.get(unitId), unitId })
     }
 
     lastIndex = CITATION_PATTERN.lastIndex
   }
 
   if (lastIndex < answer.length) {
-    parts.push({ type: 'text', key: key++, value: answer.slice(lastIndex) })
+    parts.push({ type: 'text', key: parts.length, value: answer.slice(lastIndex) })
   }
 
   return parts

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -1,0 +1,57 @@
+// The reading room's answer prose: serif body text with inline
+// CitationMarkers parsed from `[unit-id]` markers in the raw answer
+// string. Numbering follows parse order of first appearance in the
+// text itself (per UI-DESIGN.md), not citations' array order.
+import CitationMarker from './CitationMarker.jsx'
+
+const CITATION_PATTERN = /\[([^[\]]+)\]/g
+
+function parseAnswer(answer, citations) {
+  const knownIds = new Set(citations.map((unit) => unit.id))
+  const numberById = new Map()
+  const parts = []
+  let lastIndex = 0
+  let key = 0
+  let match
+
+  CITATION_PATTERN.lastIndex = 0
+  while ((match = CITATION_PATTERN.exec(answer)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', key: key++, value: answer.slice(lastIndex, match.index) })
+    }
+
+    const unitId = match[1]
+    if (!knownIds.has(unitId)) {
+      parts.push({ type: 'text', key: key++, value: match[0] })
+    } else {
+      if (!numberById.has(unitId)) numberById.set(unitId, numberById.size + 1)
+      parts.push({ type: 'marker', key: key++, number: numberById.get(unitId), unitId })
+    }
+
+    lastIndex = CITATION_PATTERN.lastIndex
+  }
+
+  if (lastIndex < answer.length) {
+    parts.push({ type: 'text', key: key++, value: answer.slice(lastIndex) })
+  }
+
+  return parts
+}
+
+function AnswerPassage({ answer, citations }) {
+  const parts = parseAnswer(answer, citations)
+
+  return (
+    <p className="font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch]">
+      {parts.map((part) =>
+        part.type === 'marker' ? (
+          <CitationMarker key={part.key} number={part.number} unitId={part.unitId} />
+        ) : (
+          <span key={part.key}>{part.value}</span>
+        ),
+      )}
+    </p>
+  )
+}
+
+export default AnswerPassage

--- a/frontend/src/ask/AnswerPassage.test.jsx
+++ b/frontend/src/ask/AnswerPassage.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AnswerPassage from './AnswerPassage.jsx'
+
+const citations = [
+  { id: 'unit-a', url: 'https://github.com/owner/repo/pull/1' },
+  { id: 'unit-b', url: 'https://github.com/owner/repo/commit/abc' },
+]
+
+describe('AnswerPassage', () => {
+  it('renders the answer text', () => {
+    render(<AnswerPassage answer="We use OAuth2 for auth [unit-a]." citations={citations} />)
+
+    expect(screen.getByText(/We use OAuth2 for auth/)).toBeInTheDocument()
+  })
+
+  it('renders citation markers numbered by first appearance in the text', () => {
+    render(
+      <AnswerPassage
+        answer="Redis was chosen [unit-b] over Postgres, first proposed [unit-a]."
+        citations={citations}
+      />,
+    )
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(2)
+    expect(links[0]).toHaveAccessibleName('Jump to source 1')
+    expect(links[0]).toHaveTextContent('1')
+    expect(links[1]).toHaveAccessibleName('Jump to source 2')
+    expect(links[1]).toHaveTextContent('2')
+  })
+
+  it('reuses the same marker number when a citation repeats', () => {
+    render(<AnswerPassage answer="[unit-a] and again [unit-a]." citations={citations} />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(2)
+    expect(links[0]).toHaveAccessibleName('Jump to source 1')
+    expect(links[1]).toHaveAccessibleName('Jump to source 1')
+  })
+
+  it('renders unresolved bracket text as plain text, not a marker', () => {
+    render(<AnswerPassage answer="Mentioned [not-a-citation] here." citations={citations} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText(/\[not-a-citation\]/)).toBeInTheDocument()
+  })
+
+  it('renders no markers when there are no citations', () => {
+    render(<AnswerPassage answer="Nothing in the indexed history covers this." citations={[]} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/ask/CitationMarker.jsx
+++ b/frontend/src/ask/CitationMarker.jsx
@@ -1,0 +1,25 @@
+// Superscript inline citation marker. Its href/id contract
+// (`#source-{unitId}` / `source-{unitId}`) is what the SourceCard (next
+// issue) will implement — this component only needs to hold up its end
+// of it.
+function CitationMarker({ number, unitId }) {
+  function handleClick(event) {
+    event.preventDefault()
+    document.getElementById(`source-${unitId}`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  }
+
+  return (
+    <sup>
+      <a
+        href={`#source-${unitId}`}
+        onClick={handleClick}
+        aria-label={`Jump to source ${number}`}
+        className="font-ui text-xs text-accent cursor-pointer no-underline hover:underline"
+      >
+        {number}
+      </a>
+    </sup>
+  )
+}
+
+export default CitationMarker

--- a/frontend/src/ask/CitationMarker.test.jsx
+++ b/frontend/src/ask/CitationMarker.test.jsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CitationMarker from './CitationMarker.jsx'
+
+describe('CitationMarker', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders the marker number', () => {
+    render(<CitationMarker number={2} unitId="abc123" />)
+
+    expect(screen.getByRole('link', { name: 'Jump to source 2' })).toHaveTextContent('2')
+  })
+
+  it('links to the fragment matching its source card id', () => {
+    render(<CitationMarker number={1} unitId="abc123" />)
+
+    expect(screen.getByRole('link', { name: 'Jump to source 1' })).toHaveAttribute('href', '#source-abc123')
+  })
+
+  it('clicking scrolls the matching source into view', () => {
+    render(<CitationMarker number={1} unitId="abc123" />)
+
+    const source = document.createElement('div')
+    source.id = 'source-abc123'
+    source.scrollIntoView = vi.fn()
+    document.body.appendChild(source)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Jump to source 1' }))
+
+    expect(source.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' })
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,22 +1,31 @@
 @import "tailwindcss";
+@import "@fontsource-variable/source-serif-4";
 
 @theme {
-  --color-surface: var(--color-zinc-50);
-  --color-panel: var(--color-white);
-  --color-ink: var(--color-zinc-900);
-  --color-ink-muted: var(--color-zinc-500);
-  --color-accent: var(--color-indigo-600);
-  --color-danger: var(--color-red-600);
+  --color-surface: oklch(0.985 0.004 70);
+  --color-panel: oklch(1 0 0);
+  --color-ink: oklch(0.24 0.01 70);
+  --color-ink-muted: oklch(0.47 0.015 70);
+  --color-accent: oklch(0.52 0.11 60);
+  --color-accent-ink: oklch(0.99 0.005 70);
+  --color-highlight: color-mix(in oklch, var(--color-accent) 12%, transparent);
+  --color-danger: oklch(0.50 0.19 27);
+
+  --font-reading: "Source Serif 4 Variable", Georgia, serif;
+  --font-ui: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-surface: var(--color-zinc-900);
-    --color-panel: var(--color-zinc-800);
-    --color-ink: var(--color-zinc-100);
-    --color-ink-muted: var(--color-zinc-400);
-    --color-accent: var(--color-indigo-400);
-    --color-danger: var(--color-red-400);
+    --color-surface: oklch(0.185 0.008 70);
+    --color-panel: oklch(0.23 0.01 70);
+    --color-ink: oklch(0.93 0.005 70);
+    --color-ink-muted: oklch(0.70 0.015 70);
+    --color-accent: oklch(0.75 0.10 65);
+    --color-accent-ink: oklch(0.17 0.02 65);
+    --color-highlight: color-mix(in oklch, var(--color-accent) 16%, transparent);
+    --color-danger: oklch(0.70 0.17 25);
   }
 }
 

--- a/frontend/src/onboarding/GeminiKeyStep.jsx
+++ b/frontend/src/onboarding/GeminiKeyStep.jsx
@@ -1,0 +1,65 @@
+// Onboarding step 4 (optional): the last step of the flow, so unlike
+// the earlier steps it owns navigation itself rather than handing an
+// onComplete callback up to an OnboardingPage state machine (that
+// orchestrator doesn't exist yet). Per the issue's scope, this step
+// does not live-validate the key — PATCH /config already validates
+// cheaply; full validation UX belongs to Settings' GeminiSection.
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { patchConfig } from '../api.js'
+
+function GeminiKeyStep() {
+  const navigate = useNavigate()
+  const [key, setKey] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSave() {
+    setSubmitting(true)
+    try {
+      await patchConfig({ gemini_api_key: key })
+      navigate('/')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleSkip() {
+    navigate('/')
+  }
+
+  return (
+    <div className="mx-auto max-w-xl">
+      <h2 className="text-lg text-ink">Add a Gemini key to get synthesized answers (optional)</h2>
+
+      <input
+        type="password"
+        value={key}
+        onChange={(event) => setKey(event.target.value)}
+        placeholder="Gemini API key"
+        aria-label="Gemini API key"
+        className="mt-4 w-full rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+      />
+
+      <p className="mt-2 text-sm text-ink-muted">
+        Only the retrieved snippets you ask about are ever sent to Gemini.
+      </p>
+
+      <div className="mt-4 flex items-center gap-4">
+        <button
+          type="button"
+          disabled={!key || submitting}
+          onClick={handleSave}
+          className="rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2 disabled:opacity-50"
+        >
+          Save
+        </button>
+
+        <button type="button" onClick={handleSkip} className="text-sm text-ink-muted">
+          Skip for now
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default GeminiKeyStep

--- a/frontend/src/onboarding/GeminiKeyStep.jsx
+++ b/frontend/src/onboarding/GeminiKeyStep.jsx
@@ -1,30 +1,37 @@
-// Onboarding step 4 (optional): the last step of the flow, so unlike
-// the earlier steps it owns navigation itself rather than handing an
-// onComplete callback up to an OnboardingPage state machine (that
-// orchestrator doesn't exist yet). Per the issue's scope, this step
-// does not live-validate the key — PATCH /config already validates
-// cheaply; full validation UX belongs to Settings' GeminiSection.
+// Onboarding step 4 (optional, last in the flow). Advancing is the
+// caller's responsibility via onComplete, same pattern as
+// ConnectStep/RepoPickerStep/IndexStep — so this composes cleanly
+// whenever an OnboardingPage state machine wires it in, rather than
+// being a special case that owns navigation itself.
+//
+// Per the issue's scope, this step does not live-validate the key —
+// PATCH /config already validates cheaply; full validation UX belongs
+// to Settings' GeminiSection. A failed PATCH still needs *some*
+// feedback, though, so a save error is shown inline and the key is
+// kept so the user isn't forced to retype it.
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { patchConfig } from '../api.js'
 
-function GeminiKeyStep() {
-  const navigate = useNavigate()
+function GeminiKeyStep({ onComplete }) {
   const [key, setKey] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
 
   async function handleSave() {
     setSubmitting(true)
+    setError(null)
     try {
       await patchConfig({ gemini_api_key: key })
-      navigate('/')
+      onComplete()
+    } catch {
+      setError('Could not save the key. Check it and try again.')
     } finally {
       setSubmitting(false)
     }
   }
 
   function handleSkip() {
-    navigate('/')
+    onComplete()
   }
 
   return (
@@ -44,12 +51,18 @@ function GeminiKeyStep() {
         Only the retrieved snippets you ask about are ever sent to Gemini.
       </p>
 
+      {error && (
+        <p role="alert" className="mt-2 text-sm text-danger">
+          {error}
+        </p>
+      )}
+
       <div className="mt-4 flex items-center gap-4">
         <button
           type="button"
           disabled={!key || submitting}
           onClick={handleSave}
-          className="rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2 disabled:opacity-50"
+          className="rounded-lg bg-accent text-accent-ink text-sm font-semibold px-4 py-2 disabled:opacity-50"
         >
           Save
         </button>

--- a/frontend/src/onboarding/GeminiKeyStep.test.jsx
+++ b/frontend/src/onboarding/GeminiKeyStep.test.jsx
@@ -1,51 +1,55 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { patchConfig } from '../api.js'
 import GeminiKeyStep from './GeminiKeyStep.jsx'
 
 vi.mock('../api.js', () => ({ patchConfig: vi.fn() }))
 
-const navigateMock = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
-  return { ...actual, useNavigate: () => navigateMock }
-})
-
-function renderStep() {
-  return render(<GeminiKeyStep />, { wrapper: MemoryRouter })
-}
-
 beforeEach(() => {
-  navigateMock.mockClear()
   patchConfig.mockReset()
 })
 
 describe('GeminiKeyStep', () => {
-  it('submits the key via PATCH /config and navigates to /', async () => {
+  it('submits the key via PATCH /config and calls onComplete', async () => {
     patchConfig.mockResolvedValue({})
+    const onComplete = vi.fn()
 
-    renderStep()
+    render(<GeminiKeyStep onComplete={onComplete} />)
     fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
     await fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(patchConfig).toHaveBeenCalledWith({ gemini_api_key: 'sk-test-123' })
-    expect(navigateMock).toHaveBeenCalledWith('/')
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
-  it('skipping navigates to / without calling PATCH', () => {
-    renderStep()
+  it('skipping calls onComplete without calling PATCH', () => {
+    const onComplete = vi.fn()
+
+    render(<GeminiKeyStep onComplete={onComplete} />)
     fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
 
     expect(patchConfig).not.toHaveBeenCalled()
-    expect(navigateMock).toHaveBeenCalledWith('/')
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
   it('disables Save until a key is entered', () => {
-    renderStep()
+    render(<GeminiKeyStep onComplete={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
 
     fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
     expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled()
+  })
+
+  it('shows an inline error and keeps the key on a failed save, without calling onComplete', async () => {
+    patchConfig.mockRejectedValue(new Error('invalid key'))
+    const onComplete = vi.fn()
+
+    render(<GeminiKeyStep onComplete={onComplete} />)
+    fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not save the key. Check it and try again.')
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Gemini API key')).toHaveValue('sk-test-123')
   })
 })

--- a/frontend/src/onboarding/GeminiKeyStep.test.jsx
+++ b/frontend/src/onboarding/GeminiKeyStep.test.jsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { patchConfig } from '../api.js'
+import GeminiKeyStep from './GeminiKeyStep.jsx'
+
+vi.mock('../api.js', () => ({ patchConfig: vi.fn() }))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+function renderStep() {
+  return render(<GeminiKeyStep />, { wrapper: MemoryRouter })
+}
+
+beforeEach(() => {
+  navigateMock.mockClear()
+  patchConfig.mockReset()
+})
+
+describe('GeminiKeyStep', () => {
+  it('submits the key via PATCH /config and navigates to /', async () => {
+    patchConfig.mockResolvedValue({})
+
+    renderStep()
+    fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
+    await fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(patchConfig).toHaveBeenCalledWith({ gemini_api_key: 'sk-test-123' })
+    expect(navigateMock).toHaveBeenCalledWith('/')
+  })
+
+  it('skipping navigates to / without calling PATCH', () => {
+    renderStep()
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
+
+    expect(patchConfig).not.toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith('/')
+  })
+
+  it('disables Save until a key is entered', () => {
+    renderStep()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
+    expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled()
+  })
+})


### PR DESCRIPTION
Closes #71
Closes #72
Closes #73

## Changelog
- Add `GeminiKeyStep.jsx`: optional final onboarding step — submits the key via `PATCH /config` or skips, then navigates to `/`.
- Rewrite `index.css` design tokens to the OKLCH bronze editorial system (surface/panel/ink/ink-muted/accent/accent-ink/highlight/danger, light+dark) and bundle `Source Serif 4` locally via `@fontsource-variable/source-serif-4`.
- Add `AnswerPassage.jsx` + `CitationMarker.jsx`: reading-room answer prose with inline superscript citation markers parsed from `[unit-id]` markers, numbered by first appearance in the text.


## Review fixes (27f16b7)

`/code-review` (Standards + Spec) and `/ponytail:ponytail-review` found:
- **Spec**: `GeminiKeyStep` imported `useNavigate` directly instead of the `onComplete`-callback pattern every other onboarding step uses — its own comment admitted this was a stopgap. Switched to `onComplete`. Also added error handling to `handleSave`, which previously let a rejected `PATCH` fail silently with no user feedback.
- Checked the review's "onboarding completion never persisted" concern against `App.jsx`'s actual setup gate (`github_connected && repos_selected && first_index_done`) — it never depended on the Gemini key, so navigating home is genuinely sufficient. No fake completion flag added.
- **Standards**: `GeminiKeyStep`'s Save button used hardcoded `text-white` instead of the `--color-accent-ink` token this same PR's `index.css` rewrite introduced for exactly that purpose.
- **Ponytail**: removed a manual counter in `AnswerPassage.parseAnswer` that duplicated `parts.length`.

111/111 frontend tests pass. Build and lint clean.
