### PR TITLE
Onboarding, Settings, and Phase 2 hardening pass (responsive + a11y)

### DIFF
--- a/backend/config_store.py
+++ b/backend/config_store.py
@@ -34,9 +34,12 @@ class ConfigValidationError(ValueError):
     """Raised when a PATCH value fails store-level validation."""
 
 
+def chroma_data_dir() -> str:
+    return os.getenv("CHROMA_DATA_DIR", DEFAULT_CHROMA_DATA_DIR)
+
+
 def _config_path() -> Path:
-    data_dir = os.getenv("CHROMA_DATA_DIR", DEFAULT_CHROMA_DATA_DIR)
-    return Path(data_dir) / "config.json"
+    return Path(chroma_data_dir()) / "config.json"
 
 
 def load() -> dict:

--- a/backend/ingestion/github_client.py
+++ b/backend/ingestion/github_client.py
@@ -7,11 +7,14 @@ and fails clearly on rate-limit exhaustion rather than hanging a run.
 
 import time
 import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
 
 import httpx
 from pydantic import BaseModel
 
 from config import get_settings
+
+_COMMIT_ESTIMATE_MAX_WORKERS = 10
 
 GITHUB_API_URL = "https://api.github.com"
 
@@ -187,14 +190,20 @@ def list_prs(repo: str, since: str | None = None) -> list[PullRequestRef]:
     ]
 
 
-def _estimate_commit_count(repo: str, rate_limiter: _RateLimiter) -> int:
+def _estimate_commit_count(repo: str) -> int:
     # GitHub has no direct "commit count" field. The documented trick: ask
     # for one commit per page and read the last page number off the Link
     # header, avoiding a full commit fetch just to size a repo picker row.
+    #
+    # Each call gets its own rate limiter rather than sharing the
+    # pagination one — these run concurrently (see list_repos) and
+    # _RateLimiter isn't thread-safe. Fine here: this estimate already
+    # degrades to 0 on any GitHubError, so losing shared rate-limit
+    # awareness across just these calls costs nothing but precision.
     try:
         response = _get(
             f"{GITHUB_API_URL}/repos/{repo}/commits",
-            rate_limiter,
+            _RateLimiter(),
             params={"per_page": 1},
         )
     except GitHubError:
@@ -212,13 +221,15 @@ def list_repos(query: str | None = None) -> list[RepoSummary]:
     rate_limiter = _RateLimiter()
     data = _paginate("/user/repos", rate_limiter, params={"per_page": 100})
 
+    # One GitHub round-trip per repo to estimate its commit count — done
+    # sequentially this made a 50-repo account take ~2 minutes to render
+    # the repo picker. Fanned out across a small thread pool instead.
+    with ThreadPoolExecutor(max_workers=_COMMIT_ESTIMATE_MAX_WORKERS) as pool:
+        estimates = list(pool.map(_estimate_commit_count, [item["full_name"] for item in data]))
+
     repos = [
-        RepoSummary(
-            name=item["full_name"],
-            private=item["private"],
-            commit_count_estimate=_estimate_commit_count(item["full_name"], rate_limiter),
-        )
-        for item in data
+        RepoSummary(name=item["full_name"], private=item["private"], commit_count_estimate=estimate)
+        for item, estimate in zip(data, estimates)
     ]
 
     if query:

--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -24,6 +24,21 @@ def get_collection() -> chromadb.Collection:
     )
 
 
+def clear_all() -> None:
+    """Wipe every indexed decision and ingestion cursor (full-wipe "clear
+    index" action, not per-repo removal). Deletes by id rather than
+    dropping the collection so this is a no-op on an empty/fresh store
+    instead of erroring on a not-yet-created collection."""
+    collection = get_collection()
+    ids = collection.get(include=[])["ids"]
+    if ids:
+        collection.delete(ids=ids)
+
+    path = _cursor_path()
+    if path.exists():
+        path.unlink()
+
+
 def _document_text(unit: DecisionUnit) -> str:
     return f"{unit.title}\n{unit.decision}\n{unit.rationale}"
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -117,6 +117,7 @@ class ConfigResponse(BaseModel):
     ollama_extraction_model: str | None = None
     ollama_embedding_model: str | None = None
     gemini_model: str
+    chroma_data_dir: str
 
 
 class ConfigPatchRequest(ConfigResponse):
@@ -125,6 +126,7 @@ class ConfigPatchRequest(ConfigResponse):
 
     ollama_host: str | None = None
     gemini_model: str | None = None
+    chroma_data_dir: str | None = None
 
 
 class DeviceStartResponse(BaseModel):

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -17,14 +17,19 @@ router = APIRouter()
 
 @router.get("/config", response_model=ConfigResponse)
 def get_config() -> ConfigResponse:
-    return ConfigResponse(**config_store.mask(config_store.load()))
+    return ConfigResponse(**config_store.mask(config_store.load()), chroma_data_dir=config_store.chroma_data_dir())
 
 
 @router.patch("/config", response_model=ConfigResponse)
 def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
+    # chroma_data_dir is env-derived (matches chroma_client.py), never
+    # actually persisted through the store, so it's dropped before saving.
+    payload = patch.model_dump(exclude_unset=True)
+    payload.pop("chroma_data_dir", None)
+
     try:
-        updated = config_store.save(patch.model_dump(exclude_unset=True))
+        updated = config_store.save(payload)
     except config_store.ConfigValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    return ConfigResponse(**config_store.mask(updated))
+    return ConfigResponse(**config_store.mask(updated), chroma_data_dir=config_store.chroma_data_dir())

--- a/backend/routers/repos.py
+++ b/backend/routers/repos.py
@@ -1,4 +1,6 @@
-"""GET /repos: thin wiring from HTTP to store.count_units per configured repo.
+"""GET /repos: thin wiring from HTTP to store.count_units per configured
+repo. DELETE /repos: full-wipe "clear index" action (#84) — clears the
+Chroma collection, ingestion cursors, and the configured repo list.
 
 Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
 service function, shape response. No business logic here.
@@ -6,8 +8,9 @@ service function, shape response. No business logic here.
 
 from fastapi import APIRouter
 
+import config_store
 from config import get_settings
-from ingestion.store import count_units
+from ingestion.store import clear_all, count_units
 from models import RepoInfo, ReposResponse
 
 router = APIRouter()
@@ -21,3 +24,10 @@ def repos() -> ReposResponse:
             for repo in get_settings().indexed_repos
         ]
     )
+
+
+@router.delete("/repos")
+def clear_repos() -> None:
+    clear_all()
+    config_store.save({"indexed_repos": []})
+    get_settings.cache_clear()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -61,7 +61,13 @@ def test_indexed_repos_splits_on_comma_and_strips_whitespace(monkeypatch):
     assert settings.indexed_repos == ["a/b", "c/d", "e/f"]
 
 
-def test_missing_required_var_raises_validation_error(monkeypatch):
+def test_missing_required_var_raises_validation_error(monkeypatch, tmp_path):
+    # Isolate config_store's fallback path from the real local
+    # {CHROMA_DATA_DIR}/config.json — if that file happens to have a
+    # real github_token saved (e.g. from actually using the app), the
+    # model_validator would silently fill the "missing" var back in
+    # from the store and this test would no longer test anything.
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
     _set_required_env(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 

--- a/backend/tests/test_config_router.py
+++ b/backend/tests/test_config_router.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import pytest
 from fastapi.testclient import TestClient
 
+import config_store
 from main import app
 
 client = TestClient(app)
@@ -16,7 +17,7 @@ def _isolated_store(tmp_path, monkeypatch):
     monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
 
 
-def test_get_config_on_empty_store_returns_defaults():
+def test_get_config_on_empty_store_returns_defaults(tmp_path):
     response = client.get("/config")
 
     assert response.status_code == 200
@@ -28,7 +29,16 @@ def test_get_config_on_empty_store_returns_defaults():
         "ollama_extraction_model": None,
         "ollama_embedding_model": None,
         "gemini_model": "gemini-2.5-flash",
+        "chroma_data_dir": str(tmp_path),
     }
+
+
+def test_patch_ignores_chroma_data_dir_since_it_is_env_derived(tmp_path):
+    response = client.patch("/config", json={"chroma_data_dir": "/somewhere/else"})
+
+    assert response.status_code == 200
+    assert response.json()["chroma_data_dir"] == str(tmp_path)
+    assert "chroma_data_dir" not in config_store.load()
 
 
 def test_patch_persists_and_is_reflected_in_a_subsequent_get():

--- a/backend/tests/test_repos_router.py
+++ b/backend/tests/test_repos_router.py
@@ -61,3 +61,28 @@ def test_repos_with_zero_indexed_units_still_appears(make_unit):
             {"repo": "owner/b", "indexed_units": 0},
         ]
     }
+
+
+def test_delete_repos_clears_units_cursors_and_indexed_repos(make_unit, monkeypatch):
+    """Full-wipe "clear index" (#84): indexed_repos here comes from
+    config_store (not the INDEXED_REPOS env override the other tests in
+    this file rely on) to match how repos are actually registered via
+    PATCH /config in production."""
+    monkeypatch.delenv("INDEXED_REPOS", raising=False)
+    client.patch("/config", json={"indexed_repos": ["owner/a", "owner/b"]})
+    store.upsert_units(
+        [make_unit(id="owner/a:pr:1", repo="owner/a", url="https://github.com/owner/a/pull/1")],
+        embeddings=[[1, 0]],
+    )
+    store.set_cursor("owner/a", {"last_commit_date": "2026-01-01T00:00:00Z"})
+
+    # Populate the cached Settings singleton before clearing, so this
+    # also proves the endpoint invalidates it rather than leaving GET
+    # /repos serving a stale indexed_repos list.
+    assert client.get("/repos").json()["repos"]
+
+    response = client.delete("/repos")
+
+    assert response.status_code == 200
+    assert client.get("/repos").json() == {"repos": []}
+    assert store.get_cursor("owner/a") == {}

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -121,6 +121,22 @@ def test_count_units_with_no_matches_returns_zero(store_module):
     assert store_module.count_units("owner/repo") == 0
 
 
+def test_clear_all_empties_collection_and_cursor_file(store_module, make_unit):
+    store_module.upsert_units([make_unit()], embeddings=[[0.1, 0.2, 0.3]])
+    store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
+
+    store_module.clear_all()
+
+    assert store_module.get_collection().count() == 0
+    assert store_module.get_cursor("owner/repo") == {}
+
+
+def test_clear_all_on_empty_store_is_a_noop(store_module):
+    store_module.clear_all()
+
+    assert store_module.get_collection().count() == 0
+
+
 def test_set_cursor_preserves_other_repos(store_module):
     store_module.set_cursor("owner/repo", {"last_commit_date": "2026-01-01T00:00:00Z"})
     store_module.set_cursor("owner/other", {"last_commit_date": "2026-02-01T00:00:00Z"})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import AskPage from './ask/AskPage.jsx'
 import LibraryPage from './library/LibraryPage.jsx'
 import { getSetupState } from './api.js'
 import { IngestStatusProvider } from './lib/useIngestStatus.js'
+import OnboardingPage from './onboarding/OnboardingPage.jsx'
 import AppShell from './shell/AppShell.jsx'
 import SettingsPage from './settings/SettingsPage.jsx'
 
@@ -46,7 +47,7 @@ function App() {
           </Route>
         ) : (
           <>
-            <Route path="/onboarding" element={<div className="p-6">Onboarding</div>} />
+            <Route path="/onboarding" element={<OnboardingPage />} />
             <Route path="*" element={<Navigate to="/onboarding" replace />} />
           </>
         )}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -11,6 +11,13 @@ vi.mock('./api.js', () => ({
   getIngestStatus: vi.fn(),
 }))
 
+// OnboardingPage has its own dedicated test file for its step machine —
+// here it's just a boundary stub so App's routing/gate tests don't also
+// need to satisfy OnboardingPage's own API calls (getConfig, etc.).
+vi.mock('./onboarding/OnboardingPage.jsx', () => ({
+  default: () => <div>Onboarding stub</div>,
+}))
+
 const INCOMPLETE_STATE = {
   github_connected: false,
   repos_selected: false,
@@ -49,7 +56,7 @@ describe('App', () => {
 
     renderAt('/library')
 
-    expect(await screen.findByText('Onboarding')).toBeInTheDocument()
+    expect(await screen.findByText('Onboarding stub')).toBeInTheDocument()
   })
 
   it('redirects to /onboarding when GET /setup/state fails', async () => {
@@ -57,7 +64,7 @@ describe('App', () => {
 
     renderAt('/')
 
-    expect(await screen.findByText('Onboarding')).toBeInTheDocument()
+    expect(await screen.findByText('Onboarding stub')).toBeInTheDocument()
   })
 
   it('renders the requested route inside the app shell when setup is complete', async () => {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -79,6 +79,10 @@ export function patchConfig(patch) {
   })
 }
 
+export function clearIndex() {
+  return request('/repos', { method: 'DELETE' })
+}
+
 export function postIngest({ repos } = {}) {
   return request('/ingest', {
     method: 'POST',

--- a/frontend/src/ask/AskPage.jsx
+++ b/frontend/src/ask/AskPage.jsx
@@ -85,11 +85,11 @@ function AskPage() {
 
   return (
     <div className="h-full flex flex-col">
-      <header className="h-14 shrink-0 bg-panel flex items-center justify-between px-4">
+      <header className="h-14 shrink-0 bg-panel flex items-center justify-between px-4 lg:px-6">
         <RepoFilter repos={repos} selected={selectedRepos} onChange={setSelectedRepos} />
       </header>
 
-      <main className="flex-1 overflow-y-auto px-4 py-4">
+      <main className="flex-1 overflow-y-auto px-4 lg:px-6 py-4">
         {messages.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center gap-4 text-center">
             <p className="text-base text-ink-muted">
@@ -115,7 +115,7 @@ function AskPage() {
         )}
       </main>
 
-      <div className="sticky bottom-0 shrink-0 bg-panel px-4 py-4">
+      <div className="sticky bottom-0 shrink-0 bg-panel px-4 lg:px-6 py-4">
         <div className="max-w-3xl mx-auto">
           <ChatInput key={chatKey} initialValue={prefill} onSubmit={handleAsk} disabled={loading} />
         </div>

--- a/frontend/src/ask/SourceCard.jsx
+++ b/frontend/src/ask/SourceCard.jsx
@@ -39,7 +39,7 @@ function SourceCard({ unit, number }) {
       target="_blank"
       rel="noreferrer"
       aria-label={accessibleName}
-      className="block w-64 rounded-xl border border-transparent bg-panel p-4 transition-colors hover:border-accent"
+      className="block w-full sm:w-64 rounded-xl border border-transparent bg-panel p-4 transition-colors hover:border-accent"
     >
       <div className="flex items-center gap-2">
         {number != null && <span className="font-ui text-xs text-ink-muted">{number}</span>}

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -1,7 +1,19 @@
-import { useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
 function ChatInput({ onSubmit, disabled, initialValue = '' }) {
   const [value, setValue] = useState(initialValue)
+  const textareaRef = useRef(null)
+
+  // No fixed textarea height (UI-DESIGN.md's mobile fix) — grow with
+  // content up to a scrollable cap instead of clipping wrapped text at
+  // the single `rows={1}` line, which is what made the bar look clipped
+  // on narrow viewports where far more questions wrap to multiple lines.
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.style.height = 'auto'
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }, [value])
 
   function submit() {
     const question = value.trim()
@@ -25,20 +37,21 @@ function ChatInput({ onSubmit, disabled, initialValue = '' }) {
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex items-end gap-4 bg-panel p-4 rounded-xl"
+      className="flex items-end gap-2 sm:gap-4 bg-panel p-3 sm:p-4 rounded-xl"
     >
       <label htmlFor="chat-input" className="sr-only">
         Ask a question
       </label>
       <textarea
         id="chat-input"
+        ref={textareaRef}
         value={value}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         rows={1}
         placeholder="Ask why something in your codebase is the way it is"
-        className="flex-1 resize-none rounded-lg bg-surface text-ink text-base p-4 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+        className="flex-1 min-w-0 resize-none overflow-y-auto max-h-40 rounded-lg bg-surface text-ink text-base p-4 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
       />
       <button
         type="submit"

--- a/frontend/src/components/ChatInput.test.jsx
+++ b/frontend/src/components/ChatInput.test.jsx
@@ -49,4 +49,24 @@ describe('ChatInput', () => {
     expect(screen.getByLabelText('Ask a question')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Ask' })).toBeDisabled()
   })
+
+  it('grows the textarea with content instead of clipping it (no fixed height)', async () => {
+    const scrollHeights = { current: 24 }
+    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
+      () => scrollHeights.current,
+    )
+
+    const user = userEvent.setup()
+    render(<ChatInput onSubmit={vi.fn()} disabled={false} />)
+    const textarea = screen.getByLabelText('Ask a question')
+
+    expect(textarea.style.height).toBe('24px')
+
+    scrollHeights.current = 72
+    await user.type(textarea, 'a much longer question that wraps to several lines')
+
+    expect(textarea.style.height).toBe('72px')
+
+    vi.restoreAllMocks()
+  })
 })

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,6 +38,18 @@ body {
 }
 
 /*
+ * UI-DESIGN.md's Accessibility § "Focus visible always: 2px
+ * --color-accent ring, outline-offset: 2px" — applied globally rather
+ * than per-component so every interactive element (buttons, links,
+ * inputs, the ChatInput textarea's own focus ring included) gets the
+ * same on-brand indicator instead of relying on each browser's default.
+ */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/*
  * The one signature motion moment (UI-DESIGN.md's Ask § "Signature
  * moment"): AnswerPassage fades up on arrival, then its CitationMarkers
  * ink in staggered. Components gate applying these classes on

--- a/frontend/src/lib/colorContrast.js
+++ b/frontend/src/lib/colorContrast.js
@@ -1,0 +1,31 @@
+// WCAG 2.1 contrast-ratio math for this app's OKLCH design tokens
+// (UI-DESIGN.md's Design tokens table). OKLCH lightness doesn't map
+// linearly to WCAG relative luminance, so the check needs a real
+// OKLCH -> linear sRGB conversion (Björn Ottosson's OKLab matrices),
+// not a shortcut off the L channel.
+export function oklchToRelativeLuminance(L, C, H) {
+  const h = (H * Math.PI) / 180
+  const a = C * Math.cos(h)
+  const b = C * Math.sin(h)
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b
+
+  const l = l_ ** 3
+  const m = m_ ** 3
+  const s = s_ ** 3
+
+  const r = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s
+  const g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s
+  const bl = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s
+
+  const clamp = (x) => Math.max(0, Math.min(1, x))
+  return 0.2126 * clamp(r) + 0.7152 * clamp(g) + 0.0722 * clamp(bl)
+}
+
+export function contrastRatio(luminanceA, luminanceB) {
+  const hi = Math.max(luminanceA, luminanceB)
+  const lo = Math.min(luminanceA, luminanceB)
+  return (hi + 0.05) / (lo + 0.05)
+}

--- a/frontend/src/lib/colorContrast.test.js
+++ b/frontend/src/lib/colorContrast.test.js
@@ -1,0 +1,61 @@
+// Verifies every token pair actually used for text/UI components in
+// UI-DESIGN.md's Design tokens table against WCAG 2.1 AA thresholds
+// (issue #86: accessibility verification pass). Values mirror
+// frontend/src/index.css's `@theme` block and its dark override — if
+// those change, this test's literal token values must be updated to
+// match, same as any other fixture.
+import { describe, expect, it } from 'vitest'
+import { contrastRatio, oklchToRelativeLuminance } from './colorContrast.js'
+
+const TOKENS = {
+  light: {
+    surface: [0.985, 0.004, 70],
+    panel: [1, 0, 0],
+    ink: [0.24, 0.01, 70],
+    'ink-muted': [0.47, 0.015, 70],
+    accent: [0.52, 0.11, 60],
+    'accent-ink': [0.99, 0.005, 70],
+    danger: [0.5, 0.19, 27],
+  },
+  dark: {
+    surface: [0.185, 0.008, 70],
+    panel: [0.23, 0.01, 70],
+    ink: [0.93, 0.005, 70],
+    'ink-muted': [0.7, 0.015, 70],
+    accent: [0.75, 0.1, 65],
+    'accent-ink': [0.17, 0.02, 65],
+    danger: [0.7, 0.17, 25],
+  },
+}
+
+const AA_BODY = 4.5
+
+// [fg, bg, minimum ratio, real usage this pair covers]
+const USED_PAIRS = [
+  ['ink', 'surface', AA_BODY, 'body text on page background'],
+  ['ink', 'panel', AA_BODY, 'body text on cards/bars/inputs'],
+  ['ink-muted', 'surface', AA_BODY, 'metadata/secondary text on page background'],
+  ['ink-muted', 'panel', AA_BODY, 'metadata/secondary text on cards'],
+  ['accent', 'surface', AA_BODY, 'active nav text, links, citation markers on page background'],
+  ['accent', 'panel', AA_BODY, 'active nav text, links, citation markers on cards'],
+  ['accent-ink', 'accent', AA_BODY, 'button/pill label text on accent fills'],
+  ['danger', 'surface', AA_BODY, 'error text on page background'],
+  ['danger', 'panel', AA_BODY, 'error text on cards'],
+  ['accent-ink', 'danger', AA_BODY, 'button label text on danger fills'],
+]
+
+function luminance(theme, name) {
+  const [L, C, H] = TOKENS[theme][name]
+  return oklchToRelativeLuminance(L, C, H)
+}
+
+describe('design token contrast (WCAG 2.1 AA)', () => {
+  for (const theme of ['light', 'dark']) {
+    for (const [fg, bg, minRatio, usage] of USED_PAIRS) {
+      it(`${theme}: ${fg} on ${bg} (${usage}) >= ${minRatio}:1`, () => {
+        const ratio = contrastRatio(luminance(theme, fg), luminance(theme, bg))
+        expect(ratio).toBeGreaterThanOrEqual(minRatio)
+      })
+    }
+  }
+})

--- a/frontend/src/library/LibraryPage.jsx
+++ b/frontend/src/library/LibraryPage.jsx
@@ -37,7 +37,7 @@ function LibraryPage() {
   }
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-6">
+    <div className="max-w-5xl mx-auto px-4 lg:px-6 py-6">
       <div className="flex items-center justify-between">
         <h1 className="font-reading text-lg text-ink">Library</h1>
         <button

--- a/frontend/src/library/RepoRow.jsx
+++ b/frontend/src/library/RepoRow.jsx
@@ -33,7 +33,7 @@ function RepoRow({ repo, onRemove }) {
 
   if (confirming) {
     return (
-      <div className="bg-panel rounded-xl p-4 flex items-center justify-between gap-4">
+      <div className="bg-panel rounded-xl p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <InlineConfirm
           message={`Remove ${repo.repo} and its ${repo.indexed_units} indexed ${
             repo.indexed_units === 1 ? 'decision' : 'decisions'
@@ -48,9 +48,22 @@ function RepoRow({ repo, onRemove }) {
   }
 
   return (
-    <div className="bg-panel rounded-xl p-4 flex items-center justify-between gap-4">
-      <span className="font-mono text-sm text-ink">{repo.repo}</span>
-      <div className="flex items-center gap-4">
+    // <640px: two lines — name+actions, then status (UI-DESIGN.md's
+    // responsive table). `sm:contents` lets the name/Remove wrapper drop
+    // out of the box model at sm+ so the single Remove button can be
+    // reordered next to the status line without a second DOM instance.
+    <div className="bg-panel rounded-xl p-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="flex items-center justify-between gap-4 sm:contents">
+        <span className="font-mono text-sm text-ink truncate min-w-0">{repo.repo}</span>
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="text-sm text-ink-muted shrink-0 sm:order-3"
+        >
+          Remove
+        </button>
+      </div>
+      <div className="sm:order-2">
         {active ? (
           <IndexProgress repo={repo.repo} />
         ) : (
@@ -58,9 +71,6 @@ function RepoRow({ repo, onRemove }) {
             {repo.indexed_units} {repo.indexed_units === 1 ? 'decision' : 'decisions'}
           </p>
         )}
-        <button type="button" onClick={() => setConfirming(true)} className="text-sm text-ink-muted">
-          Remove
-        </button>
       </div>
     </div>
   )

--- a/frontend/src/onboarding/ConnectStep.jsx
+++ b/frontend/src/onboarding/ConnectStep.jsx
@@ -2,7 +2,7 @@
 // DeviceCodeCard, which owns polling GET /auth/github/status. Advancing
 // to step 2 is the caller's responsibility (via onAuthorized), so this
 // component composes cleanly under OnboardingPage's step machine.
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { startDeviceFlow } from '../api.js'
 import DeviceCodeCard from './DeviceCodeCard.jsx'
 import RetryCard from './RetryCard.jsx'
@@ -10,22 +10,23 @@ import RetryCard from './RetryCard.jsx'
 function ConnectStep({ onAuthorized }) {
   const [device, setDevice] = useState(undefined)
   const [attempt, setAttempt] = useState(0)
+  // POST /auth/github/device/start is not idempotent — each call mints a
+  // new code and replaces the backend's one in-flight device flow. React
+  // StrictMode double-invokes this effect once on mount in dev; without
+  // this guard that fires two real device-flow starts for one screen,
+  // racing whichever the backend ends up tracking against whichever the
+  // user actually sees and approves. Mirrors IndexStep's same guard for
+  // its own non-idempotent POST /ingest.
+  const startedForAttempt = useRef(null)
 
   useEffect(() => {
-    let cancelled = false
+    if (startedForAttempt.current === attempt) return
+    startedForAttempt.current = attempt
+
     setDevice(undefined)
-
     startDeviceFlow()
-      .then((result) => {
-        if (!cancelled) setDevice(result)
-      })
-      .catch(() => {
-        if (!cancelled) setDevice('error')
-      })
-
-    return () => {
-      cancelled = true
-    }
+      .then(setDevice)
+      .catch(() => setDevice('error'))
   }, [attempt])
 
   function restart() {

--- a/frontend/src/onboarding/IndexStep.jsx
+++ b/frontend/src/onboarding/IndexStep.jsx
@@ -62,7 +62,7 @@ function IndexStep({ repos, onComplete }) {
         <button
           type="button"
           onClick={handleStartAsking}
-          className="mt-4 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2"
+          className="mt-4 rounded-lg bg-accent text-accent-ink text-sm font-semibold px-4 py-2"
         >
           Start asking
         </button>

--- a/frontend/src/onboarding/OnboardingPage.jsx
+++ b/frontend/src/onboarding/OnboardingPage.jsx
@@ -1,0 +1,94 @@
+// Full-screen onboarding flow (UI-DESIGN.md `/onboarding`), no app
+// shell. Composes ConnectStep -> RepoPickerStep -> IndexStep -> the
+// optional GeminiKeyStep into a small state machine driven by GET
+// /setup/state, so a refresh resumes at the furthest incomplete step
+// rather than restarting from Connect every time.
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getConfig, getSetupState } from '../api.js'
+import ConnectStep from './ConnectStep.jsx'
+import GeminiKeyStep from './GeminiKeyStep.jsx'
+import IndexStep from './IndexStep.jsx'
+import RepoPickerStep from './RepoPickerStep.jsx'
+
+const DOT_STEPS = ['connect', 'repos', 'index']
+
+function Dots({ step }) {
+  const current = DOT_STEPS.indexOf(step)
+  if (current === -1) return null
+
+  return (
+    <div className="flex justify-center gap-2 pt-8">
+      {DOT_STEPS.map((name, index) => (
+        <span
+          key={name}
+          className={`h-1.5 w-1.5 rounded-full ${index === current ? 'bg-accent' : 'bg-ink-muted'}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function OnboardingPage() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState(null)
+  const [repos, setRepos] = useState([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    getSetupState()
+      .then(async (state) => {
+        if (cancelled) return
+
+        if (!state.github_connected) {
+          setStep('connect')
+          return
+        }
+        if (!state.repos_selected) {
+          setStep('repos')
+          return
+        }
+        if (!state.first_index_done) {
+          const config = await getConfig()
+          if (cancelled) return
+          setRepos(config.indexed_repos)
+          setStep('index')
+          return
+        }
+        if (!state.gemini_key_set) {
+          setStep('gemini')
+          return
+        }
+        navigate('/')
+      })
+      .catch(() => {
+        if (!cancelled) setStep('connect')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate])
+
+  function handleRepoPickerNext(selected) {
+    setRepos(selected)
+    setStep('index')
+  }
+
+  if (step === null) return null
+
+  return (
+    <div className="min-h-svh bg-surface flex flex-col">
+      <div className="flex-1 flex items-center justify-center p-6">
+        {step === 'connect' && <ConnectStep onAuthorized={() => setStep('repos')} />}
+        {step === 'repos' && <RepoPickerStep onNext={handleRepoPickerNext} />}
+        {step === 'index' && <IndexStep repos={repos} onComplete={() => setStep('gemini')} />}
+        {step === 'gemini' && <GeminiKeyStep onComplete={() => navigate('/')} />}
+      </div>
+      <Dots step={step} />
+    </div>
+  )
+}
+
+export default OnboardingPage

--- a/frontend/src/onboarding/OnboardingPage.jsx
+++ b/frontend/src/onboarding/OnboardingPage.jsx
@@ -80,7 +80,7 @@ function OnboardingPage() {
 
   return (
     <div className="min-h-svh bg-surface flex flex-col">
-      <div className="flex-1 flex items-center justify-center p-6">
+      <div className="flex-1 flex items-center justify-center p-4 sm:p-6">
         {step === 'connect' && <ConnectStep onAuthorized={() => setStep('repos')} />}
         {step === 'repos' && <RepoPickerStep onNext={handleRepoPickerNext} />}
         {step === 'index' && <IndexStep repos={repos} onComplete={() => setStep('gemini')} />}

--- a/frontend/src/onboarding/OnboardingPage.test.jsx
+++ b/frontend/src/onboarding/OnboardingPage.test.jsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getConfig, getSetupState } from '../api.js'
+import OnboardingPage from './OnboardingPage.jsx'
+
+vi.mock('../api.js', () => ({
+  getSetupState: vi.fn(),
+  getConfig: vi.fn(),
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+vi.mock('./ConnectStep.jsx', () => ({ default: () => <div>Connect step</div> }))
+vi.mock('./RepoPickerStep.jsx', () => ({ default: () => <div>Repo picker step</div> }))
+vi.mock('./IndexStep.jsx', () => ({ default: ({ repos }) => <div>Index step for {repos.join(',')}</div> }))
+vi.mock('./GeminiKeyStep.jsx', () => ({ default: () => <div>Gemini key step</div> }))
+
+function renderPage() {
+  return render(<OnboardingPage />, { wrapper: MemoryRouter })
+}
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('OnboardingPage', () => {
+  it('resumes at Connect when github is not connected', async () => {
+    getSetupState.mockResolvedValue({
+      github_connected: false,
+      repos_selected: false,
+      first_index_done: false,
+      gemini_key_set: false,
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Connect step')).toBeInTheDocument()
+  })
+
+  it('resumes at RepoPicker when connected but no repos selected', async () => {
+    getSetupState.mockResolvedValue({
+      github_connected: true,
+      repos_selected: false,
+      first_index_done: false,
+      gemini_key_set: false,
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Repo picker step')).toBeInTheDocument()
+  })
+
+  it('resumes at Index (with the configured repos) when repos are selected but not indexed', async () => {
+    getSetupState.mockResolvedValue({
+      github_connected: true,
+      repos_selected: true,
+      first_index_done: false,
+      gemini_key_set: false,
+    })
+    getConfig.mockResolvedValue({ indexed_repos: ['owner/a', 'owner/b'] })
+
+    renderPage()
+
+    expect(await screen.findByText('Index step for owner/a,owner/b')).toBeInTheDocument()
+  })
+
+  it('resumes at the optional Gemini step once indexing is done', async () => {
+    getSetupState.mockResolvedValue({
+      github_connected: true,
+      repos_selected: true,
+      first_index_done: true,
+      gemini_key_set: false,
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Gemini key step')).toBeInTheDocument()
+  })
+
+  it('navigates home immediately if setup is already fully complete', async () => {
+    getSetupState.mockResolvedValue({
+      github_connected: true,
+      repos_selected: true,
+      first_index_done: true,
+      gemini_key_set: true,
+    })
+
+    renderPage()
+
+    await vi.waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'))
+  })
+
+  it('falls back to Connect when GET /setup/state fails', async () => {
+    getSetupState.mockRejectedValue(new Error('network error'))
+
+    renderPage()
+
+    expect(await screen.findByText('Connect step')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/onboarding/RepoPickerList.jsx
+++ b/frontend/src/onboarding/RepoPickerList.jsx
@@ -10,7 +10,7 @@ function RepoPickerList({ query, repos, selected, onToggle, onRetry, emptyMessag
     <div className="mt-2">
       {repos === undefined &&
         Array.from({ length: 5 }).map((_, index) => (
-          <div key={index} className="mb-1.5 h-9 animate-pulse rounded-lg bg-surface" />
+          <div key={index} className="mb-1.5 h-9 animate-pulse rounded-lg bg-highlight" />
         ))}
 
       {repos === 'error' && (

--- a/frontend/src/onboarding/RepoPickerRow.jsx
+++ b/frontend/src/onboarding/RepoPickerRow.jsx
@@ -26,10 +26,10 @@ function RepoPickerRow({ repo, selected, onToggle }) {
 
   return (
     <label className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-surface cursor-pointer">
-      <input type="checkbox" checked={selected} onChange={() => onToggle(repo.name)} />
-      <span className="font-mono text-sm text-ink">{repo.name}</span>
+      <input type="checkbox" checked={selected} onChange={() => onToggle(repo.name)} className="shrink-0" />
+      <span className="font-mono text-sm text-ink truncate min-w-0">{repo.name}</span>
       {repo.private && <LockIcon aria-label="Private" className="text-ink-muted shrink-0" />}
-      {estimate && <span className="ml-auto text-sm text-ink-muted">{estimate}</span>}
+      {estimate && <span className="ml-auto shrink-0 text-sm text-ink-muted">{estimate}</span>}
     </label>
   )
 }

--- a/frontend/src/onboarding/RepoPickerStep.jsx
+++ b/frontend/src/onboarding/RepoPickerStep.jsx
@@ -50,7 +50,7 @@ function RepoPickerStep({ onNext }) {
         type="button"
         disabled={selected.length === 0 || submitting}
         onClick={handleSubmit}
-        className="mt-4 rounded-lg bg-accent text-white text-sm font-semibold px-4 py-2 disabled:opacity-50"
+        className="mt-4 rounded-lg bg-accent text-accent-ink text-sm font-semibold px-4 py-2 disabled:opacity-50"
       >
         Index {selected.length} repo{selected.length === 1 ? '' : 's'}
       </button>

--- a/frontend/src/onboarding/RetryCard.jsx
+++ b/frontend/src/onboarding/RetryCard.jsx
@@ -5,11 +5,16 @@
 function RetryCard({ message, messageTone = 'muted', bordered = false, buttonLabel = 'Retry', buttonTone = 'accent', onRetry }) {
   return (
     <div className={`rounded-xl bg-panel p-4 ${bordered ? 'border border-danger' : ''}`}>
-      <p className={`text-sm ${messageTone === 'danger' ? 'text-danger' : 'text-ink-muted'}`}>{message}</p>
+      <p
+        role={messageTone === 'danger' ? 'alert' : 'status'}
+        className={`text-sm ${messageTone === 'danger' ? 'text-danger' : 'text-ink-muted'}`}
+      >
+        {message}
+      </p>
       <button
         type="button"
         onClick={onRetry}
-        className={`mt-2 rounded-lg text-white text-sm font-semibold px-4 py-2 ${
+        className={`mt-2 rounded-lg text-accent-ink text-sm font-semibold px-4 py-2 ${
           buttonTone === 'danger' ? 'bg-danger' : 'bg-accent'
         }`}
       >

--- a/frontend/src/onboarding/RetryCard.test.jsx
+++ b/frontend/src/onboarding/RetryCard.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import RetryCard from './RetryCard.jsx'
+
+describe('RetryCard', () => {
+  it('announces a danger-toned message via role="alert"', () => {
+    render(<RetryCard message="Authorization was denied." messageTone="danger" onRetry={vi.fn()} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Authorization was denied.')
+  })
+
+  it('announces a muted message via role="status"', () => {
+    render(<RetryCard message="Code expired." onRetry={vi.fn()} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Code expired.')
+  })
+})

--- a/frontend/src/settings/DataSection.jsx
+++ b/frontend/src/settings/DataSection.jsx
@@ -1,0 +1,99 @@
+// Settings' Data section (UI-DESIGN.md): read-only index location and
+// a full-wipe "Clear index" action (destructive, inline confirm — same
+// pattern as GitHubSection/GeminiSection/RepoRow).
+import { useEffect, useState } from 'react'
+import InlineConfirm from '../components/InlineConfirm.jsx'
+import { clearIndex, getConfig } from '../api.js'
+
+function DataSection() {
+  const [dataDir, setDataDir] = useState(undefined)
+  const [confirming, setConfirming] = useState(false)
+  const [clearing, setClearing] = useState(false)
+  const [cleared, setCleared] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    getConfig()
+      .then((result) => {
+        if (!cancelled) setDataDir(result.chroma_data_dir)
+      })
+      .catch(() => {
+        if (!cancelled) setDataDir(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function handleClear() {
+    setClearing(true)
+    setError(null)
+    try {
+      await clearIndex()
+      setCleared(true)
+      setConfirming(false)
+    } catch {
+      setError('Could not clear the index.')
+    } finally {
+      setClearing(false)
+    }
+  }
+
+  return (
+    <section className="bg-panel rounded-xl p-4">
+      <h2 className="text-lg text-ink">Data</h2>
+
+      {dataDir === undefined && (
+        <p role="status" className="mt-2 text-sm text-ink-muted">
+          Loading…
+        </p>
+      )}
+
+      {dataDir !== undefined && (
+        <>
+          {dataDir && <p className="mt-1 font-mono text-sm text-ink-muted">{dataDir}</p>}
+
+          {!confirming && (
+            <button
+              type="button"
+              disabled={clearing}
+              onClick={() => setConfirming(true)}
+              className="mt-2 text-sm font-semibold text-danger disabled:opacity-50"
+            >
+              Clear index
+            </button>
+          )}
+
+          {confirming && (
+            <div className="mt-2 flex items-center justify-between gap-4">
+              <InlineConfirm
+                message="Clear the index? This cannot be undone."
+                confirmLabel="Clear index"
+                onConfirm={handleClear}
+                onCancel={() => setConfirming(false)}
+                disabled={clearing}
+              />
+            </div>
+          )}
+
+          {cleared && (
+            <p role="status" className="mt-2 text-sm text-ink-muted">
+              Index cleared.
+            </p>
+          )}
+
+          {error && (
+            <p role="alert" className="mt-2 text-sm text-danger">
+              {error}
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default DataSection

--- a/frontend/src/settings/DataSection.jsx
+++ b/frontend/src/settings/DataSection.jsx
@@ -1,6 +1,8 @@
 // Settings' Data section (UI-DESIGN.md): read-only index location and
 // a full-wipe "Clear index" action (destructive, inline confirm — same
-// pattern as GitHubSection/GeminiSection/RepoRow).
+// pattern as GitHubSection/GeminiSection/RepoRow). Decision count (also
+// named in UI-DESIGN.md's Data row) is deliberately not shown — no such
+// field exists in ConfigResponse yet; tracked as a follow-up in #95.
 import { useEffect, useState } from 'react'
 import InlineConfirm from '../components/InlineConfirm.jsx'
 import { clearIndex, getConfig } from '../api.js'

--- a/frontend/src/settings/DataSection.test.jsx
+++ b/frontend/src/settings/DataSection.test.jsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearIndex, getConfig } from '../api.js'
+import DataSection from './DataSection.jsx'
+
+vi.mock('../api.js', () => ({ getConfig: vi.fn(), clearIndex: vi.fn() }))
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('DataSection', () => {
+  it('renders the index location from config', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/home/user/.adr-engine/chroma' })
+
+    render(<DataSection />)
+
+    expect(await screen.findByText('/home/user/.adr-engine/chroma')).toBeInTheDocument()
+  })
+
+  it('requires confirmation before calling the clear-index API', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+
+    render(<DataSection />)
+    await screen.findByText('/data')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+    expect(clearIndex).not.toHaveBeenCalled()
+    expect(screen.getByText(/Clear the index\?/)).toBeInTheDocument()
+  })
+
+  it('confirming calls DELETE /repos and shows a cleared message', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    clearIndex.mockResolvedValue(null)
+
+    render(<DataSection />)
+    await screen.findByText('/data')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+
+    expect(clearIndex).toHaveBeenCalled()
+    expect(await screen.findByText('Index cleared.')).toBeInTheDocument()
+  })
+
+  it('cancel dismisses the confirmation without calling the API', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+
+    render(<DataSection />)
+    await screen.findByText('/data')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(clearIndex).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Clear the index\?/)).not.toBeInTheDocument()
+  })
+
+  it('shows an inline error when clearing fails', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    clearIndex.mockRejectedValue(new Error('boom'))
+
+    render(<DataSection />)
+    await screen.findByText('/data')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not clear the index.')
+  })
+})

--- a/frontend/src/settings/ModelsSection.jsx
+++ b/frontend/src/settings/ModelsSection.jsx
@@ -1,0 +1,130 @@
+// Settings' Models section (UI-DESIGN.md): Ollama host and model name
+// inputs, saved together via a single PATCH /config.
+//
+// UI-DESIGN.md calls for save to ping Ollama's `/api/tags` to validate
+// host/model reachability. Issue #83 explicitly rules this out ("Skip
+// adding a new Ollama-health backend endpoint... flag as a follow-up if
+// a live check turns out to be genuinely needed") — same doc/issue
+// disagreement as GeminiSection's live-verification note, resolved the
+// same way: follow the issue's explicit scope, PATCH-only, no live
+// Ollama check.
+import { useEffect, useState } from 'react'
+import { getConfig, patchConfig } from '../api.js'
+
+function ModelsSection() {
+  const [loaded, setLoaded] = useState(false)
+  const [host, setHost] = useState('')
+  const [extractionModel, setExtractionModel] = useState('')
+  const [embeddingModel, setEmbeddingModel] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    getConfig()
+      .then((result) => {
+        if (cancelled) return
+        setHost(result.ollama_host ?? '')
+        setExtractionModel(result.ollama_extraction_model ?? '')
+        setEmbeddingModel(result.ollama_embedding_model ?? '')
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function handleSave() {
+    setSaving(true)
+    setSaved(false)
+    setError(null)
+    try {
+      await patchConfig({
+        ollama_host: host,
+        ollama_extraction_model: extractionModel,
+        ollama_embedding_model: embeddingModel,
+      })
+      setSaved(true)
+    } catch {
+      setError('Could not save model settings. Check them and try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="bg-panel rounded-xl p-4">
+      <h2 className="text-lg text-ink">Models</h2>
+
+      {!loaded && (
+        <p role="status" className="mt-2 text-sm text-ink-muted">
+          Loading…
+        </p>
+      )}
+
+      {loaded && (
+        <>
+          <div className="mt-2 flex flex-col gap-3">
+            <label className="flex flex-col gap-1 text-sm text-ink-muted">
+              Ollama host
+              <input
+                type="text"
+                value={host}
+                onChange={(event) => setHost(event.target.value)}
+                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-ink-muted">
+              Extraction model
+              <input
+                type="text"
+                value={extractionModel}
+                onChange={(event) => setExtractionModel(event.target.value)}
+                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-ink-muted">
+              Embedding model
+              <input
+                type="text"
+                value={embeddingModel}
+                onChange={(event) => setEmbeddingModel(event.target.value)}
+                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+              />
+            </label>
+          </div>
+
+          <div className="mt-3 flex items-center gap-4">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={handleSave}
+              className="rounded-lg bg-accent text-accent-ink text-sm font-semibold px-4 py-2 disabled:opacity-50"
+            >
+              Save
+            </button>
+            {saved && (
+              <span role="status" className="text-sm text-ink-muted">
+                Saved
+              </span>
+            )}
+          </div>
+
+          {error && (
+            <p role="alert" className="mt-2 text-sm text-danger">
+              {error}
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default ModelsSection

--- a/frontend/src/settings/ModelsSection.test.jsx
+++ b/frontend/src/settings/ModelsSection.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getConfig, patchConfig } from '../api.js'
+import ModelsSection from './ModelsSection.jsx'
+
+vi.mock('../api.js', () => ({ getConfig: vi.fn(), patchConfig: vi.fn() }))
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('ModelsSection', () => {
+  it('renders fields from the current config', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+
+    render(<ModelsSection />)
+
+    expect(await screen.findByLabelText('Ollama host')).toHaveValue('http://localhost:11434')
+    expect(screen.getByLabelText('Extraction model')).toHaveValue('llama3')
+    expect(screen.getByLabelText('Embedding model')).toHaveValue('nomic-embed-text')
+  })
+
+  it('save calls PATCH /config with the updated model settings', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    patchConfig.mockResolvedValue({})
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    fireEvent.change(screen.getByLabelText('Ollama host'), { target: { value: 'http://localhost:9999' } })
+    fireEvent.change(screen.getByLabelText('Extraction model'), { target: { value: 'mistral' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(patchConfig).toHaveBeenCalledWith({
+      ollama_host: 'http://localhost:9999',
+      ollama_extraction_model: 'mistral',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
+  it('shows an inline error when the save fails', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    patchConfig.mockRejectedValue(new Error('invalid host'))
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not save model settings. Check them and try again.',
+    )
+  })
+})

--- a/frontend/src/settings/SettingsPage.jsx
+++ b/frontend/src/settings/SettingsPage.jsx
@@ -1,5 +1,6 @@
 // UI-DESIGN.md's Settings page: single-column shell of per-concern
-// sections. DataSection lands in a following issue.
+// sections.
+import DataSection from './DataSection.jsx'
 import GeminiSection from './GeminiSection.jsx'
 import GitHubSection from './GitHubSection.jsx'
 import ModelsSection from './ModelsSection.jsx'
@@ -12,6 +13,7 @@ function SettingsPage() {
         <GitHubSection />
         <GeminiSection />
         <ModelsSection />
+        <DataSection />
       </div>
     </div>
   )

--- a/frontend/src/settings/SettingsPage.jsx
+++ b/frontend/src/settings/SettingsPage.jsx
@@ -7,7 +7,7 @@ import ModelsSection from './ModelsSection.jsx'
 
 function SettingsPage() {
   return (
-    <div className="max-w-xl mx-auto px-4 py-6">
+    <div className="max-w-xl mx-auto px-4 lg:px-6 py-6">
       <h1 className="font-reading text-lg text-ink">Settings</h1>
       <div className="mt-4 flex flex-col gap-4">
         <GitHubSection />

--- a/frontend/src/settings/SettingsPage.jsx
+++ b/frontend/src/settings/SettingsPage.jsx
@@ -1,7 +1,8 @@
 // UI-DESIGN.md's Settings page: single-column shell of per-concern
-// sections. ModelsSection/DataSection land in following issues.
+// sections. DataSection lands in a following issue.
 import GeminiSection from './GeminiSection.jsx'
 import GitHubSection from './GitHubSection.jsx'
+import ModelsSection from './ModelsSection.jsx'
 
 function SettingsPage() {
   return (
@@ -10,6 +11,7 @@ function SettingsPage() {
       <div className="mt-4 flex flex-col gap-4">
         <GitHubSection />
         <GeminiSection />
+        <ModelsSection />
       </div>
     </div>
   )

--- a/frontend/src/settings/SettingsPage.test.jsx
+++ b/frontend/src/settings/SettingsPage.test.jsx
@@ -8,12 +8,17 @@ vi.mock('../api.js', () => ({
   disconnectGithub: vi.fn(),
   getConfig: vi.fn(),
   patchConfig: vi.fn(),
+  clearIndex: vi.fn(),
 }))
 
 describe('SettingsPage', () => {
-  it('renders the GitHub, Gemini, and Models sections', async () => {
+  it('renders the GitHub, Gemini, Models, and Data sections', async () => {
     getAuthStatus.mockResolvedValue({ state: 'authorized', login: 'octocat' })
-    getConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef', ollama_host: 'http://localhost:11434' })
+    getConfig.mockResolvedValue({
+      gemini_api_key: 'gk_1…cdef',
+      ollama_host: 'http://localhost:11434',
+      chroma_data_dir: '/data/chroma',
+    })
 
     render(<SettingsPage />)
 
@@ -21,5 +26,6 @@ describe('SettingsPage', () => {
     expect(await screen.findByText('Connected as octocat')).toBeInTheDocument()
     expect(await screen.findByText('gk_1…cdef')).toBeInTheDocument()
     expect(await screen.findByLabelText('Ollama host')).toHaveValue('http://localhost:11434')
+    expect(await screen.findByText('/data/chroma')).toBeInTheDocument()
   })
 })

--- a/frontend/src/settings/SettingsPage.test.jsx
+++ b/frontend/src/settings/SettingsPage.test.jsx
@@ -11,14 +11,15 @@ vi.mock('../api.js', () => ({
 }))
 
 describe('SettingsPage', () => {
-  it('renders the GitHub and Gemini sections', async () => {
+  it('renders the GitHub, Gemini, and Models sections', async () => {
     getAuthStatus.mockResolvedValue({ state: 'authorized', login: 'octocat' })
-    getConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef' })
+    getConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef', ollama_host: 'http://localhost:11434' })
 
     render(<SettingsPage />)
 
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
     expect(await screen.findByText('Connected as octocat')).toBeInTheDocument()
     expect(await screen.findByText('gk_1…cdef')).toBeInTheDocument()
+    expect(await screen.findByLabelText('Ollama host')).toHaveValue('http://localhost:11434')
   })
 })

--- a/frontend/src/shell/TopNav.jsx
+++ b/frontend/src/shell/TopNav.jsx
@@ -49,7 +49,7 @@ function linkClassName({ isActive }) {
 function TopNav() {
   return (
     <header className="h-14 shrink-0 bg-panel">
-      <div className="max-w-5xl mx-auto h-full flex items-center justify-between px-4">
+      <div className="max-w-5xl mx-auto h-full flex items-center justify-between px-4 lg:px-6">
         <span className="text-lg font-semibold">adr-engine</span>
         <nav className="flex items-center gap-4">
           {NAV_LINKS.map(({ to, label, Icon }) => (


### PR DESCRIPTION
## Summary

- Builds `OnboardingPage.jsx`, the orchestrator wiring ConnectStep → RepoPickerStep → IndexStep → GeminiKeyStep into a resumable flow driven by `GET /setup/state` (no prior issue in the original backlog covered this — the composable steps existed but nothing assembled them, so `/onboarding` was still rendering the Phase 1 placeholder).
- Fixes two bugs found running that flow end-to-end for the first time: a device-flow race from React StrictMode's double-invoked effect calling the non-idempotent `POST /auth/github/device/start` twice, and `GET /github/repos` taking ~2 minutes for a 51-repo account (parallelized the per-repo commit-count estimate).
- Adds Settings' `ModelsSection` (Ollama host/model config) and `DataSection` (index location + full-wipe "Clear index" action), including a new `DELETE /repos` backend endpoint and `chroma_data_dir` on `GET /config`.
- Applies UI-DESIGN.md's responsive table across the redesigned app: fixes the known Phase 1 `ChatInput` mobile-clipping bug, stacks `SourceCard`/`RepoRow` at narrow widths, and steps page gutters down from `px-6` to `px-4` between 1024px and 640px.
- Accessibility verification pass against WCAG 2.1 AA: a real OKLCH→WCAG contrast check of every token pair (all pass, but it caught a genuine dark-mode contrast failure on three buttons that hardcoded `text-white`), a global visible-focus ring, and a missing live-region role on `RetryCard` that left device-code error states unannounced to screen readers.
- State-coverage verification pass (#87): walked every documented state in UI-DESIGN.md's tables across onboarding, Ask, Library, and Settings against the actual implementation. Fixed one small token bug found along the way (repo-picker loading skeleton). Everything else found broken or missing is catalogued in #95 rather than fixed inline, per #87's scope (verification pass, not a rewrite).

Closes #83
Closes #84
Closes #85
Closes #86
Closes #87

## Changelog

- OnboardingPage state-machine orchestrator + 3-dot progress indicator, wired into `App.jsx`'s `/onboarding` route
- Fix device-flow double-start race (StrictMode) via the same persistent-ref guard IndexStep already uses
- Parallelize per-repo commit-count estimation in `GET /github/repos` (thread pool, per-thread rate limiter)
- Add `ModelsSection.jsx`: Ollama host/extraction/embedding model inputs, saved via `PATCH /config`
- Add `chroma_data_dir` to `GET/PATCH /config` (env-derived, read-only — PATCH silently drops it rather than persisting a dead value)
- Add `ingestion/store.clear_all()` + `DELETE /repos`: full-wipe clear-index action (collection + cursors + `indexed_repos`)
- Add `DataSection.jsx`: read-only index location, "Clear index" with inline confirm
- Fix `ChatInput`'s mobile clipping bug: textarea auto-grows with content (capped, scrollable) instead of hiding wrapped text behind a fixed `rows={1}` height; input bar drops to `p-3` below 640px
- `SourceCard` goes full-width instead of a fixed `w-64` below 640px; `RepoRow` wraps to two lines (name+Remove, then status) instead of a cramped single row
- Truncate long repo names in `RepoPickerRow`/`RepoRow` so a long `owner/repo` slug can't force horizontal scroll
- Step page-level gutters (`TopNav`, `Ask`, `Library`, `Settings`) from `px-6` to `px-4` between 1024px and 640px; onboarding's centering wrapper drops to `p-4` below 640px so its cards read as full-width with a 16px margin
- Add `lib/colorContrast.js` + a permanent test asserting every design-token pair used for text/UI meets WCAG AA (4.5:1) in both themes — see contrast results below
- Fix dark-mode contrast failure on `IndexStep`/`RepoPickerStep`/`RetryCard` buttons: hardcoded `text-white` on `bg-accent`/`bg-danger` passed in light mode but fell to 2.27:1/2.88:1 in dark mode; switched to `text-accent-ink` (6.4-8.4:1 in both themes), the token already built for this and already used correctly by `ErrorCard`
- Add a global `:focus-visible` rule (2px `--color-accent` ring, 2px offset) so every interactive element gets a consistent, on-brand visible focus state instead of relying on each browser's default outline
- `RetryCard`'s message now carries `role="alert"` (danger tone) or `role="status"` (muted tone) so device-code expired/denied/network-error states are actually announced, matching the pattern already used everywhere else in the app
- Fix repo-picker loading skeleton using `bg-surface` instead of the spec's `bg-highlight` (found during the #87 sweep)

## Contrast check results (issue #86)

All 10 token pairs used for text/UI components pass AA's 4.5:1 body-text floor in both themes (see `frontend/src/lib/colorContrast.test.js`, computed via a real OKLCH→linear-sRGB→relative-luminance conversion, not an OKLCH-lightness shortcut):

| Pair | Light | Dark |
|---|---|---|
| ink / surface | 15.77 | 15.17 |
| ink / panel | 16.47 | 13.75 |
| ink-muted / surface | 6.55 | 6.97 |
| ink-muted / panel | 6.84 | 6.32 |
| accent / surface | 5.45 | 8.22 |
| accent / panel | 5.70 | 7.45 |
| accent-ink / accent | 5.53 | 8.44 |
| danger / surface | 6.34 | 6.47 |
| danger / panel | 6.62 | 5.87 |
| accent-ink / danger | 6.43 | 6.65 |

No token nudges needed — all pass comfortably as committed. The one real failure found (`text-white` on `bg-accent`/`bg-danger` in dark mode, 2.27:1/2.88:1) was a component bug, not a token problem, and is fixed above.

## Keyboard / reduced-motion verification (issue #86)

No browser/screenshot tooling available in this sandbox, so this was a full code-level audit rather than a live walkthrough — a human should still do a real keyboard-only pass before merge:

- Onboarding, Ask, Library, Settings: every interactive element is a native `<button>`/`<a href>`/`<input>`/`<label>` (no `div onClick`), so all are Tab-reachable and Enter/Space-operable by default; `RepoFilter`'s listbox intentionally keeps its existing roving-focus pattern (unchanged per scope).
- `CitationMarker` renders as a real `<a href="#source-…">` rather than the `<button>` UI-DESIGN.md's prose names — kept as-is (already focusable, keyboard-operable, and has an accessible name); flagging the doc/implementation mismatch rather than changing an established, tested component shape.
- Added the global focus ring above so focus state is visible everywhere, not just on the one component (`ChatInput`) that had explicit focus styling before.
- Answer-settle motion's reduced-motion fallback (`usePrefersReducedMotion`, gating both `AnswerPassage` and `CitationMarker`) was already correctly implemented and already covered by `AnswerPassage.test.jsx` — confirmed, no fix needed.

## State-coverage checklist (issue #87)

Walked every documented state in UI-DESIGN.md across onboarding, Ask, Library, and Settings. Checked = verified correct as implemented. Unchecked = broken/missing/diverges from spec; all catalogued in #95 for follow-up (grouped there into suggested `daily-task`-sized issues), except one trivial fix applied directly in this PR.

**Onboarding — Step 1 (DeviceCodeCard)**
- [x] pending
- [x] authorized (crossfade + auto-advance)
- [ ] expired — swaps to a generic RetryCard instead of greying the code area per spec (#95)
- [x] denied
- [x] network error (ErrorCard pattern, retry re-calls start)

**Onboarding — Step 2 (Choose repos)**
- [x] loading = 5 skeleton rows (fixed `bg-surface` → `bg-highlight` token bug in this PR)
- [x] empty search "No repos match."
- [x] API error inline + retry
- [x] org-restricted footnote (shown unconditionally by deliberate design — no reliable API signal exists to detect the state conditionally; documented in code)
- [x] Continue disabled until ≥1 selected, "Index N repo(s)"

**Onboarding — Step 3 (Indexing)**
- [x] "Start asking" appears once first repo completes; indexing continues in background
- [ ] "Some failed" per-repo retry action — no retry button exists for a failed repo (#95)

**Onboarding — optional Gemini key step**
- [x] Quiet panel, Save + Skip for now
- [ ] Save → PATCH /config with live validation — deliberately out of scope per #82 vs. a UI-DESIGN.md/SYSTEM-DESIGN.md disagreement that needs a human decision (#95)

**Ask — reading room**
- [x] User question bubble
- [x] AnswerPassage prose + CitationMarkers (numbering, click-scroll)
- [ ] Marker hover/focus highlight wash on linked SourceCard + 1.2s click wash (#95)
- [x] Sources row / SourceCard content + layout
- [ ] SourcesView degraded mode: serif lead-in, expanded cards w/ decision+rationale, dismissible banner — none implemented, biggest single gap found (#95)
- [x] LoadingCard three-dot pulse
- [ ] LoadingCard status line reflecting real backend stage — currently a fixed fake timer (#95)
- [ ] Empty-state chips generated from indexed repos — currently fully static (#95)
- [x] ErrorCard (message + Retry disabled in flight, styling)
- [x] Signature motion: passage fade-up, marker stagger ink-in, reduced-motion fallback
- [ ] Signature motion: SourceCards group entrance (+90ms) — not implemented (#95)

**Library — RepoRow**
- [ ] idle/indexed status line " · indexed N days ago" — no timestamp field in the backend/API to source this from (#95)
- [x] queued
- [x] fetching
- [x] extracting + progress bar
- [x] embedding
- [ ] failed — exact server error shown, but no Retry button (#95)
- [ ] stale (>30 days) " · consider re-indexing" — not implemented, no age data available (#95)
- [x] empty state
- [x] remove inline confirmation (row swap, no modal)
- [x] Add repos → RepoPicker panel
- [ ] Re-index action button — not implemented, only Remove exists (#95)

**Settings**
- [x] GitHub connected (account, Reconnect, Disconnect + confirm)
- [x] GitHub expired banner + Reconnect (on Settings page itself)
- [ ] GitHub expired → global quiet banner on Ask — not implemented (#95)
- [x] Gemini masked input + Save + explainer
- [ ] Gemini live 1-token validation (invalid/valid states) — deliberately out of scope per #82 vs. the same doc disagreement as above (#95)
- [x] Gemini remove key + confirm
- [x] Models host/extraction/embedding inputs
- [ ] Models "Advanced" collapse — not implemented, inputs render flat (#95)
- [ ] Models save pings Ollama `/api/tags` + missing-model warning — deliberately out of scope per #83, same doc disagreement (#95)
- [x] Data index location (read-only, mono)
- [ ] Data decision count — not implemented, no field in `ConfigResponse` (#95)
- [ ] Data clear-index confirm count ("Clear N indexed decisions?") — generic text only, no count (#95)

## Test plan

- [x] `npm test` (frontend): 193/193 passing
- [x] `npm run lint` / `npm run build`: clean
- [x] Backend changes reviewed end-to-end per CLAUDE.md's no-test-suite-yet verification rule; `pytest` could not be executed in this sandbox (python invocations were blocked at the tool-permission layer) — new/updated tests are included in `tests/test_store.py`, `tests/test_repos_router.py`, `tests/test_config_router.py` for a human or CI run to confirm
- [x] Responsive pass (#85) and accessibility pass (#86) verified via static/code-level audit (no browser/screenshot tooling in this sandbox) — a human should spot-check breakpoints and do a live keyboard walkthrough before merge
- [x] State-coverage sweep (#87) verified via static/code-level audit against UI-DESIGN.md's state tables (no browser/screenshot tooling in this sandbox)

