### PR TITLE
docs: v2 design — prove the core, then build the platform

### DIFF
--- a/docs/superpowers/specs/2026-08-04-v2-design.md
+++ b/docs/superpowers/specs/2026-08-04-v2-design.md
@@ -1,0 +1,373 @@
+# v2 design — prove the core, then build the archive
+
+Status: approved 2026-08-04. Supersedes ROADMAP.md's Phase 3 and Phase 4.
+
+## Why v2 exists
+
+Phase 2 shipped a well-tested, accessible, visually considered application
+shell. It did not prove that the thing inside the shell works.
+
+Four measurements taken against the running instance on 2026-08-04:
+
+| Measurement | Value |
+|---|---|
+| Commit body text, last 50 commits — adr-engine | 15,872 chars |
+| Commit body text, last 50 commits — BuFin | 299 chars |
+| Indexed decisions — adr-engine | 38 (from 169 commits, ~22%) |
+| Indexed decisions — BuFin | 0 |
+
+The golden evaluation set in `docs/eval-questions.md` contains ten
+questions. All ten source from BuFin. BuFin has zero indexed decisions,
+so the quality gate the project designed for itself has never been run.
+
+There is no `cursors.json` in `chroma_data/` at all. `set_cursor()` fires
+once, at the end of `run_ingestion()`. Units are upserted incrementally
+before it. So adr-engine holds 38 units from a run that never finished,
+and no ingestion has ever completed cleanly for either repo.
+
+### The root cause
+
+Extraction reads commit messages and PR text. It never reads the diff.
+
+adr-engine's commit bodies are agent-written essays that already state
+decision, rationale, and alternatives in prose. The extractor reformats
+them. BuFin's commits are subject-line-only — `fix: preserve UTC
+timestamps for impulse cooldown`, body empty — which is what normal
+repositories look like. The extractor correctly returns nothing, because
+there is nothing there to read.
+
+This inverts the product's central promise:
+
+> answers "why is this built this way?" ... mined automatically from
+> GitHub history — no one has to remember to write an ADR
+> — PRODUCT.md
+
+Today the tool works only where someone already did. The repositories
+that need it most are precisely the ones it returns zero for. Nothing in
+the planned Phase 3 or Phase 4 addresses this; a decision browser over
+zero decisions is an empty page.
+
+## Decisions
+
+Ten decisions were settled before this document was written.
+
+1. **v2 is quality first, then features, gated.** A measurable retrieval
+   bar separates the two halves.
+2. **Extraction reads code diffs**, locally, via Ollama.
+3. **Privacy is enforced per repository**, with a `cloud_synthesis_allowed`
+   flag.
+4. **That flag defaults from GitHub visibility** — public repos allow
+   cloud synthesis, private repos default to local-only.
+5. **The gate is recall@5** against a frozen fixture index, run in CI.
+6. **The Ask page abandons the chat transcript** for an annotated page
+   with margin citations.
+7. **All four archive features ship in v2**: decision browser with
+   path-scoped questions, question history with permalinks and
+   follow-ups, the decision inbox, and scheduled re-indexing with
+   Markdown export.
+8. **The redesign runs after the gate, before the features.**
+9. **Delivery is unchanged, plus a CI quality gate** on every rolling PR.
+10. **Live validation pings are reinstated**, and **SQLite joins Chroma**
+    as an application datastore.
+
+## Shape
+
+```
+V2-A  Prove the core     →  [GATE: recall@5]  →  V2-B  Reading room  →  V2-C  Living archive
+      ~19 issues                                       ~12 issues            ~28 issues
+```
+
+The gate sits between A and B only. Once retrieval is proven, B and C run
+to completion without further gating.
+
+This document is the decomposition, not an implementation plan. Each of
+V2-A, V2-B, and V2-C gets its own spec and its own implementation plan
+before any of its issues are written.
+
+The redesign follows the gate because margin citations are a typographic
+system whose proportions depend on how many citations a typical answer
+carries and how long answers run. Today that is one citation and four
+sentences. Designing a margin apparatus around that would be designing
+around a defect.
+
+---
+
+## V2-A — Prove the core
+
+### A1 · Ingestion reliability
+
+Fixes behaviour that is provably broken today.
+
+| Problem | Fix |
+|---|---|
+| Cursor written once at the end of `run_ingestion()`; any crash discards all progress, and no `cursors.json` has ever been written | Persist the cursor incrementally as units are stored |
+| `state.counts` never updates mid-run, so the indexing UI shows static zeros for the whole run | Thread a progress callback from `run_ingestion` through `ingest_job` into `state.counts` |
+| Merge commits produce restatement units carrying no decision content | Skip merge commits at fetch time |
+| A failed repo offers no retry | Per-repo retry action (from #95) |
+
+### A2 · Diff-aware extraction
+
+The quality unlock.
+
+- `github_client` fetches per-commit and per-PR file diffs.
+- Content is filtered before the model sees it: lockfiles, generated
+  output, vendored directories, and binaries are excluded. Per-commit
+  diffs are capped with head/tail truncation. BuFin's median diff is 45
+  lines and its p90 is 361, so the cap engages rarely; its p99 of 3,140
+  lines is the case it exists for.
+- The extraction prompt receives the commit message *and* the filtered
+  diff.
+- `DecisionUnit` gains `files_changed: list[str]`. This is a byproduct of
+  reading diffs and is what makes V2-C's path-scoped questions cheap.
+- Each repository carries a `cloud_synthesis_allowed` setting in the
+  config store, checked at query time so a local-only repository never
+  reaches Gemini.
+
+#### Privacy model
+
+Extraction is local in every configuration; diffs never leave the
+machine. Synthesis is what varies.
+
+`synthesis/answer._format_unit()` sends Gemini `id`, `title`, `decision`,
+`rationale`, and `url` — deliberately never `source_excerpt`. Once diffs
+feed extraction, `decision` and `rationale` become prose *derived from*
+source. That is not code, and it is unmistakably a description of code.
+
+Therefore: each repository carries `cloud_synthesis_allowed`, defaulting
+to `true` for public repositories and `false` for private ones, read from
+the `private` flag already present on `RepoSummary`. The default requires
+no user decision and is explainable in one line on screen. It is
+overridable per repository from the Library page.
+
+A local-only repository falls back to local synthesis, and its answers
+are labelled as such.
+
+### A3 · Eval harness
+
+The gate.
+
+- A frozen fixture corpus is checked into the repository: `DecisionUnit`
+  records plus precomputed embeddings, built from BuFin and adr-engine
+  history.
+- `backend/eval/` loads the fixture, runs the golden questions, and
+  reports recall@5 against the expected commit SHAs already recorded in
+  `docs/eval-questions.md`.
+- The golden set grows from 10 to approximately 40 questions across both
+  repositories.
+- A CI workflow runs `pytest` and the eval harness on every rolling PR.
+  This absorbs open issue #42.
+
+Recall@5 is deterministic, requires no LLM judge, no network, and no
+Ollama — satisfying ARCHITECTURE.md's CI constraints.
+
+#### Setting the threshold
+
+The threshold is not chosen in advance, because no baseline exists — the
+golden questions have never been successfully run. The procedure is:
+
+1. Land the harness and the fixture corpus.
+2. Run it once against extraction as it stands at that moment. That run
+   defines the baseline.
+3. Set the gate at a stated improvement over the baseline, recorded in
+   `docs/eval-questions.md` alongside the baseline number and its date.
+
+Any threshold written today would be invented.
+
+#### Fixture regeneration rule
+
+Frozen embeddings couple the fixture to the embedding model. If
+`OLLAMA_EMBEDDING_MODEL` changes, the fixture must be regenerated or
+recall@5 becomes meaningless. This is recorded as an enforced rule in
+ARCHITECTURE.md, not left as folklore.
+
+### A4 · Retrieval tuning
+
+`retrieval/search.py` sets `k=5` and `RELEVANCE_FLOOR=0.3`. Its own
+docstring records that the floor is a starting value awaiting tuning.
+Neither has ever been tuned.
+
+Both are tuned against the harness. Hybrid keyword-plus-vector retrieval
+and query expansion are each tried and kept **only where they measurably
+move recall@5**. Nothing in A4 ships on intuition.
+
+---
+
+## V2-B — The reading room
+
+### The annotated page
+
+One question renders as one composed page.
+
+```
+┌─ gutter ─┬────── reading column (~68ch) ──────┬── margin (260px) ──┬─ gutter ─┐
+│          │  Why is authentication done        │                    │          │
+│          │  this way?                         │                    │          │
+│          │  ── searched 2 repos · 38 decisions│                    │          │
+│          │                                    │                    │          │
+│          │  Body prose at a real measure,     │  ┌──────────────┐  │          │
+│          │  serif, with inline markers¹ set   │  │ commit d393e68│  │          │
+│          │  where the claim is made.²         │  │ add GitHub…   │  │          │
+│          │                                    │  │ anubhab · 6d  │  │          │
+│          │  Next paragraph continues.³        │  └──────────────┘  │          │
+└──────────┴────────────────────────────────────┴────────────────────┴──────────┘
+```
+
+- The question is set as a heading carrying a provenance dek — *"searched
+  2 repos · 38 decisions"* — stated before the answer is read, per design
+  principle 3.
+- Citations sit beside the paragraph that used them rather than collected
+  underneath. This makes #95's unimplemented highlight wash spatial
+  rather than numeric: focusing marker ² lights the note physically
+  beside it.
+- There is no sticky chat bar. The page is the composition; "Ask another
+  question" is a footer of that page. This removes the roughly 400px of
+  dead space below the current input bar by construction.
+
+### Responsive citation apparatus
+
+| Width | Treatment |
+|---|---|
+| ≥1280px | True margin notes in the right track |
+| 900–1280px | Margin track narrows; notes remain beside their paragraph |
+| <900px | Notes collapse inline, immediately after the citing paragraph |
+
+The narrow-width rule is the important one. Batching notes at the foot of
+the page is what every chat interface does and is exactly what buries
+sources. Keeping each note adjacent to its own paragraph preserves design
+principle 1 at every width.
+
+### Library
+
+- The backend gains `indexed_at`. Rows read `312 decisions · indexed 2
+  days ago`, with a stale marker past 30 days. Both states were blocked
+  in #95 solely for want of this field.
+- `Re-index` and `Remove` per row; retry on failure.
+- The per-repository cloud/local control lives here, not in Settings — it
+  is a property of a repository, and Library is where repositories are
+  seen. The derived default is shown and can be flipped.
+- A repository with zero decisions states why, per design principle 3.
+
+### Settings
+
+- `Extraction model` and `Embedding model` currently render as empty
+  boxes because config holds `null`; the effective defaults are
+  invisible and the section reads as broken. Effective defaults render as
+  placeholders.
+- The Data section gains the total decision count, and the clear-index
+  confirmation gains its count.
+- Host and model inputs move behind the `Advanced` disclosure.
+
+### Live validation
+
+UI-DESIGN.md specifies live Gemini and Ollama validation pings on save.
+SYSTEM-DESIGN.md and issues #82 and #83 forbid them. #95 flagged this as
+a standing contradiction needing a human decision; it has been deferred
+twice.
+
+**Resolved in UI-DESIGN.md's favour.** Once per-repository cloud/local
+routing exists, "is cloud synthesis actually working?" is a question the
+user genuinely needs answered on screen, and silent failure is what
+design principle 3 forbids. SYSTEM-DESIGN.md is amended to permit
+validation pings on explicit save, and only on explicit save.
+
+---
+
+## V2-C — The living archive
+
+Sequenced so each stage feeds the next.
+
+### C1 · History, permalinks, follow-ups
+
+Persisted threads. Every answer receives a stable URL. Follow-up
+questions carry prior citations into retrieval. The redesign's "Ask
+another question" footer grows into a shelf of past pages.
+
+**This forces an architectural addition.** Chroma is a vector store, not
+an application database, and `config_store` is a single flat JSON blob.
+Neither can hold an unbounded, queryable thread history. V2-C introduces
+**SQLite** as the application datastore, alongside Chroma. This is the
+largest structural change in v2 and is recorded in ARCHITECTURE.md before
+any C1 issue is written.
+
+### C2 · Decision browser, path-scoped questions
+
+A browsable, filterable timeline of every extracted decision per
+repository. Consumes `files_changed` from A2, so *"why is
+`backend/auth.py` like this?"* is largely plumbing rather than new
+capability.
+
+This is also the honest fix for the sparse Library page: the application
+gains a second reason to exist besides its search box.
+
+### C3 · Scheduled re-indexing, Markdown export
+
+Interval-based refresh reusing the Phase 2 job machinery. Copy-any-answer
+-with-citations, formatted for PR descriptions and documentation. Both
+small; both make the tool fit into a workflow rather than being a
+destination.
+
+### C4 · Decision inbox
+
+Newly extracted decisions land in a confirm, edit, or discard queue.
+Confirmed units are boosted in retrieval.
+
+It is sequenced last for a specific reason: the retrieval boost is a
+claim about quality, and A3's harness is the only thing that can
+demonstrate the boost helps rather than merely feels right.
+
+---
+
+## Documentation changes
+
+| Document | Change |
+|---|---|
+| `ROADMAP.md` | Phases 1 and 2 become history; V2-A, V2-B, V2-C replace Phases 3 and 4 |
+| `PRODUCT.md` | Privacy claim gains the per-repository model; positioning restated precisely |
+| `SYSTEM-DESIGN.md` | Diff fetching, `files_changed`, `indexed_at`, per-repo flag, eval contract, SQLite, validation pings permitted on explicit save |
+| `ARCHITECTURE.md` | `backend/eval/`, diff filtering rules, SQLite store, fixture regeneration rule |
+| `UI-DESIGN.md` | Major rewrite: annotated page, margin apparatus, responsive collapse |
+| `docs/eval-questions.md` | Grown to ~40 questions; records the baseline and the gate threshold |
+
+## Delivery
+
+Unchanged, plus the CI gate.
+
+Rolling branch `agent/rolling`; the `daily-task` → `in-pr` →
+merged-and-closed state machine; issues sized to one module or component
+at roughly 150 lines of diff; issues numbered in dependency order.
+
+Every rolling PR now runs `pytest` **and** the recall@5 harness, so the
+agent cannot silently regress retrieval.
+
+Issue **#42** is absorbed into A3. The sixteen items catalogued in **#95**
+distribute into V2-B; #95 closes as superseded once they are filed.
+
+Estimated total: approximately 59 issues, or two to three months of daily
+runs at one to three issues per run.
+
+## Risks
+
+- **Local synthesis quality is unproven.** Private repositories default
+  to local-only, so their default experience depends on Ollama prose
+  quality, which is weaker than Gemini's. If it proves unacceptable, the
+  honest response is to say so on screen, not to quietly change the
+  default.
+- **Diff-aware extraction raises volume and noise together.** Yield will
+  rise above 22%, and some of the new volume will be junk. C4's inbox is
+  the intended valve, but it lands last — so V2-A must keep the
+  extractor's "not a decision" path strict rather than permissive.
+- **The eval fixture can rot.** It is coupled to the embedding model by
+  construction. The regeneration rule mitigates this but depends on being
+  followed.
+- **v2 is large.** Fifty-nine issues is longer than Phase 1 and Phase 2
+  combined. The gate between A and B is the natural place to reassess
+  scope if the timeline proves wrong.
+
+## Non-goals
+
+Unchanged from ROADMAP.md: hosted or multi-user deployment, user
+accounts, real-time ingestion, fine-tuning, TypeScript migration.
+
+Jira and Slack sources remain parked until GitHub is fully proven —
+which, by this document's own evidence, it is not yet. Editor and CLI
+integration remain parked for the same reason.

--- a/docs/superpowers/specs/2026-08-04-v2-design.md
+++ b/docs/superpowers/specs/2026-08-04-v2-design.md
@@ -1,40 +1,58 @@
-# v2 design — prove the core, then build the archive
+# v2 design — prove the core, then build the platform
 
-Status: approved 2026-08-04. Supersedes ROADMAP.md's Phase 3 and Phase 4.
+Status: approved 2026-08-04. Supersedes ROADMAP.md Phases 3 and 4, and
+amends its non-goals.
 
 ## Why v2 exists
 
-Phase 2 shipped a well-tested, accessible, visually considered application
-shell. It did not prove that the thing inside the shell works.
+Phase 2 shipped a well-tested, accessible, visually considered
+application shell. It did not prove that the thing inside the shell
+works.
 
-Four measurements taken against the running instance on 2026-08-04:
+Five measurements taken against the running instance on 2026-08-04:
 
 | Measurement | Value |
 |---|---|
 | Commit body text, last 50 commits — adr-engine | 15,872 chars |
 | Commit body text, last 50 commits — BuFin | 299 chars |
-| Indexed decisions — adr-engine | 38 (from 169 commits, ~22%) |
+| Ratio | 53x |
+| Indexed decisions — adr-engine | 38 (from 169 commits, ~22% yield) |
 | Indexed decisions — BuFin | 0 |
 
 The golden evaluation set in `docs/eval-questions.md` contains ten
 questions. All ten source from BuFin. BuFin has zero indexed decisions,
 so the quality gate the project designed for itself has never been run.
+Not "failed" — never run. There has been no point at which anyone could
+look at a number and know whether retrieval works.
 
-There is no `cursors.json` in `chroma_data/` at all. `set_cursor()` fires
-once, at the end of `run_ingestion()`. Units are upserted incrementally
-before it. So adr-engine holds 38 units from a run that never finished,
-and no ingestion has ever completed cleanly for either repo.
+There is no `cursors.json` in `chroma_data/` at all. `set_cursor()`
+fires once, at the end of `run_ingestion()`. Units are upserted
+incrementally before it. So adr-engine holds 38 units from a run that
+never finished, and no ingestion has ever completed cleanly for either
+repository. The 38 decisions currently browsable in the product are a
+side effect of a crash, not the output of a designed process.
+
+BuFin's diff sizes, measured over its last 100 commits: median 45
+lines, mean 140, p90 361, max 3,140. The real code changed across those
+commits totals roughly 9,300 lines; lockfile and generated-file noise
+inside that set is 18 lines, negligible. This matters for what follows:
+BuFin is not a hard case because its commits are large or noisy. It is
+a hard case because its commits are normal, and the extractor was
+built against a corpus that is not.
 
 ### The root cause
 
 Extraction reads commit messages and PR text. It never reads the diff.
 
 adr-engine's commit bodies are agent-written essays that already state
-decision, rationale, and alternatives in prose. The extractor reformats
-them. BuFin's commits are subject-line-only — `fix: preserve UTC
-timestamps for impulse cooldown`, body empty — which is what normal
-repositories look like. The extractor correctly returns nothing, because
-there is nothing there to read.
+decision, rationale, and alternatives in prose. The extractor
+reformats them — it is doing the job of a summarizer applied to text
+that was already a summary. BuFin's commits are subject-line-only —
+`fix: preserve UTC timestamps for impulse cooldown`, body empty —
+which is what normal repositories look like. The extractor correctly
+returns nothing, because there is nothing in the message to read. The
+decision is still there. It is in the diff. Extraction has never
+looked.
 
 This inverts the product's central promise:
 
@@ -42,161 +60,348 @@ This inverts the product's central promise:
 > GitHub history — no one has to remember to write an ADR
 > — PRODUCT.md
 
-Today the tool works only where someone already did. The repositories
-that need it most are precisely the ones it returns zero for. Nothing in
-the planned Phase 3 or Phase 4 addresses this; a decision browser over
-zero decisions is an empty page.
+Today the tool works only where someone already did the work the tool
+claims to remove. The repositories that need it most — the ones where
+no one wrote the essay, where the reasoning lives only in the diff —
+are precisely the ones it returns zero for. A decision browser over
+zero decisions is an empty page. A margin-citation redesign over zero
+decisions is elegant typesetting for an empty page. Nothing planned in
+ROADMAP.md's Phase 3 or Phase 4 touches this, because both phases
+assume a working corpus to browse, thread, and export. v2 exists to
+supply that assumption before spending further effort on top of it.
 
 ## Decisions
 
-Ten decisions were settled before this document was written.
+Fifteen decisions were settled before this document was written.
 
-1. **v2 is quality first, then features, gated.** A measurable retrieval
-   bar separates the two halves.
-2. **Extraction reads code diffs**, locally, via Ollama.
-3. **Privacy is enforced per repository**, with a `cloud_synthesis_allowed`
-   flag.
-4. **That flag defaults from GitHub visibility** — public repos allow
-   cloud synthesis, private repos default to local-only.
+1. **v2 is quality first, then features, behind one measurable gate.**
+   Everything that assumes a working corpus waits until the corpus is
+   shown to work.
+2. **Extraction reads code diffs, locally, via Ollama.** The root cause
+   above is a missing input, not a missing model capability.
+3. **Privacy is enforced per repository**, via a `cloud_synthesis_allowed`
+   flag, because diffs and the prose derived from them are not
+   uniformly safe to send to a cloud model across every repository a
+   user might index.
+4. **That flag defaults from GitHub visibility**: public repositories
+   allow cloud synthesis, private repositories default to local-only.
+   The default requires no decision from the user and is defensible on
+   its face.
 5. **The gate is recall@5** against a frozen fixture index, run in CI.
-6. **The Ask page abandons the chat transcript** for an annotated page
-   with margin citations.
-7. **All four archive features ship in v2**: decision browser with
-   path-scoped questions, question history with permalinks and
-   follow-ups, the decision inbox, and scheduled re-indexing with
-   Markdown export.
-8. **The redesign runs after the gate, before the features.**
-9. **Delivery is unchanged, plus a CI quality gate** on every rolling PR.
-10. **Live validation pings are reinstated**, and **SQLite joins Chroma**
-    as an application datastore.
+   Deterministic, cheap, and repeatable on every PR.
+6. **The gate threshold is an absolute floor of 70%**, committed now,
+   not a relative improvement over whatever baseline the harness
+   happens to measure. A moving bar is not a bar.
+7. **The Ask page abandons the chat transcript** for an annotated page
+   with margin citations, because the product's claim is "cited prose
+   you read," not "messages you scroll."
+8. **Local git ingestion replaces the GitHub API as the primary
+   transport**, and lands before the gate, because the gate's own
+   fixture-building and CI runs need a transport that does not depend
+   on rate limits or a network call.
+9. **Live validation pings (Gemini, Ollama) are reinstated on explicit
+   save**, resolving the standing UI-DESIGN.md vs SYSTEM-DESIGN.md
+   contradiction in UI-DESIGN.md's favor.
+10. **SQLite joins Chroma** as the application datastore, because
+    thread history, permalinks, and the decision inbox need a
+    queryable relational store that a vector index and a flat JSON
+    blob cannot provide.
+11. **v2 spans 23 tracks in 7 waves, approximately 1,355 issues.** The
+    scope below is the honest size of "build the platform," stated
+    once rather than discovered piecemeal.
+12. **Optional team sync is added**; local-first single-user remains
+    the default and the thesis. ROADMAP.md's non-goals are amended
+    accordingly, not abandoned.
+13. **A plugin SDK makes the source catalog open-ended** rather than
+    finite, because Track D's source list — Jira, Linear, Slack,
+    Notion, and the rest — will always be incomplete by construction.
+14. **An MCP server exposes adr-engine to coding agents**, meeting the
+    question where an increasing share of code-touching work already
+    happens.
+15. **Delivery model unchanged** — rolling branch, daily-task state
+    machine, roughly 150-line issues — plus a CI quality gate on every
+    rolling PR from Wave 0 onward.
 
-## Shape
+## Structure
 
 ```
-V2-A  Prove the core     →  [GATE: recall@5]  →  V2-B  Reading room  →  V2-C  Living archive
-      ~19 issues                                       ~12 issues            ~28 issues
+Wave 0   A                              35 issues   →  [GATE: recall@5]
+Wave 1   B, C, R                       175 issues
+Wave 2   D, E, N, M                    290 issues
+Wave 3   F, G, T, U                    220 issues
+Wave 4   H, I, Q, O, P                 250 issues
+Wave 5   J, L, S, V, W                 235 issues
+Wave 6   K                             150 issues
+                                     ─────────────
+                            Total    1,355 issues
 ```
 
-The gate sits between A and B only. Once retrieval is proven, B and C run
-to completion without further gating.
+The gate sits only between Wave 0 and Wave 1. Nothing after it is
+gated. This is deliberate: the gate exists to answer one question —
+does retrieval work at all — and once that question has a measured
+answer, re-litigating it at every subsequent wave boundary would slow
+delivery without improving quality. Waves 1 through 6 are sequenced by
+dependency, not by further quality checkpoints.
 
-This document is the decomposition, not an implementation plan. Each of
-V2-A, V2-B, and V2-C gets its own spec and its own implementation plan
-before any of its issues are written.
+The redesign (Track B) follows the gate rather than running alongside
+it, because margin citations are a typographic system whose
+proportions depend on typical citation count and typical answer
+length. Today that is one citation and four sentences. Designing a
+margin apparatus around that would be designing around a defect —
+fitting the furniture to a room that is not yet the right shape.
 
-The redesign follows the gate because margin citations are a typographic
-system whose proportions depend on how many citations a typical answer
-carries and how long answers run. Today that is one citation and four
-sentences. Designing a margin apparatus around that would be designing
-around a defect.
+Track C, which contains the decision inbox, precedes Track D, because
+the inbox is the noise valve. Track D roughly triples the number of
+source types feeding extraction — issues, discussions, ADR files,
+GitLab, Bitbucket, Jira, Linear, Slack, Notion, Confluence, migrations,
+IaC, CI config, dependency manifests, postmortems, meeting transcripts.
+Shipping that expansion before a review queue exists floods the index
+with unvetted units and makes Track E's modeling work harder for no
+gain. The valve has to exist before the taps are opened.
 
----
+Tracks D and E precede Track G, because contradiction detection over
+38 units is a party trick — there is not enough corpus for
+supersession chains to be interesting. Over an enriched, well-modeled
+corpus, the same capability is the differentiating feature described
+in Track G below. Intelligence needs the corpus to exist before it can
+be intelligent about it.
 
-## V2-A — Prove the core
+Track I (integrations) sits in Wave 4 because it exposes a stable API
+surface, and that surface is more stable once Waves 1 through 3 have
+settled the shape of the underlying product. The CLI specifically is
+the one piece of Track I that can be pulled forward at any point in
+the plan — it is a thin client over the existing API, nothing depends
+on it, and nothing in Track I depends on it being late.
 
-### A1 · Ingestion reliability
+Track K (team sync) is last because it requires everything else to be
+stable: an established data model, a proven retrieval pipeline, a
+settled UI, and integrations already in use. Building sync on top of a
+still-moving foundation would mean rebuilding it.
 
-Fixes behaviour that is provably broken today.
+This document is the decomposition, not an implementation plan. Each
+of the 23 tracks gets its own spec and its own implementation plan
+before its issues are written. What follows sizes and orders the work;
+it does not design it.
 
-| Problem | Fix |
-|---|---|
-| Cursor written once at the end of `run_ingestion()`; any crash discards all progress, and no `cursors.json` has ever been written | Persist the cursor incrementally as units are stored |
-| `state.counts` never updates mid-run, so the indexing UI shows static zeros for the whole run | Thread a progress callback from `run_ingestion` through `ingest_job` into `state.counts` |
-| Merge commits produce restatement units carrying no decision content | Skip merge commits at fetch time |
-| A failed repo offers no retry | Per-repo retry action (from #95) |
+## The gate
 
-### A2 · Diff-aware extraction
+The single quality checkpoint in v2 sits between Wave 0 and Wave 1. It
+exists because, as the evidence above shows, no measurement of
+retrieval quality has ever completed successfully for this project.
+Wave 0 does not ship until one has.
 
-The quality unlock.
+**Metric.** Recall@5 against expected commit SHAs already recorded in
+`docs/eval-questions.md`. For each golden question, the harness runs
+retrieval and checks whether the commit that actually contains the
+answer appears in the top 5 results. This is deterministic: no LLM
+judge scores the answer, no network call is made, no Ollama instance
+needs to be running. It satisfies ARCHITECTURE.md's binding testing
+constraint that CI have none of network, Ollama, or a Gemini call
+available to it.
 
-- `github_client` fetches per-commit and per-PR file diffs.
-- Content is filtered before the model sees it: lockfiles, generated
-  output, vendored directories, and binaries are excluded. Per-commit
-  diffs are capped with head/tail truncation. BuFin's median diff is 45
-  lines and its p90 is 361, so the cap engages rarely; its p99 of 3,140
-  lines is the case it exists for.
-- The extraction prompt receives the commit message *and* the filtered
-  diff.
-- `DecisionUnit` gains `files_changed: list[str]`. This is a byproduct of
-  reading diffs and is what makes V2-C's path-scoped questions cheap.
-- Each repository carries a `cloud_synthesis_allowed` setting in the
-  config store, checked at query time so a local-only repository never
-  reaches Gemini.
+**Absolute floor: 70%, committed now.** This is not a number backed
+into after a baseline run. It is written into this document before
+Track A's tuning work begins, and it does not move once that work is
+done.
 
-#### Privacy model
+**Broken threshold: below 50%.** A recall@5 below half means retrieval
+is not merely under-tuned, it is fundamentally not working — the
+embeddings, the chunking, or the relevance floor are structurally
+wrong. Below that line the correct response is not further tuning
+inside the current approach; it is to stop and change approach.
 
-Extraction is local in every configuration; diffs never leave the
-machine. Synthesis is what varies.
+**Ratchet.** Once a recall@5 number is recorded, CI fails any run that
+drops more than 5 points below the best score on record. The floor of
+70% is the entry requirement; the ratchet prevents backsliding once
+the floor is cleared.
 
-`synthesis/answer._format_unit()` sends Gemini `id`, `title`, `decision`,
-`rationale`, and `url` — deliberately never `source_excerpt`. Once diffs
-feed extraction, `decision` and `rationale` become prose *derived from*
-source. That is not code, and it is unmistakably a description of code.
+**Justifying 70% without a baseline.** The golden set is the easy case,
+by construction. Each question was hand-written by someone who already
+knew the answer existed and which commit held it. Real questions,
+asked by a real user against a real repository, arrive with no such
+guarantee — the answer might not be in the index at all, might be
+split across several commits, or might not exist. If the system cannot
+reliably surface the source for 7 of 10 questions that were rigged in
+its favor, it will do considerably worse against questions that were
+not. This is a judgment about user experience, and it is defensible in
+one sentence: a tool that fails a third of its easiest cases has not
+earned the right to be trusted on its hardest ones.
 
-Therefore: each repository carries `cloud_synthesis_allowed`, defaulting
-to `true` for public repositories and `false` for private ones, read from
-the `private` flag already present on `RepoSummary`. The default requires
-no user decision and is explainable in one line on screen. It is
-overridable per repository from the Library page.
+**Why a purely relative gate was rejected.** Consider the alternative
+this document's own predecessor proposed: measure a baseline, then
+require some stated improvement over it. Suppose that baseline
+measures 28%. "Baseline plus 10 points" passes at 38%. At 38% recall@5,
+roughly two-thirds of the rigged, easy, hand-built golden questions
+fail — and a relative gate says ship it, because the number went up
+from wherever it started. A gate that can pass while the product
+plainly does not work is not a gate. It is a progress bar wearing a
+gate's clothing. The absolute floor exists precisely so that this
+scenario cannot occur.
 
-A local-only repository falls back to local synthesis, and its answers
-are labelled as such.
+**The escape valve.** If Track A exhausts its tuning budget — hybrid
+retrieval, query expansion, relevance floor adjustment, k adjustment —
+and recall@5 still will not clear 70%, that outcome is information, not
+a reason to lower the bar. It means one of two things: the current
+embedding model or retrieval approach is the wrong tool (try a
+different embedding model, add reranking, or move to hybrid keyword-
+plus-vector search), or the product thesis itself needs revisiting. A
+gate that gets quietly lowered the first time it is not cleared was
+never a gate; it was a suggestion.
 
-### A3 · Eval harness
+**Baseline is still measured.** None of the above means the baseline
+number goes unrecorded. It is measured, at the point A3's harness first
+runs against A2's diff-aware extraction, and it is used to size the
+retrieval-tuning work in A4 — how far the current approach is from
+70%, and therefore how much tuning effort to budget. It does not define
+where the bar sits.
 
-The gate.
+**Fixture regeneration rule.** The frozen fixture corpus embeds its
+`DecisionUnit` records with a specific embedding model at build time.
+Frozen embeddings couple the fixture to that model by construction. If
+`OLLAMA_EMBEDDING_MODEL` changes, the fixture's vectors no longer
+correspond to what live retrieval would produce, and recall@5 measured
+against it becomes meaningless — a number that looks like a
+measurement but is not one. This is written into ARCHITECTURE.md as an
+enforced rule — any change to the embedding model configuration
+requires fixture regeneration in the same PR — rather than left as
+something a reviewer is expected to remember.
 
-- A frozen fixture corpus is checked into the repository: `DecisionUnit`
-  records plus precomputed embeddings, built from BuFin and adr-engine
-  history.
-- `backend/eval/` loads the fixture, runs the golden questions, and
-  reports recall@5 against the expected commit SHAs already recorded in
-  `docs/eval-questions.md`.
-- The golden set grows from 10 to approximately 40 questions across both
-  repositories.
-- A CI workflow runs `pytest` and the eval harness on every rolling PR.
-  This absorbs open issue #42.
+## Privacy model
 
-Recall@5 is deterministic, requires no LLM judge, no network, and no
-Ollama — satisfying ARCHITECTURE.md's CI constraints.
+Extraction is local in every configuration. Diffs never leave the
+machine, regardless of whether a repository is public or private,
+regardless of the `cloud_synthesis_allowed` setting described below.
+Only synthesis — the step that turns retrieved decisions into
+answering prose — ever has a cloud option, and even there the option
+is narrow.
 
-#### Setting the threshold
+`synthesis/answer._format_unit()` sends Gemini exactly five fields per
+retrieved unit: `id`, `title`, `decision`, `rationale`, and `url`. It
+deliberately never sends `source_excerpt`. That restriction was sound
+when decisions were extracted from commit messages and PR text, which
+are themselves already public-adjacent, user-authored summaries. It
+stops being sufficient once extraction reads diffs (Track A, decision
+2 above): `decision` and `rationale` are now prose *derived from*
+source code, not independent commentary about it. A well-written
+rationale sentence generated from a diff can restate the shape of the
+code closely enough that it is, in substance, a description of that
+code. That is not a flaw in the extraction prompt — a good rationale
+is supposed to explain what changed — but it means the five fields
+sent to Gemini are no longer safely decoupled from source content the
+way they were in Phase 2.
 
-The threshold is not chosen in advance, because no baseline exists — the
-golden questions have never been successfully run. The procedure is:
+Therefore each repository carries a `cloud_synthesis_allowed` flag in
+the config store. It defaults to `true` for public repositories and
+`false` for private ones, read from the `private` flag already present
+on `RepoSummary` — no new GitHub call, no new field to fetch, just a
+default derived from data already on hand. This requires no decision
+from the user at onboarding time, and it is explainable in one line on
+screen: "this repository is private, so answers are generated locally."
+It is overridable per repository from the Library page (Track B),
+because visibility is a property of a repository and Library is where
+repositories are managed.
 
-1. Land the harness and the fixture corpus.
-2. Run it once against extraction as it stands at that moment. That run
-   defines the baseline.
-3. Set the gate at a stated improvement over the baseline, recorded in
-   `docs/eval-questions.md` alongside the baseline number and its date.
+A repository with `cloud_synthesis_allowed = false` falls back to
+local synthesis via Ollama, and its answers are labeled as such in the
+UI, consistent with design principle 3 (honest state) and design
+principle 4 (earn the privacy claim on-screen) from PRODUCT.md. The
+label is not a caveat buried in Settings; it sits next to the answer
+it describes.
 
-Any threshold written today would be invented.
+Track L (security and compliance, Wave 5) extends this model with
+three further controls: secret detection before indexing, so that a
+leaked API key sitting in a diff never becomes part of the corpus in
+the first place; PII redaction ahead of cloud synthesis, catching
+personal data that slips into commit messages, PR descriptions, or
+Slack threads (Track D) before it reaches Gemini; and an audit log
+recording exactly what left the machine, and when, for any repository
+where cloud synthesis is enabled. Together these make the privacy
+claim something the product can show, not merely something it states.
 
-#### Fixture regeneration rule
+## The tracks
 
-Frozen embeddings couple the fixture to the embedding model. If
-`OLLAMA_EMBEDDING_MODEL` changes, the fixture must be regenerated or
-recall@5 becomes meaningless. This is recorded as an enforced rule in
-ARCHITECTURE.md, not left as folklore.
+Twenty-three tracks, organized into the seven waves above. Each
+section states what the track contains, why it exists at this point in
+the sequence, what it depends on, and what it unlocks downstream.
 
-### A4 · Retrieval tuning
+### Track A · Core proving (~35, Wave 0)
 
-`retrieval/search.py` sets `k=5` and `RELEVANCE_FLOOR=0.3`. Its own
-docstring records that the floor is a starting value awaiting tuning.
-Neither has ever been tuned.
+Track A exists to make the product's central claim true before
+anything else is built on top of it. Its contents fall into five
+groups.
 
-Both are tuned against the harness. Hybrid keyword-plus-vector retrieval
-and query expansion are each tried and kept **only where they measurably
-move recall@5**. Nothing in A4 ships on intuition.
+**Local git transport** replaces the GitHub API as the primary
+ingestion path. Reading 169 commits off a local clone is a `git log`
+call and a set of `git show` invocations against disk — instant,
+compared to paginated API calls that need a token, respect a rate
+limiter, and depend on network availability. Local transport also
+works offline, against air-gapped repositories, and against
+repositories that are not hosted on GitHub at all, none of which the
+current GitHub-only client supports. This lands first in Track A
+because the eval harness (below) needs a transport it can run
+repeatedly in CI without hitting a rate limit or requiring network
+access, and because everything else in Track A is easier to build and
+test against a local clone than against paginated API responses.
 
----
+**Diff-aware extraction** is the fix for the root cause described
+above. It fetches per-commit and per-PR diffs, filters out lockfiles,
+generated output, vendored directories, and binaries before the model
+ever sees them, and applies a head-tail truncation cap to oversized
+diffs — BuFin's own p90 of 361 lines and max of 3,140 lines is the
+range this cap is sized against. The extraction prompt is rewritten to
+receive the commit message *and* the filtered diff together, rather
+than the message alone. As a byproduct of reading diffs, `DecisionUnit`
+gains a `files_changed: list[str]` field — cheap to compute once the
+diff is already in hand, and the field that makes Track C's path-scoped
+questions and Track G's line-level "why is this here" tractable later
+without a second pass over history.
 
-## V2-B — The reading room
+**Resumable, honest ingestion** fixes three provably broken behaviors
+documented in the evidence section above: cursors are persisted
+incrementally as each unit is stored, not once at the end of
+`run_ingestion()`, so a crash mid-run no longer discards all progress;
+a progress callback threads from `run_ingestion` through `ingest_job`
+into `state.counts`, so the indexing UI shows real counts instead of
+static zeros for the run's entire duration; and merge commits are
+skipped at fetch time, because they produce restatement units that
+carry no decision content of their own. Per-repository retry on
+failure is added alongside these, absorbing the retry item already
+catalogued in open issue #95.
 
-### The annotated page
+**The eval harness** is the gate itself: a frozen fixture corpus of
+`DecisionUnit` records and precomputed embeddings, checked into the
+repository and built from BuFin and adr-engine history; a
+`backend/eval/` module that loads the fixture and reports recall@5
+against the expected commit SHAs already recorded in
+`docs/eval-questions.md`; growth of the golden set from 10 questions
+to roughly 40, spanning both repositories; and a CI workflow running
+`pytest` plus the recall@5 harness on every rolling PR, which absorbs
+open issue #42.
 
-One question renders as one composed page.
+**Retrieval tuning** closes Track A. `retrieval/search.py` currently
+sets `k=5` and `RELEVANCE_FLOOR=0.3`; the module's own docstring
+admits the floor is a starting value, and neither number has ever
+been tuned against a working measurement, because until this track no
+working measurement existed. Both are tuned against the harness.
+Hybrid keyword-plus-vector search and query expansion are each tried
+and kept only where they measurably move recall@5 — nothing in this
+track ships on intuition, per the gate's own rules above.
+
+Per-repository `cloud_synthesis_allowed` plumbing is threaded through
+the config store in this track as well, so the privacy model above is
+in place before diff-derived rationale text starts flowing to
+synthesis in Wave 1 and beyond.
+
+Track A is what makes `files_changed` available for everything
+downstream that needs to answer "why is this line here" cheaply,
+rather than reconstructing file-to-commit mappings from scratch in a
+later track.
+
+### Track B · Reading surfaces (~75, Wave 1)
+
+Track B is the redesign this document's decisions section commits to:
+the Ask page stops being a chat transcript and becomes one composed,
+annotated page per question.
 
 ```
 ┌─ gutter ─┬────── reading column (~68ch) ──────┬── margin (260px) ──┬─ gutter ─┐
@@ -212,18 +417,22 @@ One question renders as one composed page.
 └──────────┴────────────────────────────────────┴────────────────────┴──────────┘
 ```
 
-- The question is set as a heading carrying a provenance dek — *"searched
-  2 repos · 38 decisions"* — stated before the answer is read, per design
-  principle 3.
-- Citations sit beside the paragraph that used them rather than collected
-  underneath. This makes #95's unimplemented highlight wash spatial
-  rather than numeric: focusing marker ² lights the note physically
-  beside it.
-- There is no sticky chat bar. The page is the composition; "Ask another
-  question" is a footer of that page. This removes the roughly 400px of
-  dead space below the current input bar by construction.
+The question is set as a heading carrying a provenance dek —
+*"searched 2 repos · 38 decisions"* — stated before the answer is read,
+per design principle 3 (honest state). Citations sit beside the
+paragraph that used them rather than collected underneath, which
+matters for a concrete reason: it turns the still-unimplemented
+highlight-wash interaction from issue #95 into something spatial
+rather than numeric — focusing citation marker ² lights the note
+physically beside it, instead of requiring a jump to a numbered list
+at the foot of the page. There is no sticky chat bar. The page is the
+composition, and "Ask another question" is its footer, which removes
+the roughly 400px of dead space that sits below the current input bar
+by construction, not by a subsequent layout fix.
 
-### Responsive citation apparatus
+The responsive citation apparatus is the part of this track most
+likely to be gotten wrong, so it is specified as a table rather than
+left to per-breakpoint judgment calls:
 
 | Width | Treatment |
 |---|---|
@@ -231,143 +440,657 @@ One question renders as one composed page.
 | 900–1280px | Margin track narrows; notes remain beside their paragraph |
 | <900px | Notes collapse inline, immediately after the citing paragraph |
 
-The narrow-width rule is the important one. Batching notes at the foot of
-the page is what every chat interface does and is exactly what buries
-sources. Keeping each note adjacent to its own paragraph preserves design
-principle 1 at every width.
+The narrow-width row is the one that matters most. Batching citations
+at the foot of the page — the behavior of essentially every chat
+interface — is exactly what buries sources. Collapsing notes inline,
+immediately after the paragraph that cites them, rather than
+relocating them to a shared list, preserves design principle 1
+(citations are the product) at every viewport width, including the
+one where space is tightest and the temptation to economize is
+strongest.
 
-### Library
+Beyond the core reading surface, Track B adds a command palette; graph
+and timeline views over the decision corpus; a file-tree decision
+heatmap; bookmarks; personal annotations on answers; a print and PDF
+stylesheet; density and measure preferences for the reading column;
+and a focus mode that suppresses chrome entirely. It also adds
+coverage and confidence signalling: every answer states what it drew
+on — "from 3 decisions spanning 2019–2024; coverage for this area is
+thin" — rather than presenting a confident-sounding paragraph with no
+indication of how much evidence stands behind it. A privacy
+transparency panel shows exactly what was sent to Gemini for the last
+answer and what stayed local, making the privacy model in the section
+above something the user can inspect rather than take on faith.
 
-- The backend gains `indexed_at`. Rows read `312 decisions · indexed 2
-  days ago`, with a stale marker past 30 days. Both states were blocked
-  in #95 solely for want of this field.
-- `Re-index` and `Remove` per row; retry on failure.
-- The per-repository cloud/local control lives here, not in Settings — it
-  is a property of a repository, and Library is where repositories are
-  seen. The derived default is shown and can be flipped.
-- A repository with zero decisions states why, per design principle 3.
+Two long-standing Library and Settings defects are fixed in this
+track because they are blocked on exactly the same missing pieces the
+redesign needs anyway. Library gains a backend `indexed_at` field, so
+rows read "312 decisions · indexed 2 days ago" with a stale marker
+past 30 days — both states were blocked in issue #95 solely for want
+of this field. Re-index and Remove actions land per row, along with
+retry on failure. The per-repository cloud/local control from the
+privacy model lives here, because it is a property of a repository and
+Library is where repositories are seen and managed. A repository with
+zero decisions states why, rather than showing an empty list with no
+explanation, per design principle 3. In Settings, `Extraction model`
+and `Embedding model` currently render as empty input boxes because
+the config store holds `null` and the effective defaults are never
+shown — the section reads as broken rather than merely unconfigured.
+Effective defaults now render as placeholders. The Data section gains
+a total decision count, the clear-index confirmation gains that same
+count so the action's consequence is stated in numbers rather than
+implied, and host and model inputs move behind an `Advanced`
+disclosure so the common path stays uncluttered.
 
-### Settings
+### Track C · The living archive (~60, Wave 1)
 
-- `Extraction model` and `Embedding model` currently render as empty
-  boxes because config holds `null`; the effective defaults are
-  invisible and the section reads as broken. Effective defaults render as
-  placeholders.
-- The Data section gains the total decision count, and the clear-index
-  confirmation gains its count.
-- Host and model inputs move behind the `Advanced` disclosure.
+Track C is where Phase 3's planned features land, rebuilt on top of a
+proven retrieval pipeline instead of a 38-unit accident.
 
-### Live validation
+The foundation is structural rather than a feature: Chroma is a vector
+store, not an application database, and `config_store` is a single
+flat JSON blob. Neither can hold unbounded, queryable thread history,
+a decision browser's filters, or an inbox's review state. SQLite joins
+Chroma as the application datastore — the largest structural change in
+v2 — and it is recorded in ARCHITECTURE.md before any Track C issue is
+written, consistent with ARCHITECTURE.md's own rule that this file is
+binding and deviations belong in a PR discussion, not silent drift.
 
-UI-DESIGN.md specifies live Gemini and Ollama validation pings on save.
-SYSTEM-DESIGN.md and issues #82 and #83 forbid them. #95 flagged this as
-a standing contradiction needing a human decision; it has been deferred
-twice.
+On top of that foundation, Track C adds question history with
+persisted threads; permalinks, so every answer receives a stable URL
+rather than existing only for the session that produced it; follow-up
+questions that carry prior citations into retrieval, so a second
+question in a thread benefits from what the first one already
+surfaced; a decision browser — a browsable, filterable timeline of
+every extracted decision per repository; and path-scoped questions
+("why is `backend/auth.py` like this?"), which consume the
+`files_changed` field Track A produced as a byproduct, making this
+capability largely plumbing rather than new extraction work. Markdown
+export formats any answer with its citations for direct use in PR
+descriptions and documentation. Scheduled re-indexing reuses the
+Phase 2 job and status machinery to keep an index current on an
+interval rather than only on manual re-index.
 
-**Resolved in UI-DESIGN.md's favour.** Once per-repository cloud/local
-routing exists, "is cloud synthesis actually working?" is a question the
-user genuinely needs answered on screen, and silent failure is what
-design principle 3 forbids. SYSTEM-DESIGN.md is amended to permit
-validation pings on explicit save, and only on explicit save.
+The centerpiece of Track C is the decision inbox: newly extracted
+decisions land in a confirm, edit, or discard queue rather than being
+written straight into the index, and confirmed units are boosted in
+retrieval. This is the differentiator named in ROADMAP.md's Phase 4 —
+"the system writes the ADRs; you approve them" — and in this sequence
+it is also the noise valve for Wave 2. Track D is about to roughly
+triple the number of source types feeding extraction. Shipping that
+expansion before a review queue exists would mean flooding the index
+with unvetted units from Jira tickets, Slack threads, and meeting
+transcripts with no human check between extraction and retrieval. The
+inbox has to exist first.
 
----
+The decision browser is also the honest fix for a problem the Library
+page has had since Phase 2: it gives the application a second reason
+to exist besides its search box, a place to browse the corpus that
+does not require having a question already in mind.
 
-## V2-C — The living archive
+### Track R · Onboarding and education (~40, Wave 1)
 
-Sequenced so each stage feeds the next.
+Track R makes the first fifteen seconds of using adr-engine actually
+demonstrate what it does, rather than asking a new user to authorize
+GitHub and wait through an index before seeing anything.
 
-### C1 · History, permalinks, follow-ups
+It contains an interactive product tour; a shipped demo index, built
+from a fixed, known-good repository, so a stranger can ask a real
+question and get a real cited answer within seconds, with no GitHub
+authorization and no wait for ingestion; a guided first-question flow
+for users who have connected their own repository; contextual help
+throughout the app; a keyboard shortcut reference; a library of example
+questions organized by repository type (a web app, a library, an
+infra repo); and a generated new-joiner walkthrough for a given module,
+built from the same retrieval and synthesis pipeline as ordinary
+questions.
 
-Persisted threads. Every answer receives a stable URL. Follow-up
-questions carry prior citations into retrieval. The redesign's "Ask
-another question" footer grows into a shelf of past pages.
+The shipped demo index is the single highest-leverage item in this
+track: it removes what is currently the biggest evaluation barrier to
+the product at all — a new user cannot judge whether adr-engine is
+useful without first connecting a repository, waiting for it to index,
+and hoping the corpus yields something. A demo index collapses that to
+zero wait and zero setup.
 
-**This forces an architectural addition.** Chroma is a vector store, not
-an application database, and `config_store` is a single flat JSON blob.
-Neither can hold an unbounded, queryable thread history. V2-C introduces
-**SQLite** as the application datastore, alongside Chroma. This is the
-largest structural change in v2 and is recorded in ARCHITECTURE.md before
-any C1 issue is written.
+Track R sits in Wave 1, immediately after the gate, because Wave 1 is
+the first point at which there is something worth demonstrating.
+Before the gate, a product tour would be showing off unproven
+retrieval; before Track B's redesign, it would be touring a chat
+interface the product has already decided to retire.
 
-### C2 · Decision browser, path-scoped questions
+### Track D · Sources (~120, Wave 2)
 
-A browsable, filterable timeline of every extracted decision per
-repository. Consumes `files_changed` from A2, so *"why is
-`backend/auth.py` like this?"* is largely plumbing rather than new
-capability.
+Track D is the largest single track in v2 by issue count, and it is
+scoped that way deliberately: it is the track that takes adr-engine
+from "a GitHub decision index" to "a decision index over everywhere a
+team actually records reasoning."
 
-This is also the honest fix for the sparse Library page: the application
-gains a second reason to exist besides its search box.
+GitHub Issues and Discussions come first, because the real "why" often
+lives in an issue thread — the arguments made, the alternatives
+considered and rejected, the decision to close an issue a particular
+way — none of which a commit message or PR description captures.
+Existing ADR and design documents already checked into a repository
+(`docs/adr/*.md`, RFCs, and similar) follow immediately after: this is
+the one place a team may have deliberately written decisions down
+already, it is cheap to index, and it is immediately high quality,
+since it requires no extraction inference at all — the decision is
+already stated as such. Long-form code comments with file and line
+anchors follow; these are noisier than either of the first two
+sources and depend on Track C's inbox already existing as a filter,
+since a comment explaining a decision is much harder to distinguish
+from an ordinary comment than a commit or an issue thread is.
 
-### C3 · Scheduled re-indexing, Markdown export
+The remaining sources extend coverage across the tools teams actually
+use: GitLab and Bitbucket, for teams not on GitHub; Jira and Linear,
+for issue tracking outside GitHub's own; Slack, opt-in per channel;
+Notion and Confluence, for documentation platforms; database migration
+history; Terraform and other infrastructure-as-code changes; CI
+configuration changes; dependency manifest changes (capturing why a
+particular dependency was added or removed); incident postmortems; and
+meeting transcripts. Every one of these produces the same
+`DecisionUnit` model already in place since Phase 1 — Track D adds new
+`kind` values to that model, not a new data model.
 
-Interval-based refresh reusing the Phase 2 job machinery. Copy-any-answer
--with-citations, formatted for PR descriptions and documentation. Both
-small; both make the tool fit into a workflow rather than being a
-destination.
+Jira and Slack were explicitly parked in ROADMAP.md's non-goals until
+GitHub was proven. Wave 0's gate is what unparks them: the evidence
+section above shows GitHub-sourced extraction did not work reliably
+even on its own terms, so extending to new sources before that was
+fixed would have compounded a problem rather than diversified past it.
 
-### C4 · Decision inbox
+### Track E · Extraction and modeling (~80, Wave 2)
 
-Newly extracted decisions land in a confirm, edit, or discard queue.
-Confirmed units are boosted in retrieval.
+Where Track D grows the number of places extraction looks, Track E
+grows what extraction understands once it looks there. This is the
+track that turns a flat list of extracted text into a queryable model,
+and it is a direct prerequisite for Track G's intelligence features —
+contradiction detection, drift detection, and impact analysis all need
+structured fields to operate on, not prose alone.
 
-It is sequenced last for a specific reason: the retrieval boost is a
-claim about quality, and A3's harness is the only thing that can
-demonstrate the boost helps rather than merely feels right.
+It adds a decision taxonomy and categorization scheme (architecture,
+dependency, process, security, performance, UX); entity extraction,
+pulling out the technologies, services, and files a decision concerns;
+actor extraction — who decided, who reviewed, who objected, mined from
+commit authorship, PR review threads, and issue participants; decision
+strength classification, distinguishing an experiment from a
+convention from a hard constraint; temporal scoping, recording when a
+decision was made, when it took effect, and when (if ever) it was
+superseded; extraction confidence scores, so a low-confidence unit can
+be weighted or flagged differently from a high-confidence one;
+cross-repository decision linking, for organizations running
+adr-engine over more than one repository that share technologies or
+teams; duplicate detection and merging, since the same decision often
+gets restated across a commit, an issue, and a Slack thread once
+Track D is in place; custom extraction prompts per repository, for
+teams whose conventions do not match the default taxonomy; and
+re-extraction — both a one-time re-extraction with a newer model and
+incremental re-extraction as new signal arrives for units already
+indexed.
 
----
+Track E and Track D both precede Track G specifically because
+contradiction detection is only interesting once there is enough
+structured, cross-referenced corpus for a contradiction to be found
+in. Running it over 38 units, as today's index would allow, would
+surface at most a handful of coincidences. Running it over an enriched
+corpus with actors, timestamps, and strength classifications attached
+is where the same capability becomes the differentiating feature
+described under Track G below.
+
+### Track N · Search UX (~45, Wave 2)
+
+Track N exists because question-answering alone stops being
+sufficient once the corpus crosses a few hundred units. At that scale,
+people need to browse and filter, not only ask.
+
+It adds faceted search over the taxonomy and entities Track E
+produces; boolean and regex search operators; search history; entity
+autocomplete; a did-you-mean correction layer; result previews before
+opening a full decision; sort modes by relevance, date, or confidence;
+and pinned results for decisions a user returns to often.
+
+This track sits in Wave 2 rather than earlier because it depends on
+Track E's taxonomy and entity fields to facet against — searching by
+category or by technology is not possible before those fields exist —
+and rather than later because the corpus growth driven by Track D
+means the need for this kind of browsing arrives immediately once
+Wave 2 lands, not after.
+
+### Track M · Storage engineering (~45, Wave 2)
+
+Wave 2 multiplies corpus size by an order of magnitude across the new
+sources in Track D and the new structured fields in Track E. Storage,
+which has been effectively free at 38 to a few hundred units, stops
+being free at that scale.
+
+Track M adds index compaction and vacuum routines; incremental
+embedding updates, so a change to one unit does not require
+re-embedding the whole corpus; embedding-model migration tooling, which
+also serves the fixture regeneration rule from the gate section above
+by giving that rule a real, tested procedure to point to; multi-vector
+storage per decision (a vector for the title, a separate one for the
+body, since the two serve different retrieval purposes); chunking
+strategies for long decisions that exceed a single embedding's
+effective context; sharding by repository, for installations indexing
+many repositories at once; encryption at rest, for the SQLite and
+Chroma stores introduced in Track C; and a portable index format, so
+an index can be exported, moved between machines, or shared as a
+single file.
+
+### Track F · Retrieval and answering (~65, Wave 3)
+
+Wave 3 is where the product's answering behavior gets materially
+better, built on top of the corpus that Waves 1 and 2 established.
+Track F covers the retrieval and answer-composition side of that
+improvement.
+
+It adds reranking on top of the vector retrieval Track A tuned;
+multi-hop retrieval that follows the decision chains Track G's
+supersession detection produces (a question about a decision can now
+pull in the decision it replaced, and the one that replaced it in
+turn); filters on date, author, repository, kind, and tag; saved
+searches; multiple answer modes — brief, thorough, and timeline —
+rather than one fixed answer shape; comparative questions ("X vs Y");
+aggregate questions ("how many times did we change databases"), which
+require counting and grouping rather than single-answer retrieval;
+handling for conflicting sources, where retrieval surfaces two
+decisions that disagree and the answer must say so rather than picking
+one silently; a calibrated "I don't know," so low-confidence retrieval
+produces an honest non-answer instead of a fabricated one; and answer
+regeneration against a different model, for comparison or for a second
+opinion.
+
+### Track G · Intelligence (~75, Wave 3)
+
+Track G is where the corpus assembled across Waves 1 and 2 becomes
+more than a searchable archive — this is the track containing the
+capabilities no comparable tool offers, because no comparable tool has
+the structured, multi-source decision corpus this one does by this
+point in the sequence.
+
+Contradiction and supersession detection is the centerpiece: detecting
+when a later decision reverses or replaces an earlier one, and linking
+the two into a chain. This answers "why did we flip on this?" directly,
+and it closes a real correctness risk that exists in the product
+today — without it, the system can and does cite a decision that has
+since been overturned, presenting stale reasoning as current. Nothing
+else in the product currently guards against that. Line-level "why is
+this here" follows: given a file and a line number, surface the
+decision behind it, using `files_changed` from Track A together with
+per-hunk anchors to implement something like git-blame semantics over
+decisions rather than over commits. This is arguably the most natural
+way a developer actually asks the product's core question — pointing
+at a line of code, not typing a sentence.
+
+The remaining items extend the same corpus-level intelligence: topic
+timelines, rendering how a decision evolved as a chronological chain
+across repositories rather than a flat list of results; decision debt,
+surfacing decisions recorded with no rationale attached; orphan
+decisions, those never referenced by any later decision or question;
+architecture drift detection, comparing stated decisions against the
+code's current shape; decision impact analysis, showing what depends
+on a given decision; an auto-generated technology radar built from
+the corpus's own dependency and technology entities; bus-factor
+mapping, showing who holds the context for each area based on actor
+extraction; decision clustering by theme; and similar-decision
+recommendations surfaced alongside an answer.
+
+### Track T · Answer assurance (~40, Wave 3)
+
+The product's specific claim is "cited to the commit where it was
+decided." That claim is falsifiable, and as of this document, nothing
+in the codebase actually checks whether a cited source supports the
+sentence it is attached to. Track T exists to close that gap before
+Wave 3's other intelligence features (Track G) make wrong citations
+harder to notice among a larger, more elaborate set of answers.
+
+It adds multi-model ensemble answers, generating a response from more
+than one model and comparing them; citation verification — checking
+whether the cited source actually supports the claim attached to it,
+rather than merely being topically related; hallucination detection;
+answer diffing across model versions, to catch regressions when a
+model is upgraded; confidence calibration, tying the calibrated
+"I don't know" from Track F to a measured rather than assumed
+confidence; and user corrections that feed directly back into Track
+C's inbox, so a human catching a wrong citation improves the corpus
+rather than only fixing one answer.
+
+Citation verification specifically protects the entire product claim
+stated in PRODUCT.md's positioning line. A tool that answers
+confidently but occasionally cites the wrong commit is worse than one
+that says it does not know, because the wrong citation looks exactly
+as authoritative as a correct one.
+
+### Track U · Repo intelligence (~40, Wave 3)
+
+Where Track G looks inward at the decision corpus, Track U looks
+outward at the repository the corpus was extracted from, and turns
+what it finds back into pressure on the corpus itself.
+
+It adds a repository decision-coverage score; undocumented-decision
+detection, flagging commits with a large diff and an empty message —
+exactly the shape of commit the root-cause analysis above identifies
+as invisible to message-only extraction, now surfaced explicitly
+rather than silently missed; commit-message quality feedback, offered
+at commit time or in review; suggest-an-ADR prompts, triggered when a
+commit's shape suggests a decision worth writing down formally;
+per-module coverage, showing which parts of a codebase have thin
+decision history; and an onboarding-difficulty score per module, built
+from coverage and bus-factor data.
+
+The value of this track compounds: better commit messages and more
+ADRs written because the tool nudged for them become better raw
+material for the next extraction run, which is exactly the kind of
+feedback loop the product's positioning promises but nothing before
+this track actually created.
+
+### Track H · Outputs (~55, Wave 4)
+
+Track H is where adr-engine starts producing artifacts other tools and
+processes can consume, rather than only answering questions inside its
+own UI.
+
+It includes Markdown export with citations (extending Track C's
+version); a PR description generator that, given a branch, drafts its
+"why" section from the decisions its commits touch; a weekly digest;
+generation of real ADR files written back into a repository; generated
+architecture overview documents; generated module onboarding guides;
+an RSS feed; Slack and Discord digest posting; email digest; and a
+report builder for ad hoc combinations of the above.
+
+The PR description generator is the notable item in this track for a
+reason beyond convenience: it flips the product from read-side to
+write-side for the first time, and it quietly improves the commit
+corpus in the process. A PR description drafted from the decisions its
+own commits touch is more likely to state the "why" up front than a
+manually written one — which is exactly the kind of commit body the
+evidence section above shows adr-engine depends on and BuFin-shaped
+repositories lack. This is a second compounding loop, alongside Track
+U's.
+
+### Track I · Integrations (~70, Wave 4)
+
+Track I meets the product's core question at the places developers
+actually work, rather than requiring a trip to the web UI every time.
+
+The CLI (`adr why "..."`) is the highest-frequency touchpoint in this
+track by a wide margin, because the question "why is this built this
+way" arises in a terminal mid-task, not in a browser tab. It is a thin
+client over the existing retrieval and synthesis API, so its
+implementation cost is low relative to how much it raises daily usage
+— and it is the one item in this track, noted in the Structure section
+above, that can be pulled forward and built at any point in the plan,
+since nothing in Track I depends on it landing here specifically.
+
+The MCP server is the second major item: it exposes adr-engine to
+Claude Code and other coding agents as a callable tool, making any
+agent able to ask why before touching code. This is the moment the
+product's core question matters most — immediately before a change is
+made, not after — and it is a surface no comparable tool currently
+occupies.
+
+The remainder of Track I extends the same reach: a VS Code extension;
+a JetBrains plugin; a Neovim plugin; a GitHub Action that comments
+relevant decisions on PRs; a pre-commit hook warning on undocumented
+decisions (the write-side counterpart to Track U's coverage work); a
+browser extension overlaying decision context on GitHub itself; a
+keyed REST API for third-party integration; webhooks; and a git blame
+integration surfacing the decision behind a line directly in a blame
+view, the editor-native counterpart to Track G's line-level "why is
+this here."
+
+### Track Q · Visualization (~50, Wave 4)
+
+Track Q renders the corpus and its structure visually, for the
+questions that are better explored by looking than by asking.
+
+It includes a force-directed decision graph; a decision timeline view;
+a file-and-module heatmap of decision density; a Sankey diagram of
+decision evolution through supersession chains; contributor decision
+maps; technology adoption curves built from entity extraction over
+time; decision density over time generally; and a dependency graph of
+decisions built from Track G's impact analysis.
+
+### Track O · Notifications (~35, Wave 4)
+
+Track O gives the application a reason to be opened when a user does
+not already have a question in mind — a return-visit driver, in the
+same sense PRODUCT.md's stated Phase 2 success criterion ("the app
+keeps earning return visits before every dive into old code") pointed
+at, but now for cases where nothing prompted the visit.
+
+It includes watching a file, module, or topic for new decisions;
+desktop notifications; contradiction alerts, tied to Track G's
+supersession detection; stale-index alerts; decision-debt threshold
+alerts, tied to Track G's decision-debt detection; and digest
+customization controlling what triggers a notification versus a
+digest entry.
+
+### Track P · Personalization (~40, Wave 4)
+
+Track P covers the smaller set of features that make the product fit
+an individual user's working habits rather than the corpus's shape.
+
+It includes custom taxonomies, letting a team override Track E's
+default categorization scheme; a prompt library for reusable question
+templates; saved question templates; personal annotations on answers
+(extending Track B's annotation feature); reading history; a
+read-later queue; and personal tags and labels applied across
+decisions and answers.
+
+### Track J · Ops and platform (~65, Wave 5)
+
+As the product accumulates the retrieval, extraction, and source
+machinery of Waves 0 through 4, it needs operational visibility into
+its own behavior — Track J is that visibility layer.
+
+It includes an eval dashboard tracking recall over time, giving the
+gate established in Wave 0 an ongoing, visible history rather than a
+single pass/fail per CI run; A/B testing of extraction prompts; a model
+benchmarking UI, comparing Ollama and Gemini model choices against the
+eval harness; an index health dashboard; an ingestion log viewer;
+backup and restore; index migration tooling between machines, building
+on Track M's portable index format; multi-index management, for users
+running adr-engine against several unrelated repository groups; cloud
+cost tracking, for the Gemini calls the privacy model routes to;
+Ollama model management and download directly from the UI; a
+diagnostics support bundle for bug reports; and storage statistics and
+pruning tools.
+
+### Track L · Security and compliance (~50, Wave 5)
+
+Track L is the concrete extension of the privacy model described
+earlier in this document, and it directly serves design principle 4
+from PRODUCT.md — earning the privacy claim on-screen, not only in a
+README.
+
+It includes secret detection before indexing, so a leaked key in a
+diff is caught rather than embedded into the corpus; PII redaction
+ahead of cloud synthesis; an audit log of everything that left the
+machine, viewable per repository; license decision tracking; CVE-to-
+decision linking, connecting a vulnerability disclosure to the
+decision that introduced the affected dependency; supply-chain
+decision history; and compliance evidence report generation, for teams
+that need to demonstrate decision provenance to an external auditor.
+
+### Track S · Distribution and DX (~45, Wave 5)
+
+Track S makes adr-engine easier to install, run, and extend, and it is
+the track that ends the finiteness of Track D's source catalog.
+
+It includes a Dockerfile and Docker Compose setup; a Homebrew formula;
+single-binary distribution; auto-update; opt-in, local-only telemetry;
+crash reporting; a debug mode; and — the item with the largest
+downstream effect — a plugin SDK and custom source-adapter API.
+
+Track D's source list, however long, is finite by construction:
+every source it adds is one adr-engine's own maintainers chose to
+build. The plugin SDK changes that. Once a stable adapter API exists,
+every source not built by the core team becomes one a user or a third
+party can build themselves. This is what turns the source catalog from
+a list into a category.
+
+### Track V · Interop and migration (~35, Wave 5)
+
+Track V handles the boundary between adr-engine's own decision model
+and the formats teams already use or might move to.
+
+It includes importing existing ADRs in the MADR and Nygard formats;
+exporting adr-engine's own decisions back to MADR, for teams that want
+the artifact without the tool; an OpenAPI specification for the REST
+API introduced in Track I; a GraphQL API as an alternative to the REST
+surface; bulk export; and migration tooling from other ADR or decision-
+tracking tools.
+
+### Track W · Accessibility and i18n (~40, Wave 5)
+
+PRODUCT.md already commits to WCAG 2.1 AA as a binding accessibility
+standard. Track W goes beyond that compliance floor toward genuine
+usability for users who need more than the minimum.
+
+It includes a screen-reader optimization pass beyond baseline
+compliance; a high-contrast theme; a dyslexia-friendly font option;
+complete keyboard-only flows through every surface added across Waves
+1 through 4; an internationalization framework; multi-language
+decision extraction, for repositories whose commit history and
+documentation are not in English; and right-to-left layout support.
+
+### Track K · Team sync (~150, Wave 6)
+
+Track K is the largest single track after Track D, and it is last for
+a specific reason stated plainly rather than left implicit: it
+introduces auth, hosting, and conflict resolution — three problem
+domains this project has deliberately avoided until now, each with its
+own failure modes and its own ongoing maintenance burden.
+
+It includes an opt-in sync layer; shared confirmed decisions across a
+team; shared inbox verdicts, so one team member's confirm or discard
+decision in Track C's inbox is visible to others; conflict resolution,
+for cases where two team members act on the same unit differently; a
+permissions model; a hosting story, for teams that want a shared
+instance rather than syncing between individually run local instances;
+and authentication for that shared instance.
+
+This is stated as clearly as the rest of this document states its
+evidence: the index stays local by default, and local-first
+single-user remains both the default configuration and the thesis of
+the product, unchanged from Phase 1 through every wave before this
+one. Sync is opt-in and additive on top of that default, never a
+replacement for it. This is also, honestly, how the project becomes
+something a team buys rather than a tool one person runs — and it is
+deliberately last in the sequence because it is the track most likely
+to be cut if the timeline in the Delivery section below proves
+optimistic, and building it on an unsettled foundation would mean
+rebuilding it regardless.
+
+## Architectural additions
+
+Three structural changes are introduced across v2, and each is
+recorded in ARCHITECTURE.md before the first issue of its owning track
+is written, consistent with that document's own rule that it is
+binding and deviations belong in a PR discussion, not silent drift.
+
+| Addition | Owning track | Reason |
+|---|---|---|
+| SQLite as application datastore, alongside Chroma | Track C | Chroma is a vector store, not a relational one; `config_store` is a flat JSON blob. Neither can hold unbounded, queryable thread history, browser filters, or inbox review state. |
+| Plugin SDK and source-adapter API | Track S | Makes Track D's source catalog open-ended instead of finite; every unbuilt source becomes buildable by someone else. |
+| Optional sync layer, with auth and conflict resolution | Track K | Required for team sync; introduces hosting and multi-user concerns the project has deliberately avoided until this point. |
 
 ## Documentation changes
 
 | Document | Change |
 |---|---|
-| `ROADMAP.md` | Phases 1 and 2 become history; V2-A, V2-B, V2-C replace Phases 3 and 4 |
-| `PRODUCT.md` | Privacy claim gains the per-repository model; positioning restated precisely |
-| `SYSTEM-DESIGN.md` | Diff fetching, `files_changed`, `indexed_at`, per-repo flag, eval contract, SQLite, validation pings permitted on explicit save |
-| `ARCHITECTURE.md` | `backend/eval/`, diff filtering rules, SQLite store, fixture regeneration rule |
-| `UI-DESIGN.md` | Major rewrite: annotated page, margin apparatus, responsive collapse |
-| `docs/eval-questions.md` | Grown to ~40 questions; records the baseline and the gate threshold |
+| `ROADMAP.md` | Phases 1 and 2 become history; the 23 tracks across 7 waves replace Phases 3 and 4; non-goals amended for optional team sync |
+| `PRODUCT.md` | Privacy claim gains the per-repository model; positioning restated precisely against the current state of the product |
+| `SYSTEM-DESIGN.md` | Diff fetching, `files_changed`, `indexed_at`, the per-repository cloud/local flag, the eval contract, SQLite, and validation pings permitted on explicit save |
+| `ARCHITECTURE.md` | `backend/eval/`, diff filtering rules, the SQLite store, the fixture regeneration rule, the plugin SDK, and the sync layer |
+| `UI-DESIGN.md` | Major rewrite: the annotated page, the margin apparatus, and its responsive collapse |
+| `docs/eval-questions.md` | Grown to roughly 40 questions; records the baseline measurement and the gate threshold |
 
 ## Delivery
 
-Unchanged, plus the CI gate.
+Unchanged from ROADMAP.md, plus the CI gate. Work continues on the
+rolling branch `agent/rolling`; the `daily-task` → `in-pr` →
+merged-and-closed issue state machine is unchanged; issues remain sized
+to one module or component at roughly 150 lines of diff; issues remain
+numbered in dependency order, so the picker's lowest-numbered-eligible
+rule continues to hold across all 23 tracks. Every rolling PR now runs
+`pytest` and the recall@5 harness from Wave 0 onward, so the agent
+cannot silently regress retrieval quality in any later wave.
 
-Rolling branch `agent/rolling`; the `daily-task` → `in-pr` →
-merged-and-closed state machine; issues sized to one module or component
-at roughly 150 lines of diff; issues numbered in dependency order.
+Issue #42 is absorbed into Track A, as the CI workflow item. The
+sixteen items catalogued in issue #95 distribute across Track A (retry)
+and Track B (the stale-marker fields, per-row actions, and the
+highlight-wash interaction); #95 closes as superseded once its items
+are filed against their respective tracks.
 
-Every rolling PR now runs `pytest` **and** the recall@5 harness, so the
-agent cannot silently regress retrieval.
+**Timeline.** 1,355 issues at 1 to 3 issues per daily run is 450 to
+1,355 runs. At two issues per run, roughly the middle of that range,
+that is about 678 runs — approximately 22 months of daily operation.
+The full range spans roughly 15 months at the fast end to nearly 4
+years at the slow end. Stated plainly: the delivery machine, not the
+size of the backlog, is the binding constraint on how long this takes.
+The gate after Wave 0, and each wave boundary after it, are the natural
+points to reassess that estimate against actual throughput, exactly as
+this document's predecessor named its own single gate as the place to
+reassess if its much smaller estimate proved wrong.
 
-Issue **#42** is absorbed into A3. The sixteen items catalogued in **#95**
-distribute into V2-B; #95 closes as superseded once they are filed.
-
-Estimated total: approximately 59 issues, or two to three months of daily
-runs at one to three issues per run.
+The one lever that materially changes this timeline is raising
+throughput — more issues completed per daily run, or more than one
+agent working independent tracks in parallel. Tracks within a given
+wave are, by the dependency logic in the Structure section above,
+largely independent of each other: Wave 2's D, E, N, and M do not
+block one another, and neither do Wave 4's H, I, Q, O, and P. This
+makes them parallelizable in principle, which is the only realistic
+way to bring the slow end of the range down toward the fast end.
 
 ## Risks
 
 - **Local synthesis quality is unproven.** Private repositories default
   to local-only, so their default experience depends on Ollama prose
-  quality, which is weaker than Gemini's. If it proves unacceptable, the
-  honest response is to say so on screen, not to quietly change the
-  default.
-- **Diff-aware extraction raises volume and noise together.** Yield will
-  rise above 22%, and some of the new volume will be junk. C4's inbox is
-  the intended valve, but it lands last — so V2-A must keep the
-  extractor's "not a decision" path strict rather than permissive.
+  quality, which is weaker than Gemini's. If it proves unacceptable in
+  practice, the honest response is to say so on screen — per design
+  principle 3 — not to quietly change the default and erode the
+  privacy model the rest of this document depends on.
+- **Diff-aware extraction raises volume and noise together.** Yield
+  rises above today's roughly 22%, and some share of that new volume
+  will be junk rather than genuine decisions. Track C's inbox is the
+  intended valve, but it lands in Wave 1 alongside the redesign, one
+  wave after Track A ships diff-aware extraction. Track A must
+  therefore keep the extractor's "not a decision" path strict rather
+  than permissive in the interval before the inbox exists.
 - **The eval fixture can rot.** It is coupled to the embedding model by
-  construction. The regeneration rule mitigates this but depends on being
-  followed.
-- **v2 is large.** Fifty-nine issues is longer than Phase 1 and Phase 2
-  combined. The gate between A and B is the natural place to reassess
-  scope if the timeline proves wrong.
+  construction, as the fixture regeneration rule states. That rule
+  mitigates the risk but depends on being followed at every future
+  change to `OLLAMA_EMBEDDING_MODEL`, not merely at the moment it is
+  written down.
+- **Scope.** 1,355 issues is roughly 20 times Phases 1 and 2 combined.
+  Every wave boundary in the Structure section above is a genuine
+  off-ramp, and the plan should be re-costed at each one against actual
+  throughput, not carried forward on the original estimate by default.
+- **Team sync (Track K) introduces auth, hosting, and conflict
+  resolution** — three problem domains this project has deliberately
+  avoided through every prior phase and wave. It is sequenced last for
+  that reason, and of the 23 tracks in this document it is the one
+  most likely to be cut if the timeline above proves optimistic.
+- **Breadth risk.** 23 tracks is wide enough that depth in any single
+  one may suffer relative to a narrower plan. The gate protects
+  retrieval quality specifically, and only retrieval quality; nothing
+  in this document structurally protects the quality of the other 22
+  tracks the way the gate protects Track A.
 
 ## Non-goals
 
-Unchanged from ROADMAP.md: hosted or multi-user deployment, user
-accounts, real-time ingestion, fine-tuning, TypeScript migration.
+Retained from ROADMAP.md, unchanged: real-time ingestion, fine-tuning,
+and TypeScript migration remain out of scope for v2.
 
-Jira and Slack sources remain parked until GitHub is fully proven —
-which, by this document's own evidence, it is not yet. Editor and CLI
-integration remain parked for the same reason.
+Amended: ROADMAP.md previously ruled out hosted deployment and
+multi-user use entirely. Track K makes optional team sync in scope,
+while local-first single-user use remains the default configuration
+and the thesis of the product, unchanged from every phase before this
+one.
+
+Unparked: Jira and Slack sources were parked in ROADMAP.md until GitHub
+was proven; Wave 0's gate is what proves it, and Track D unparks both.
+Editor and CLI integration were similarly parked until the web product
+proved the core loop; Track I unparks both, with the CLI specifically
+available to be pulled forward ahead of the rest of that track at any
+point in the sequence.


### PR DESCRIPTION
## Summary

Adds `docs/superpowers/specs/2026-08-04-v2-design.md`, the design and roadmap for v2. Supersedes ROADMAP.md's Phase 3 and Phase 4, and amends its non-goals.

**Why v2 exists:** measured against the running instance on 2026-08-04 — adr-engine holds 38 indexed decisions from 169 commits; BuFin holds 0. All ten golden eval questions in `docs/eval-questions.md` source from BuFin, so the project's own quality gate has never been run. Root cause: extraction reads commit messages only, never the diff — it reformats adr-engine's unusually rich, agent-written commit bodies and correctly finds nothing in BuFin's normal, terse ones. This inverts the product's own promise ("no one has to remember to write an ADR"): today the tool only works where someone already did.

**Structure:** 23 tracks across 7 waves, ~1,355 issues, one quality gate between Wave 0 and Wave 1 (recall@5 ≥ 70%, committed as an absolute floor — not a relative improvement over an unmeasured baseline, which would let a broken system pass). Wave 0 proves the core (local git ingestion, diff-aware extraction, resumable ingestion, the eval harness, retrieval tuning). Waves 1–6 build the reading-room redesign, the living archive, source breadth, extraction modeling, retrieval and intelligence, outputs and integrations (including a CLI and an MCP server), and — last, opt-in — team sync.

**Non-goals amended:** hosted deployment and multi-user were ruled out entirely; Track K makes optional team sync in scope while local-first single-user remains the default and the thesis.

**Timeline stated plainly in the doc:** 450–1,355 daily agent runs, roughly 15 months to 4 years depending on throughput. The delivery machine, not the backlog, is the binding constraint — the doc notes tracks within a wave are largely independent and therefore parallelizable, which is the only lever that materially changes this.

This document is the decomposition, not an implementation plan. Each track gets its own spec and implementation plan before its issues are written — starting with Track A.

## Test plan

N/A — documentation only, no code changes.