### PR TITLE
fix: two config-resolution bugs that made Settings-saved values invisible

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -39,7 +39,13 @@ class Settings(BaseSettings):
 
         stored = config_store.load()
         for key, value in stored.items():
-            if value is not None and key not in data:
+            # `data.get(key) == ""` (not just `key not in data`) so an env
+            # var that's declared but empty (e.g. .env's `GEMINI_API_KEY=`
+            # with nothing after the `=`) still falls back to the store
+            # instead of permanently shadowing it with "". An empty list
+            # (e.g. indexed_repos cleared via DELETE /repos) is a real,
+            # deliberate value and must NOT be treated the same way.
+            if value is not None and (key not in data or data[key] == ""):
                 data[key] = value
         return data
 

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -10,6 +10,7 @@ parses the request, calls the store, and shapes the response.
 from fastapi import APIRouter, HTTPException
 
 import config_store
+from config import get_settings
 from models import ConfigPatchRequest, ConfigResponse
 
 router = APIRouter()
@@ -31,5 +32,11 @@ def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
         updated = config_store.save(payload)
     except config_store.ConfigValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    # Other routers (query, repos, github_client...) read config.Settings,
+    # which is @lru_cache'd — without this, a saved change here (e.g. a
+    # new Gemini key) is invisible to them until process restart. Mirrors
+    # DELETE /repos's same cache_clear() after its own config_store write.
+    get_settings.cache_clear()
 
     return ConfigResponse(**config_store.mask(updated), chroma_data_dir=config_store.chroma_data_dir())

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from pydantic import ValidationError
 
+import config_store
 from config import Settings, get_settings
 
 REQUIRED_ENV = {
@@ -73,6 +74,22 @@ def test_missing_required_var_raises_validation_error(monkeypatch, tmp_path):
 
     with pytest.raises(ValidationError):
         Settings()
+
+
+def test_empty_env_var_still_falls_back_to_config_store(monkeypatch, tmp_path):
+    # A `.env` line like `GEMINI_API_KEY=` (declared but empty) used to
+    # permanently shadow a real value saved in config_store via Settings
+    # UI, since the fallback only ran when the key was fully absent from
+    # env. Reported live: saving a Gemini key in Settings kept showing
+    # "no Gemini key configured" until the .env line itself was removed.
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    _set_required_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "")
+    config_store.save({"gemini_api_key": "gk_from_store"})
+
+    settings = Settings()
+
+    assert settings.gemini_api_key == "gk_from_store"
 
 
 def test_get_settings_is_cached(monkeypatch):

--- a/backend/tests/test_config_router.py
+++ b/backend/tests/test_config_router.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import config_store
+from config import get_settings
 from main import app
 
 client = TestClient(app)
@@ -74,6 +75,24 @@ def test_patch_rejects_an_empty_string_field():
     response = client.patch("/config", json={"github_token": "   "})
 
     assert response.status_code == 422
+
+
+def test_patch_invalidates_the_cached_settings_singleton(monkeypatch):
+    # get_settings() is @lru_cache'd; other routers (query, repos,
+    # github_client...) read it instead of config_store directly, so a
+    # PATCH here must invalidate that cache or they'd keep serving the
+    # pre-patch value (e.g. a stale/empty Gemini key) until process
+    # restart, per the "no Gemini key" bug found running the live app.
+    # GEMINI_API_KEY must be unset here since env always wins over the
+    # store (config.py) — this test is about the store's value reaching
+    # a fresh Settings(), not about env precedence.
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    get_settings.cache_clear()
+    get_settings()  # populate the cache with the pre-patch value
+
+    client.patch("/config", json={"gemini_api_key": "gk_1234567890abcdef"})
+
+    assert get_settings().gemini_api_key == "gk_1234567890abcdef"
 
 
 def test_patch_can_clear_indexed_repos_without_touching_other_fields():

--- a/backend/tests/test_query_router.py
+++ b/backend/tests/test_query_router.py
@@ -81,7 +81,12 @@ def test_query_translates_embedding_error_to_503():
     assert "failed to reach Ollama" in response.json()["detail"]
 
 
-def test_query_returns_sources_only_when_no_gemini_key_is_configured(monkeypatch, make_unit):
+def test_query_returns_sources_only_when_no_gemini_key_is_configured(monkeypatch, make_unit, tmp_path):
+    # Isolate config_store's fallback path (config.py's _fill_from_config_store):
+    # an empty-but-present GEMINI_API_KEY now correctly falls back to the
+    # store, so this test must not see the real local config_store.json's
+    # own key, or it'd synthesize instead of testing the no-key path.
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("GEMINI_API_KEY", "")
     config.get_settings.cache_clear()
 


### PR DESCRIPTION
## Summary

Two independent backend bugs, both found running the app live right after #94 merged. Together they made saving a Gemini key in Settings appear to do nothing — the Ask page kept showing *"No Gemini key configured — showing retrieved sources directly."* no matter how many times the key was saved.

## The bugs

**1. `PATCH /config` never invalidated the cached `Settings` singleton** (`3c72c6d`)

`get_settings()` is `@lru_cache`d, and `routers/query.py` (via `synthesis_available()`), `routers/repos.py`, and `github_client.py` all read through it rather than hitting `config_store` directly. `DELETE /repos` already calls `get_settings.cache_clear()` after its own `config_store` write; `PATCH /config` was missing the same call — so any value saved through Settings stayed invisible to every consumer until the process restarted.

**2. `_fill_from_config_store` ignored env vars that are present but empty** (`b4af555`)

The fallback only backfilled a field when the env var was *entirely absent* (`key not in data`). A `.env` line declared but left blank — `GEMINI_API_KEY=` — counts as present, so it permanently shadowed the real value saved via the Settings UI with `""`. No amount of saving a key in Settings could ever take effect while that blank line stayed in `.env`.

Now falls back when the env value is `""` too, while still treating an explicitly-saved empty list (e.g. `indexed_repos` cleared via `DELETE /repos`) as a real, deliberate value rather than triggering a bogus fallback.

## Test plan

- [x] `pytest`: 163/163 passing (`.env` moved aside to match CI's no-`.env` condition)
- [x] New test `test_patch_invalidates_the_cached_settings_singleton` — populates the cache, PATCHes, asserts the new value is visible
- [x] New test `test_empty_env_var_still_falls_back_to_config_store` — reproduces the exact `GEMINI_API_KEY=` shadowing case
- [x] Fixed a test-isolation gap in `test_query_router.py` that the fallback fix surfaced: `test_query_returns_sources_only_when_no_gemini_key_is_configured` never isolated `CHROMA_DATA_DIR`, so it began reading the real local `config_store.json`'s key
- [x] Verified live: `POST /query` now returns `mode: "synthesized"` where it previously returned `mode: "sources_only"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)