### PR TITLE
Track B: AnswerPage (+ print stylesheet, PDF export, reading preferences), SourcesView, command palette, decisions timeline, file-tree heatmap, focus mode, coverage heuristics, privacy panel, Library repo-row/page states, Models/Gemini settings polish & live validation, Data section decision count

### DIFF
--- a/backend/config_store.py
+++ b/backend/config_store.py
@@ -27,6 +27,7 @@ DEFAULTS = {
     "gemini_model": "gemini-2.5-flash",
     "local_repo_paths": {},
     "repo_settings": {},
+    "repo_metadata": {},
 }
 
 _SECRET_FIELDS = {"github_token", "gemini_api_key"}
@@ -128,3 +129,16 @@ def set_cloud_synthesis_allowed(repo: str, allowed: bool) -> dict:
     settings = dict(load()["repo_settings"])
     settings[repo] = {"cloud_synthesis_allowed": allowed, "explicit": True}
     return save({"repo_settings": settings})
+
+
+def get_indexed_at(repo: str) -> str | None:
+    metadata = load()["repo_metadata"].get(repo)
+    return metadata["indexed_at"] if metadata else None
+
+
+def set_indexed_at(repo: str, timestamp: str) -> dict:
+    """Record `repo`'s ingestion completion time. Called when a job's
+    phase reaches `"done"`; a re-index overwrites the prior timestamp."""
+    metadata = dict(load()["repo_metadata"])
+    metadata[repo] = {"indexed_at": timestamp}
+    return save({"repo_metadata": metadata})

--- a/backend/eval/harness.py
+++ b/backend/eval/harness.py
@@ -5,7 +5,11 @@ Replays golden questions from `docs/eval-questions.md` against a frozen
 fixture and reports the fraction whose expected source unit lands in the
 top-5 retrieved results, ranked by cosine similarity. Deterministic: no
 LLM judge, no network call, no Ollama instance — satisfies
-ARCHITECTURE.md's CI testing constraints.
+ARCHITECTURE.md's CI testing constraints. Golden-question embeddings are
+themselves frozen fixture data (`golden_question_embeddings.json`,
+generated alongside the corpus fixture by `eval.build_fixture`), not
+computed live — `embed_query` stays available for non-CI callers (e.g. a
+manual retrieval-tuning sweep) that need a fresh embedding.
 
 Gate: 70% absolute floor, below 50% is "broken", and CI fails any run
 that drops more than 5 points below the best score on record.
@@ -41,17 +45,23 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 
 
 def compute_recall_at_5(
-    golden_questions: list[dict], units: list[DecisionUnit], embeddings: list[list[float]]
+    golden_questions: list[dict],
+    units: list[DecisionUnit],
+    embeddings: list[list[float]],
+    query_embeddings: dict[str, list[float]],
 ) -> float:
     """Fraction of `golden_questions` whose `expected_unit_id` appears in
-    the top-5 `units` ranked by cosine similarity to the embedded
-    question. `units` and `embeddings` are parallel lists."""
+    the top-5 `units` ranked by cosine similarity to the question's
+    embedding. `units` and `embeddings` are parallel lists.
+    `query_embeddings` maps each golden question's text to its
+    precomputed embedding — this function performs no embedding itself,
+    so it never calls out to Ollama."""
     if not golden_questions:
         return 0.0
 
     hits = 0
     for golden in golden_questions:
-        query_vector = embed_query(golden["question"])
+        query_vector = query_embeddings[golden["question"]]
         ranked = sorted(
             zip(units, embeddings),
             key=lambda pair: _cosine_similarity(query_vector, pair[1]),
@@ -76,6 +86,10 @@ def _load_fixture() -> tuple[list[DecisionUnit], list[list[float]]]:
     return [DecisionUnit(**unit) for unit in units_raw], embeddings
 
 
+def _load_query_embeddings() -> dict[str, list[float]]:
+    return json.loads((FIXTURES_DIR / "golden_question_embeddings.json").read_text())
+
+
 def _load_best_score() -> float | None:
     if not BEST_SCORE_PATH.exists():
         return None
@@ -89,8 +103,9 @@ def _record_best_score(score: float) -> None:
 def main() -> int:
     golden_questions = _load_golden_questions()
     units, embeddings = _load_fixture()
+    query_embeddings = _load_query_embeddings()
 
-    score = compute_recall_at_5(golden_questions, units, embeddings)
+    score = compute_recall_at_5(golden_questions, units, embeddings, query_embeddings)
     best = _load_best_score()
 
     print(f"recall@5: {score:.1%} ({len(golden_questions)} questions)")

--- a/backend/ingestion/ollama_client.py
+++ b/backend/ingestion/ollama_client.py
@@ -1,0 +1,44 @@
+"""Ollama reachability + model-presence check.
+
+Separate from embed.py/extract.py (which perform real embedding/extraction
+calls) — this only lists what Ollama has pulled, via GET /api/tags, so the
+validation router can confirm the configured host and models are live.
+"""
+
+import httpx
+
+from config import get_settings
+
+
+def check_ollama() -> tuple[bool, str | None]:
+    settings = get_settings()
+
+    try:
+        response = httpx.get(
+            f"{settings.ollama_host}/api/tags",
+            timeout=settings.ollama_request_timeout_seconds,
+        )
+    except httpx.HTTPError as exc:
+        return False, f"failed to reach Ollama at {settings.ollama_host}: {exc}"
+
+    if response.is_error:
+        return False, f"Ollama returned {response.status_code} for /api/tags"
+
+    try:
+        available = {model["name"] for model in response.json()["models"]}
+    except (ValueError, KeyError, TypeError):
+        return False, "Ollama /api/tags response missing expected 'models' field"
+
+    missing = [
+        model
+        for model in (settings.ollama_extraction_model, settings.ollama_embedding_model)
+        if not _is_pulled(model, available)
+    ]
+    if missing:
+        return False, f"model(s) not found on Ollama: {', '.join(missing)}"
+
+    return True, None
+
+
+def _is_pulled(model: str, available: set[str]) -> bool:
+    return model in available or any(name.startswith(f"{model}:") for name in available)

--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -93,6 +93,38 @@ def query_units(
     ]
 
 
+def list_units(
+    repo: str,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[list[DecisionUnit], int]:
+    """All units for `repo`, optionally bounded by `since`/`until` (both
+    inclusive, compared lexicographically against `DecisionUnit.date` —
+    which sorts correctly since dates are ISO 8601 strings), newest
+    first. Chroma's `where` only does exact-match filtering reliably for
+    string metadata, so the date bounds and pagination are applied here
+    rather than pushed into the query; sorting by `(date, id)` before
+    slicing keeps pages stable (no duplicates/gaps) across calls for a
+    fixed dataset.
+
+    Returns `(page, total)` where `total` is the count before slicing,
+    for the caller to compute page count.
+    """
+    result = get_collection().get(where={"repo": repo}, include=["metadatas"])
+    units = [_unit_from_metadata(id, metadata) for id, metadata in zip(result["ids"], result["metadatas"])]
+
+    if since is not None:
+        units = [unit for unit in units if unit.date >= since]
+    if until is not None:
+        units = [unit for unit in units if unit.date <= until]
+
+    units.sort(key=lambda unit: (unit.date, unit.id), reverse=True)
+
+    return units[offset : offset + limit], len(units)
+
+
 def count_units(repo: str) -> int:
     return len(get_collection().get(where={"repo": repo}, include=[])["ids"])
 

--- a/backend/ingestion/store.py
+++ b/backend/ingestion/store.py
@@ -129,6 +129,19 @@ def count_units(repo: str) -> int:
     return len(get_collection().get(where={"repo": repo}, include=[])["ids"])
 
 
+def count_units_by_path(repo: str) -> dict[str, int]:
+    """Decision counts per file path for `repo`, from each unit's
+    `files_changed` — a file touched by 3 decisions counts 3, not 1."""
+    result = get_collection().get(where={"repo": repo}, include=["metadatas"])
+
+    counts: dict[str, int] = {}
+    for metadata in result["metadatas"]:
+        for path in json.loads(metadata.get("files_changed", "[]")):
+            counts[path] = counts.get(path, 0) + 1
+
+    return counts
+
+
 def _cursor_path() -> Path:
     return Path(get_settings().chroma_data_dir) / "cursors.json"
 

--- a/backend/jobs/ingest_job.py
+++ b/backend/jobs/ingest_job.py
@@ -6,9 +6,11 @@ ARCHITECTURE.md's stated exception (it orchestrates it).
 """
 
 import uuid
+from datetime import datetime, timezone
 
 from pydantic import BaseModel
 
+import config_store
 from ingestion.embed import EmbeddingError
 from ingestion.extract import ExtractionError
 from ingestion.github_client import GitHubError
@@ -31,6 +33,10 @@ class Job(BaseModel):
 
 _jobs: dict[str, Job] = {}
 _latest_job_id: str | None = None
+
+
+def _current_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def start_job(repos: list[str]) -> str:
@@ -75,6 +81,7 @@ def _run_repo(repo: str, state: RepoJobState) -> None:
         skipped=result.skipped,
         stored=result.stored,
     )
+    config_store.set_indexed_at(repo, _current_timestamp())
 
 
 def run_job(job_id: str) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from routers.query import router as query_router
 from routers.repos import router as repos_router
 from routers.retrieve import router as retrieve_router
 from routers.setup import router as setup_router
+from routers.validation import router as validation_router
 
 app = FastAPI(title="adr-engine")
 
@@ -34,6 +35,7 @@ app.include_router(github_router)
 app.include_router(config_router)
 app.include_router(auth_router)
 app.include_router(setup_router)
+app.include_router(validation_router)
 
 
 @app.get("/health")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from chroma_client import get_chroma_client
 from routers.auth import router as auth_router
 from routers.config import router as config_router
+from routers.decisions import router as decisions_router
 from routers.github import router as github_router
 from routers.ingest import router as ingest_router
 from routers.query import router as query_router
@@ -30,6 +31,7 @@ app.add_middleware(
 app.include_router(ingest_router)
 app.include_router(retrieve_router)
 app.include_router(query_router)
+app.include_router(decisions_router)
 app.include_router(repos_router)
 app.include_router(github_router)
 app.include_router(config_router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -86,6 +86,13 @@ class RetrieveResponse(BaseModel):
     results: list[RetrieveResult]
 
 
+class DecisionsResponse(BaseModel):
+    units: list[DecisionUnit]
+    total: int
+    page: int
+    limit: int
+
+
 class QueryRequest(BaseModel):
     question: str
     repos: list[str] | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -96,6 +96,8 @@ class QueryResponse(BaseModel):
     citations: list[DecisionUnit]
     retrieved_count: int
     mode: Literal["synthesized", "sources_only"]
+    sent_to_cloud: bool
+    cloud_synthesis_fields: list[str] | None = None
 
 
 class RepoInfo(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -102,6 +102,7 @@ class RepoInfo(BaseModel):
     repo: str
     indexed_units: int
     cloud_synthesis_allowed: bool = True
+    indexed_at: str | None = None
 
 
 class ReposResponse(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -154,6 +154,11 @@ class AuthStatusResponse(BaseModel):
     avatar_url: str | None = None
 
 
+class ValidationResponse(BaseModel):
+    ok: bool
+    detail: str | None = None
+
+
 class SetupStateResponse(BaseModel):
     github_connected: bool
     repos_selected: bool

--- a/backend/models.py
+++ b/backend/models.py
@@ -93,6 +93,10 @@ class DecisionsResponse(BaseModel):
     limit: int
 
 
+class DecisionsByPathResponse(BaseModel):
+    paths: dict[str, int]
+
+
 class QueryRequest(BaseModel):
     question: str
     repos: list[str] | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -126,6 +126,7 @@ class ConfigResponse(BaseModel):
     ollama_embedding_model: str | None = None
     gemini_model: str
     chroma_data_dir: str
+    decision_count: int
 
 
 class ConfigPatchRequest(ConfigResponse):
@@ -135,6 +136,7 @@ class ConfigPatchRequest(ConfigResponse):
     ollama_host: str | None = None
     gemini_model: str | None = None
     chroma_data_dir: str | None = None
+    decision_count: int | None = None
 
 
 class DeviceStartResponse(BaseModel):

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -11,22 +11,33 @@ from fastapi import APIRouter, HTTPException
 
 import config_store
 from config import get_settings
+from ingestion.store import count_units
 from models import ConfigPatchRequest, ConfigResponse
 
 router = APIRouter()
 
 
+def _decision_count(stored: dict) -> int:
+    return sum(count_units(repo) for repo in stored["indexed_repos"])
+
+
 @router.get("/config", response_model=ConfigResponse)
 def get_config() -> ConfigResponse:
-    return ConfigResponse(**config_store.mask(config_store.load()), chroma_data_dir=config_store.chroma_data_dir())
+    stored = config_store.load()
+    return ConfigResponse(
+        **config_store.mask(stored),
+        chroma_data_dir=config_store.chroma_data_dir(),
+        decision_count=_decision_count(stored),
+    )
 
 
 @router.patch("/config", response_model=ConfigResponse)
 def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
-    # chroma_data_dir is env-derived (matches chroma_client.py), never
-    # actually persisted through the store, so it's dropped before saving.
+    # chroma_data_dir and decision_count are derived, never actually
+    # persisted through the store, so they're dropped before saving.
     payload = patch.model_dump(exclude_unset=True)
     payload.pop("chroma_data_dir", None)
+    payload.pop("decision_count", None)
 
     try:
         updated = config_store.save(payload)
@@ -39,4 +50,8 @@ def patch_config(patch: ConfigPatchRequest) -> ConfigResponse:
     # DELETE /repos's same cache_clear() after its own config_store write.
     get_settings.cache_clear()
 
-    return ConfigResponse(**config_store.mask(updated), chroma_data_dir=config_store.chroma_data_dir())
+    return ConfigResponse(
+        **config_store.mask(updated),
+        chroma_data_dir=config_store.chroma_data_dir(),
+        decision_count=_decision_count(updated),
+    )

--- a/backend/routers/decisions.py
+++ b/backend/routers/decisions.py
@@ -6,8 +6,8 @@ service function, shape response. No business logic here.
 
 from fastapi import APIRouter
 
-from ingestion.store import list_units
-from models import DecisionsResponse
+from ingestion.store import count_units_by_path, list_units
+from models import DecisionsByPathResponse, DecisionsResponse
 
 router = APIRouter()
 
@@ -22,3 +22,8 @@ def decisions(
 ) -> DecisionsResponse:
     units, total = list_units(repo, since=since, until=until, limit=limit, offset=(page - 1) * limit)
     return DecisionsResponse(units=units, total=total, page=page, limit=limit)
+
+
+@router.get("/decisions/by-path", response_model=DecisionsByPathResponse)
+def decisions_by_path(repo: str) -> DecisionsByPathResponse:
+    return DecisionsByPathResponse(paths=count_units_by_path(repo))

--- a/backend/routers/decisions.py
+++ b/backend/routers/decisions.py
@@ -1,0 +1,24 @@
+"""GET /decisions: thin wiring from HTTP to store.list_units.
+
+Per ARCHITECTURE.md's "routers are thin" rule: parse request, call one
+service function, shape response. No business logic here.
+"""
+
+from fastapi import APIRouter
+
+from ingestion.store import list_units
+from models import DecisionsResponse
+
+router = APIRouter()
+
+
+@router.get("/decisions", response_model=DecisionsResponse)
+def decisions(
+    repo: str,
+    since: str | None = None,
+    until: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+) -> DecisionsResponse:
+    units, total = list_units(repo, since=since, until=until, limit=limit, offset=(page - 1) * limit)
+    return DecisionsResponse(units=units, total=total, page=page, limit=limit)

--- a/backend/routers/query.py
+++ b/backend/routers/query.py
@@ -13,7 +13,12 @@ from fastapi import APIRouter, HTTPException
 from ingestion.embed import EmbeddingError
 from models import QueryRequest, QueryResponse
 from retrieval.search import search
-from synthesis.answer import SynthesisError, synthesis_available, synthesize
+from synthesis.answer import (
+    SENT_TO_GEMINI_FIELDS,
+    SynthesisError,
+    synthesis_available,
+    synthesize,
+)
 
 router = APIRouter()
 
@@ -31,6 +36,7 @@ def query(request: QueryRequest) -> QueryResponse:
             citations=[r.unit for r in results],
             retrieved_count=len(results),
             mode="sources_only",
+            sent_to_cloud=False,
         )
 
     try:
@@ -39,5 +45,10 @@ def query(request: QueryRequest) -> QueryResponse:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     return QueryResponse(
-        answer=answer, citations=citations, retrieved_count=len(results), mode="synthesized"
+        answer=answer,
+        citations=citations,
+        retrieved_count=len(results),
+        mode="synthesized",
+        sent_to_cloud=True,
+        cloud_synthesis_fields=SENT_TO_GEMINI_FIELDS,
     )

--- a/backend/routers/repos.py
+++ b/backend/routers/repos.py
@@ -26,6 +26,7 @@ def repos() -> ReposResponse:
                 repo=repo,
                 indexed_units=count_units(repo),
                 cloud_synthesis_allowed=config_store.get_cloud_synthesis_allowed(repo),
+                indexed_at=config_store.get_indexed_at(repo),
             )
             for repo in get_settings().indexed_repos
         ]
@@ -39,6 +40,7 @@ def patch_repo(repo: str, request: RepoPrivacyPatchRequest) -> RepoInfo:
         repo=repo,
         indexed_units=count_units(repo),
         cloud_synthesis_allowed=request.cloud_synthesis_allowed,
+        indexed_at=config_store.get_indexed_at(repo),
     )
 
 

--- a/backend/routers/validation.py
+++ b/backend/routers/validation.py
@@ -1,0 +1,26 @@
+"""POST /config/validate-gemini and /config/validate-ollama: live pings.
+
+Only ever hit on the frontend's explicit "save" action, never on GET
+/config or automatically, per docs/superpowers/specs/2026-08-04-v2-design.md
+decision 9.
+"""
+
+from fastapi import APIRouter
+
+from ingestion.ollama_client import check_ollama
+from models import ValidationResponse
+from synthesis.answer import validate_gemini
+
+router = APIRouter()
+
+
+@router.post("/config/validate-gemini", response_model=ValidationResponse)
+def validate_gemini_endpoint() -> ValidationResponse:
+    ok, detail = validate_gemini()
+    return ValidationResponse(ok=ok, detail=detail)
+
+
+@router.post("/config/validate-ollama", response_model=ValidationResponse)
+def validate_ollama_endpoint() -> ValidationResponse:
+    ok, detail = check_ollama()
+    return ValidationResponse(ok=ok, detail=detail)

--- a/backend/synthesis/answer.py
+++ b/backend/synthesis/answer.py
@@ -94,6 +94,19 @@ def synthesize(question: str, units: list[DecisionUnit]) -> tuple[str, list[Deci
     return answer, _resolve_citations(answer, units)
 
 
+def validate_gemini() -> tuple[bool, str | None]:
+    """Real, minimal call to confirm the configured Gemini key/model works.
+
+    Reuses `_call_gemini` rather than a second Gemini client, per
+    ARCHITECTURE.md's "LLM calls isolated in exactly three places" rule.
+    """
+    try:
+        _call_gemini("Reply with exactly one word: OK")
+    except SynthesisError as exc:
+        return False, str(exc)
+    return True, None
+
+
 def synthesis_available(repos: list[str] | None) -> bool:
     """Whether synthesis can run at all — false when no Gemini key is
     configured, or when any repo the query touches disallows cloud

--- a/backend/synthesis/answer.py
+++ b/backend/synthesis/answer.py
@@ -32,19 +32,18 @@ If the decisions above don't cover the question, respond with exactly: \
 
 _CITATION_PATTERN = re.compile(r"\[([^\[\]]+)\]")
 
+# The DecisionUnit fields _format_unit sends to Gemini. QueryResponse.
+# cloud_synthesis_fields reports this same list, so it can never drift out
+# of sync with what's actually sent.
+SENT_TO_GEMINI_FIELDS = ["id", "title", "decision", "rationale", "url"]
+
 
 class SynthesisError(Exception):
     """Raised when Gemini can't be reached, or returns an error, for synthesis."""
 
 
 def _format_unit(unit: DecisionUnit) -> str:
-    return (
-        f"id: {unit.id}\n"
-        f"title: {unit.title}\n"
-        f"decision: {unit.decision}\n"
-        f"rationale: {unit.rationale}\n"
-        f"url: {unit.url}"
-    )
+    return "\n".join(f"{field}: {getattr(unit, field)}" for field in SENT_TO_GEMINI_FIELDS)
 
 
 def _build_prompt(question: str, units: list[DecisionUnit]) -> str:

--- a/backend/tests/test_config_router.py
+++ b/backend/tests/test_config_router.py
@@ -6,8 +6,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import pytest
 from fastapi.testclient import TestClient
 
+import chroma_client
 import config_store
 from config import get_settings
+from ingestion import store
 from main import app
 
 client = TestClient(app)
@@ -16,6 +18,11 @@ client = TestClient(app)
 @pytest.fixture(autouse=True)
 def _isolated_store(tmp_path, monkeypatch):
     monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    chroma_client.get_chroma_client.cache_clear()
+
+    yield
+
+    chroma_client.get_chroma_client.cache_clear()
 
 
 def test_get_config_on_empty_store_returns_defaults(tmp_path):
@@ -31,6 +38,7 @@ def test_get_config_on_empty_store_returns_defaults(tmp_path):
         "ollama_embedding_model": None,
         "gemini_model": "gemini-2.5-flash",
         "chroma_data_dir": str(tmp_path),
+        "decision_count": 0,
     }
 
 
@@ -103,3 +111,27 @@ def test_patch_can_clear_indexed_repos_without_touching_other_fields():
     assert response.status_code == 200
     assert response.json()["gemini_api_key"] == "gk_1…cdef"
     assert response.json()["indexed_repos"] == []
+
+
+def test_get_config_decision_count_sums_units_across_all_indexed_repos(make_unit):
+    client.patch("/config", json={"indexed_repos": ["owner/a", "owner/b"]})
+    store.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a", url="https://github.com/owner/a/pull/1"),
+            make_unit(id="owner/a:pr:2", repo="owner/a", url="https://github.com/owner/a/pull/2"),
+            make_unit(id="owner/b:pr:1", repo="owner/b", url="https://github.com/owner/b/pull/1"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    response = client.get("/config")
+
+    assert response.json()["decision_count"] == 3
+
+
+def test_patch_ignores_a_client_supplied_decision_count():
+    response = client.patch("/config", json={"decision_count": 999})
+
+    assert response.status_code == 200
+    assert response.json()["decision_count"] == 0
+    assert "decision_count" not in config_store.load()

--- a/backend/tests/test_config_store.py
+++ b/backend/tests/test_config_store.py
@@ -64,3 +64,36 @@ def test_stored_value_used_when_env_var_unset(tmp_path, monkeypatch):
 
     assert settings.gemini_api_key == "gk_from_store"
     config.get_settings.cache_clear()
+
+
+def test_get_indexed_at_defaults_to_none_for_an_unindexed_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    assert config_store.get_indexed_at("owner/repo") is None
+
+
+def test_set_indexed_at_round_trips(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.set_indexed_at("owner/repo", "2026-01-01T00:00:00+00:00")
+
+    assert config_store.get_indexed_at("owner/repo") == "2026-01-01T00:00:00+00:00"
+
+
+def test_set_indexed_at_overwrites_on_reindex(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.set_indexed_at("owner/repo", "2026-01-01T00:00:00+00:00")
+    config_store.set_indexed_at("owner/repo", "2026-01-02T00:00:00+00:00")
+
+    assert config_store.get_indexed_at("owner/repo") == "2026-01-02T00:00:00+00:00"
+
+
+def test_set_indexed_at_does_not_clobber_other_repos(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+
+    config_store.set_indexed_at("owner/a", "2026-01-01T00:00:00+00:00")
+    config_store.set_indexed_at("owner/b", "2026-01-02T00:00:00+00:00")
+
+    assert config_store.get_indexed_at("owner/a") == "2026-01-01T00:00:00+00:00"
+    assert config_store.get_indexed_at("owner/b") == "2026-01-02T00:00:00+00:00"

--- a/backend/tests/test_decisions_router.py
+++ b/backend/tests/test_decisions_router.py
@@ -1,0 +1,112 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import chroma_client
+import config
+from ingestion import store
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _decisions_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+    yield
+
+    config.get_settings.cache_clear()
+    chroma_client.get_chroma_client.cache_clear()
+
+
+def test_decisions_returns_units_for_requested_repo_only(make_unit):
+    store.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a"),
+            make_unit(id="owner/b:pr:1", repo="owner/b"),
+        ],
+        embeddings=[[1, 0], [1, 0]],
+    )
+
+    response = client.get("/decisions", params={"repo": "owner/a"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert [unit["id"] for unit in body["units"]] == ["owner/a:pr:1"]
+
+
+def test_decisions_with_no_matches_returns_empty_list():
+    response = client.get("/decisions", params={"repo": "owner/repo"})
+
+    assert response.status_code == 200
+    assert response.json() == {"units": [], "total": 0, "page": 1, "limit": 20}
+
+
+def test_decisions_filters_by_since_and_until(make_unit):
+    store.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", date="2026-01-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:2", date="2026-02-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:3", date="2026-03-01T00:00:00Z"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    response = client.get(
+        "/decisions",
+        params={"repo": "owner/repo", "since": "2026-01-15T00:00:00Z", "until": "2026-02-15T00:00:00Z"},
+    )
+
+    assert response.status_code == 200
+    assert [unit["id"] for unit in response.json()["units"]] == ["owner/repo:pr:2"]
+
+
+def test_decisions_since_and_until_bounds_are_inclusive(make_unit):
+    store.upsert_units(
+        [make_unit(id="owner/repo:pr:1", date="2026-01-01T00:00:00Z")],
+        embeddings=[[1, 0]],
+    )
+
+    response = client.get(
+        "/decisions",
+        params={"repo": "owner/repo", "since": "2026-01-01T00:00:00Z", "until": "2026-01-01T00:00:00Z"},
+    )
+
+    assert [unit["id"] for unit in response.json()["units"]] == ["owner/repo:pr:1"]
+
+
+def test_decisions_orders_newest_first(make_unit):
+    store.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", date="2026-01-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:2", date="2026-03-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:3", date="2026-02-01T00:00:00Z"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    response = client.get("/decisions", params={"repo": "owner/repo", "limit": 10})
+
+    assert [unit["id"] for unit in response.json()["units"]] == [
+        "owner/repo:pr:2",
+        "owner/repo:pr:3",
+        "owner/repo:pr:1",
+    ]
+
+
+def test_decisions_paginates_without_duplicates_or_gaps(make_unit):
+    units = [make_unit(id=f"owner/repo:pr:{i}", date=f"2026-01-{i:02d}T00:00:00Z") for i in range(1, 6)]
+    store.upsert_units(units, embeddings=[[1, 0]] * 5)
+
+    pages = [
+        client.get("/decisions", params={"repo": "owner/repo", "page": page, "limit": 2}).json()
+        for page in (1, 2, 3)
+    ]
+
+    all_ids = [unit["id"] for page in pages for unit in page["units"]]
+    assert len(all_ids) == len(set(all_ids)) == 5
+    assert all(page["total"] == 5 for page in pages)
+    assert [len(page["units"]) for page in pages] == [2, 2, 1]

--- a/backend/tests/test_decisions_router.py
+++ b/backend/tests/test_decisions_router.py
@@ -110,3 +110,46 @@ def test_decisions_paginates_without_duplicates_or_gaps(make_unit):
     assert len(all_ids) == len(set(all_ids)) == 5
     assert all(page["total"] == 5 for page in pages)
     assert [len(page["units"]) for page in pages] == [2, 2, 1]
+
+
+def test_decisions_by_path_counts_overlapping_files_changed(make_unit):
+    store.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", files_changed=["backend/auth.py", "backend/models.py"]),
+            make_unit(id="owner/repo:pr:2", files_changed=["backend/auth.py"]),
+            make_unit(id="owner/repo:pr:3", files_changed=["backend/auth.py", "frontend/src/api.js"]),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    response = client.get("/decisions/by-path", params={"repo": "owner/repo"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "paths": {
+            "backend/auth.py": 3,
+            "backend/models.py": 1,
+            "frontend/src/api.js": 1,
+        }
+    }
+
+
+def test_decisions_by_path_only_counts_requested_repo(make_unit):
+    store.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a", files_changed=["a.py"]),
+            make_unit(id="owner/b:pr:1", repo="owner/b", files_changed=["b.py"]),
+        ],
+        embeddings=[[1, 0], [1, 0]],
+    )
+
+    response = client.get("/decisions/by-path", params={"repo": "owner/a"})
+
+    assert response.json() == {"paths": {"a.py": 1}}
+
+
+def test_decisions_by_path_with_no_units_returns_empty_map():
+    response = client.get("/decisions/by-path", params={"repo": "owner/repo"})
+
+    assert response.status_code == 200
+    assert response.json() == {"paths": {}}

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -8,19 +8,18 @@ import pytest
 from eval import harness
 
 
-def test_recall_is_one_when_expected_unit_ranks_first(monkeypatch, make_unit):
+def test_recall_is_one_when_expected_unit_ranks_first(make_unit):
     hit_unit = make_unit(id="owner/repo:commit:aaa")
     other_unit = make_unit(id="owner/repo:commit:bbb")
     units = [hit_unit, other_unit]
     embeddings = [[1.0, 0.0], [0.0, 1.0]]
     golden_questions = [{"question": "why aaa", "expected_unit_id": "owner/repo:commit:aaa"}]
+    query_embeddings = {"why aaa": [1.0, 0.0]}
 
-    monkeypatch.setattr(harness, "embed_query", lambda question: [1.0, 0.0])
-
-    assert harness.compute_recall_at_5(golden_questions, units, embeddings) == 1.0
+    assert harness.compute_recall_at_5(golden_questions, units, embeddings, query_embeddings) == 1.0
 
 
-def test_recall_is_zero_when_expected_unit_is_never_in_top_5(monkeypatch, make_unit):
+def test_recall_is_zero_when_expected_unit_is_never_in_top_5(make_unit):
     distractors = [
         make_unit(id=f"owner/repo:commit:d{i}") for i in range(5)
     ]
@@ -28,13 +27,12 @@ def test_recall_is_zero_when_expected_unit_is_never_in_top_5(monkeypatch, make_u
     units = distractors + [miss_unit]
     embeddings = [[1.0, 0.1 * (i + 1)] for i in range(5)] + [[-1.0, 0.0]]
     golden_questions = [{"question": "why zzz", "expected_unit_id": "owner/repo:commit:zzz"}]
+    query_embeddings = {"why zzz": [1.0, 0.0]}
 
-    monkeypatch.setattr(harness, "embed_query", lambda question: [1.0, 0.0])
-
-    assert harness.compute_recall_at_5(golden_questions, units, embeddings) == 0.0
+    assert harness.compute_recall_at_5(golden_questions, units, embeddings, query_embeddings) == 0.0
 
 
-def test_recall_averages_correctly_across_multiple_questions(monkeypatch, make_unit):
+def test_recall_averages_correctly_across_multiple_questions(make_unit):
     hit_unit = make_unit(id="owner/repo:commit:hit")
     distractors = [
         make_unit(id=f"owner/repo:commit:d{i}") for i in range(4)
@@ -46,17 +44,16 @@ def test_recall_averages_correctly_across_multiple_questions(monkeypatch, make_u
         {"question": "hit question", "expected_unit_id": "owner/repo:commit:hit"},
         {"question": "miss question", "expected_unit_id": "owner/repo:commit:miss"},
     ]
+    query_embeddings = {"hit question": [1.0, 0.0], "miss question": [1.0, 0.0]}
 
-    monkeypatch.setattr(harness, "embed_query", lambda question: [1.0, 0.0])
-
-    assert harness.compute_recall_at_5(golden_questions, units, embeddings) == 0.5
+    assert harness.compute_recall_at_5(golden_questions, units, embeddings, query_embeddings) == 0.5
 
 
 def test_recall_is_zero_for_empty_golden_questions(make_unit):
     units = [make_unit(id="owner/repo:commit:aaa")]
     embeddings = [[1.0, 0.0]]
 
-    assert harness.compute_recall_at_5([], units, embeddings) == 0.0
+    assert harness.compute_recall_at_5([], units, embeddings, {}) == 0.0
 
 
 @pytest.fixture
@@ -67,7 +64,16 @@ def _isolated_best_score(tmp_path, monkeypatch):
 def _stub_gate_inputs(monkeypatch, golden_questions, units, embeddings):
     monkeypatch.setattr(harness, "_load_golden_questions", lambda: golden_questions)
     monkeypatch.setattr(harness, "_load_fixture", lambda: (units, embeddings))
-    monkeypatch.setattr(harness, "embed_query", lambda question: [1.0, 0.0])
+    monkeypatch.setattr(
+        harness,
+        "_load_query_embeddings",
+        lambda: {golden["question"]: [1.0, 0.0] for golden in golden_questions},
+    )
+
+    def _unreachable_embed_query(question):
+        raise AssertionError("main() must not embed queries live — it should read fixture data")
+
+    monkeypatch.setattr(harness, "embed_query", _unreachable_embed_query)
 
 
 def _six_unit_fixture(make_unit):

--- a/backend/tests/test_ingest_job.py
+++ b/backend/tests/test_ingest_job.py
@@ -2,12 +2,20 @@ from unittest.mock import patch
 
 import pytest
 
+import config_store
 from ingestion.extract import ExtractionResult
 from ingestion.github_client import CommitRef, GitHubError
 from jobs.ingest_job import get_latest_job, retry_job, run_job, start_job
 from models import IngestCounts
 
 DECISION = ExtractionResult(is_decision=True, decision="Use Redis", rationale="Shared state", alternatives=[])
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_store(tmp_path, monkeypatch):
+    """`_run_repo` now records `indexed_at` via config_store on success —
+    isolate every test in this file from the real `./chroma_data`."""
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
 
 
 def _commit(sha="abc123", date="2026-01-01T00:00:00Z"):
@@ -145,6 +153,46 @@ def test_run_job_only_writes_the_cursor_for_the_successful_repo(mocks):
     run_job(job_id)
 
     mocks["set_cursor"].assert_called_once_with("owner/good", {"last_commit_date": "2026-01-01T00:00:00Z"})
+
+
+def test_run_job_records_indexed_at_when_a_repo_completes(mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["extract_decision"].return_value = DECISION
+
+    assert config_store.get_indexed_at("owner/repo") is None
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    assert config_store.get_indexed_at("owner/repo") is not None
+
+
+def test_run_job_does_not_record_indexed_at_for_a_failed_repo(mocks):
+    mocks["list_commits"].side_effect = GitHubError(403, "rate limited")
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+
+    assert get_latest_job().repos["owner/repo"].phase == "failed"
+    assert config_store.get_indexed_at("owner/repo") is None
+
+
+def test_reindex_updates_indexed_at_to_the_new_run(monkeypatch, mocks):
+    mocks["list_commits"].return_value = [_commit()]
+    mocks["extract_decision"].return_value = DECISION
+
+    timestamps = iter(["2026-01-01T00:00:00+00:00", "2026-01-02T00:00:00+00:00"])
+    monkeypatch.setattr("jobs.ingest_job._current_timestamp", lambda: next(timestamps))
+
+    job_id = start_job(["owner/repo"])
+    run_job(job_id)
+    first = config_store.get_indexed_at("owner/repo")
+
+    retry_job(job_id, "owner/repo")
+    second = config_store.get_indexed_at("owner/repo")
+
+    assert first == "2026-01-01T00:00:00+00:00"
+    assert second == "2026-01-02T00:00:00+00:00"
 
 
 def test_run_job_marks_the_job_inactive_once_every_repo_finishes(mocks):

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -84,7 +84,12 @@ def test_retrieve_models_round_trip():
 def test_query_models_round_trip():
     unit = make_decision_unit()
     response = QueryResponse(
-        answer="Because of revocation.", citations=[unit], retrieved_count=1, mode="synthesized"
+        answer="Because of revocation.",
+        citations=[unit],
+        retrieved_count=1,
+        mode="synthesized",
+        sent_to_cloud=True,
+        cloud_synthesis_fields=["id", "title", "decision", "rationale", "url"],
     )
 
     restored = QueryResponse.model_validate_json(response.model_dump_json())

--- a/backend/tests/test_query_router.py
+++ b/backend/tests/test_query_router.py
@@ -7,7 +7,7 @@ import config_store
 from ingestion.embed import EmbeddingError
 from main import app
 from models import RetrieveResult
-from synthesis.answer import SynthesisError
+from synthesis.answer import SENT_TO_GEMINI_FIELDS, SynthesisError
 
 client = TestClient(app)
 
@@ -38,6 +38,8 @@ def test_query_returns_answer_with_resolved_citations_and_retrieved_count(make_u
         "citations": [unit.model_dump() for unit in cited],
         "retrieved_count": 3,
         "mode": "synthesized",
+        "sent_to_cloud": True,
+        "cloud_synthesis_fields": SENT_TO_GEMINI_FIELDS,
     }
 
 
@@ -105,6 +107,8 @@ def test_query_returns_sources_only_when_no_gemini_key_is_configured(monkeypatch
         "citations": [r.unit.model_dump() for r in results],
         "retrieved_count": 2,
         "mode": "sources_only",
+        "sent_to_cloud": False,
+        "cloud_synthesis_fields": None,
     }
 
 
@@ -159,6 +163,39 @@ def test_query_falls_back_to_sources_only_when_a_scoped_repo_disallows_cloud_syn
     assert response.status_code == 200
     synthesize.assert_not_called()
     assert response.json()["mode"] == "sources_only"
+
+
+def test_query_reports_nothing_sent_to_cloud_in_sources_only_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("CHROMA_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("GEMINI_API_KEY", "")
+    config.get_settings.cache_clear()
+
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = []
+
+        response = client.post("/query", json={"question": "why redis?"})
+
+    assert response.status_code == 200
+    synthesize.assert_not_called()
+    body = response.json()
+    assert body["sent_to_cloud"] is False
+    assert body["cloud_synthesis_fields"] is None
+
+
+def test_query_reports_real_sent_field_list_in_synthesized_mode(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "key")
+    config.get_settings.cache_clear()
+
+    with patch("routers.query.search") as search, patch("routers.query.synthesize") as synthesize:
+        search.return_value = []
+        synthesize.return_value = ("Nothing in the indexed history covers this question.", [])
+
+        response = client.post("/query", json={"question": "why redis?"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sent_to_cloud"] is True
+    assert body["cloud_synthesis_fields"] == SENT_TO_GEMINI_FIELDS
 
 
 def test_query_synthesizes_when_scoped_only_to_allowed_repos(monkeypatch, tmp_path):

--- a/backend/tests/test_repos_router.py
+++ b/backend/tests/test_repos_router.py
@@ -41,8 +41,8 @@ def test_repos_returns_counts_per_repo(make_unit):
     assert response.status_code == 200
     assert response.json() == {
         "repos": [
-            {"repo": "owner/a", "indexed_units": 2, "cloud_synthesis_allowed": True},
-            {"repo": "owner/b", "indexed_units": 1, "cloud_synthesis_allowed": True},
+            {"repo": "owner/a", "indexed_units": 2, "cloud_synthesis_allowed": True, "indexed_at": None},
+            {"repo": "owner/b", "indexed_units": 1, "cloud_synthesis_allowed": True, "indexed_at": None},
         ]
     }
 
@@ -58,10 +58,25 @@ def test_repos_with_zero_indexed_units_still_appears(make_unit):
     assert response.status_code == 200
     assert response.json() == {
         "repos": [
-            {"repo": "owner/a", "indexed_units": 1, "cloud_synthesis_allowed": True},
-            {"repo": "owner/b", "indexed_units": 0, "cloud_synthesis_allowed": True},
+            {"repo": "owner/a", "indexed_units": 1, "cloud_synthesis_allowed": True, "indexed_at": None},
+            {"repo": "owner/b", "indexed_units": 0, "cloud_synthesis_allowed": True, "indexed_at": None},
         ]
     }
+
+
+def test_repos_reflects_indexed_at_once_set(make_unit):
+    config_store.set_indexed_at("owner/a", "2026-01-01T00:00:00+00:00")
+    store.upsert_units(
+        [make_unit(id="owner/a:pr:1", repo="owner/a", url="https://github.com/owner/a/pull/1")],
+        embeddings=[[1, 0]],
+    )
+
+    response = client.get("/repos")
+
+    repo_a = next(r for r in response.json()["repos"] if r["repo"] == "owner/a")
+    repo_b = next(r for r in response.json()["repos"] if r["repo"] == "owner/b")
+    assert repo_a["indexed_at"] == "2026-01-01T00:00:00+00:00"
+    assert repo_b["indexed_at"] is None
 
 
 def test_delete_repos_clears_units_cursors_and_indexed_repos(make_unit, monkeypatch):
@@ -112,7 +127,12 @@ def test_patch_repo_overrides_cloud_synthesis_allowed(make_unit):
     response = client.patch("/repos/owner/a", json={"cloud_synthesis_allowed": True})
 
     assert response.status_code == 200
-    assert response.json() == {"repo": "owner/a", "indexed_units": 1, "cloud_synthesis_allowed": True}
+    assert response.json() == {
+        "repo": "owner/a",
+        "indexed_units": 1,
+        "cloud_synthesis_allowed": True,
+        "indexed_at": None,
+    }
 
     follow_up = client.get("/repos")
     repo_a = next(r for r in follow_up.json()["repos"] if r["repo"] == "owner/a")

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -103,6 +103,75 @@ def test_query_units_reconstructs_full_decision_unit(store_module, make_unit):
     assert score == pytest.approx(1.0)
 
 
+def test_list_units_filters_by_repo(store_module, make_unit):
+    store_module.upsert_units(
+        [
+            make_unit(id="owner/a:pr:1", repo="owner/a"),
+            make_unit(id="owner/b:pr:1", repo="owner/b"),
+        ],
+        embeddings=[[1, 0], [1, 0]],
+    )
+
+    units, total = store_module.list_units("owner/a")
+
+    assert [unit.id for unit in units] == ["owner/a:pr:1"]
+    assert total == 1
+
+
+def test_list_units_orders_newest_first(store_module, make_unit):
+    store_module.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", date="2026-01-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:2", date="2026-03-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:3", date="2026-02-01T00:00:00Z"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    units, _total = store_module.list_units("owner/repo", limit=10)
+
+    assert [unit.id for unit in units] == ["owner/repo:pr:2", "owner/repo:pr:3", "owner/repo:pr:1"]
+
+
+def test_list_units_filters_by_since_and_until(store_module, make_unit):
+    store_module.upsert_units(
+        [
+            make_unit(id="owner/repo:pr:1", date="2026-01-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:2", date="2026-02-01T00:00:00Z"),
+            make_unit(id="owner/repo:pr:3", date="2026-03-01T00:00:00Z"),
+        ],
+        embeddings=[[1, 0], [1, 0], [1, 0]],
+    )
+
+    units, total = store_module.list_units(
+        "owner/repo", since="2026-01-15T00:00:00Z", until="2026-02-15T00:00:00Z"
+    )
+
+    assert [unit.id for unit in units] == ["owner/repo:pr:2"]
+    assert total == 1
+
+
+def test_list_units_paginates_without_duplicates_or_gaps(store_module, make_unit):
+    units = [make_unit(id=f"owner/repo:pr:{i}", date=f"2026-01-{i:02d}T00:00:00Z") for i in range(1, 6)]
+    store_module.upsert_units(units, embeddings=[[1, 0]] * 5)
+
+    page_one, total_one = store_module.list_units("owner/repo", limit=2, offset=0)
+    page_two, total_two = store_module.list_units("owner/repo", limit=2, offset=2)
+    page_three, total_three = store_module.list_units("owner/repo", limit=2, offset=4)
+
+    all_ids = [unit.id for page in (page_one, page_two, page_three) for unit in page]
+    assert len(all_ids) == len(set(all_ids)) == 5
+    assert total_one == total_two == total_three == 5
+    assert [len(page_one), len(page_two), len(page_three)] == [2, 2, 1]
+
+
+def test_list_units_with_no_matches_returns_empty(store_module):
+    units, total = store_module.list_units("owner/repo")
+
+    assert units == []
+    assert total == 0
+
+
 def test_count_units_counts_only_matching_repo(store_module, make_unit):
     store_module.upsert_units(
         [

--- a/backend/tests/test_validation_router.py
+++ b/backend/tests/test_validation_router.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+import httpx
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _tags_response(models: list[str]) -> httpx.Response:
+    return httpx.Response(200, json={"models": [{"name": name} for name in models]})
+
+
+def test_validate_gemini_ok_on_valid_response():
+    gemini_response = httpx.Response(
+        200, json={"candidates": [{"content": {"parts": [{"text": "OK"}]}}]}
+    )
+
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = gemini_response
+
+        response = client.post("/config/validate-gemini")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "detail": None}
+
+
+def test_validate_gemini_reports_auth_error_with_human_readable_detail():
+    with patch("synthesis.answer.httpx.post") as mock_post:
+        mock_post.return_value = httpx.Response(401, json={"error": "unauthorized"})
+
+        response = client.post("/config/validate-gemini")
+
+    body = response.json()
+    assert body["ok"] is False
+    assert "401" in body["detail"]
+
+
+def test_validate_gemini_reports_connection_failure():
+    with patch("synthesis.answer.httpx.post", side_effect=httpx.ConnectError("refused")):
+        response = client.post("/config/validate-gemini")
+
+    body = response.json()
+    assert body["ok"] is False
+    assert body["detail"]
+
+
+def test_validate_ollama_ok_when_host_reachable_and_models_present():
+    # REQUIRED_ENV configures OLLAMA_EXTRACTION_MODEL=phi4-mini and
+    # OLLAMA_EMBEDDING_MODEL=nomic-embed-text.
+    with patch("ingestion.ollama_client.httpx.get") as mock_get:
+        mock_get.return_value = _tags_response(["phi4-mini:latest", "nomic-embed-text:latest"])
+
+        response = client.post("/config/validate-ollama")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "detail": None}
+
+
+def test_validate_ollama_reports_unreachable_host():
+    with patch("ingestion.ollama_client.httpx.get", side_effect=httpx.ConnectError("refused")):
+        response = client.post("/config/validate-ollama")
+
+    body = response.json()
+    assert body["ok"] is False
+    assert body["detail"]
+
+
+def test_validate_ollama_reports_missing_model():
+    with patch("ingestion.ollama_client.httpx.get") as mock_get:
+        mock_get.return_value = _tags_response(["some-other-model:latest"])
+
+        response = client.post("/config/validate-ollama")
+
+    body = response.json()
+    assert body["ok"] is False
+    assert "phi4-mini" in body["detail"]
+    assert "nomic-embed-text" in body["detail"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import AskPage from './ask/AskPage.jsx'
 import LibraryPage from './library/LibraryPage.jsx'
 import { getSetupState } from './api.js'
 import { IngestStatusProvider } from './lib/useIngestStatus.js'
+import { NewQuestionProvider } from './lib/useNewQuestion.js'
 import OnboardingPage from './onboarding/OnboardingPage.jsx'
 import AppShell from './shell/AppShell.jsx'
 import SettingsPage from './settings/SettingsPage.jsx'
@@ -37,21 +38,23 @@ function App() {
 
   return (
     <IngestStatusProvider>
-      <Routes>
-        {setupComplete ? (
-          <Route element={<AppShell />}>
-            <Route path="/" element={<AskPage />} />
-            <Route path="/library" element={<LibraryPage />} />
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Route>
-        ) : (
-          <>
-            <Route path="/onboarding" element={<OnboardingPage />} />
-            <Route path="*" element={<Navigate to="/onboarding" replace />} />
-          </>
-        )}
-      </Routes>
+      <NewQuestionProvider>
+        <Routes>
+          {setupComplete ? (
+            <Route element={<AppShell />}>
+              <Route path="/" element={<AskPage />} />
+              <Route path="/library" element={<LibraryPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Route>
+          ) : (
+            <>
+              <Route path="/onboarding" element={<OnboardingPage />} />
+              <Route path="*" element={<Navigate to="/onboarding" replace />} />
+            </>
+          )}
+        </Routes>
+      </NewQuestionProvider>
     </IngestStatusProvider>
   )
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -103,6 +103,10 @@ export function retryIngest(repo) {
   return request(`/ingest/retry/${repo}`, { method: 'POST' })
 }
 
+export function validateOllama() {
+  return request('/config/validate-ollama', { method: 'POST' })
+}
+
 export function getDecisions({ repo, since, until, page } = {}) {
   const params = new URLSearchParams({ repo })
   if (since) params.set('since', since)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -94,3 +94,11 @@ export function postIngest({ repos } = {}) {
 export function retryIngest(repo) {
   return request(`/ingest/retry/${repo}`, { method: 'POST' })
 }
+
+export function getDecisions({ repo, since, until, page } = {}) {
+  const params = new URLSearchParams({ repo })
+  if (since) params.set('since', since)
+  if (until) params.set('until', until)
+  if (page) params.set('page', page)
+  return request(`/decisions?${params.toString()}`, { method: 'GET' })
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -42,6 +42,14 @@ export function postQuery({ question, repos }) {
   })
 }
 
+export function patchRepo(repo, patch) {
+  return request(`/repos/${repo}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+}
+
 export function getIngestStatus() {
   return request('/ingest/status', { method: 'GET' })
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -107,6 +107,10 @@ export function validateOllama() {
   return request('/config/validate-ollama', { method: 'POST' })
 }
 
+export function validateGemini() {
+  return request('/config/validate-gemini', { method: 'POST' })
+}
+
 export function getDecisions({ repo, since, until, page } = {}) {
   const params = new URLSearchParams({ repo })
   if (since) params.set('since', since)

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -21,7 +21,13 @@ const DENSITY_OPTIONS = [
   { value: 'compact', label: 'Compact' },
 ]
 
-function densityToggleClassName(active) {
+const MEASURE_OPTIONS = [
+  { value: 'narrow', label: 'Narrow' },
+  { value: 'default', label: 'Default' },
+  { value: 'wide', label: 'Wide' },
+]
+
+function preferenceToggleClassName(active) {
   return `rounded-md px-2 py-1 text-xs font-ui ${active ? 'bg-highlight text-ink' : 'text-ink-muted hover:text-ink'}`
 }
 
@@ -52,7 +58,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const reducedMotion = usePrefersReducedMotion()
   const paragraphs = parseAnswer(answer, citations)
   const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
-  const { density, setDensity } = useReadingPreferences()
+  const { density, setDensity, measure, setMeasure } = useReadingPreferences()
 
   return (
     <article className="answer-page max-w-3xl min-[900px]:max-w-none">
@@ -66,7 +72,20 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
                 type="button"
                 aria-pressed={density === option.value}
                 onClick={() => setDensity(option.value)}
-                className={densityToggleClassName(density === option.value)}
+                className={preferenceToggleClassName(density === option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <div role="group" aria-label="Reading width" className="flex items-center gap-1 rounded-lg bg-surface p-1">
+            {MEASURE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={measure === option.value}
+                onClick={() => setMeasure(option.value)}
+                className={preferenceToggleClassName(measure === option.value)}
               >
                 {option.label}
               </button>
@@ -95,6 +114,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
                 paragraph={paragraph}
                 reducedMotion={reducedMotion}
                 density={density}
+                measure={measure}
                 className="min-[900px]:col-start-1"
               />
               {units.length > 0 && (

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -38,6 +38,16 @@ function decisionCount(repos, selectedRepos) {
     .reduce((total, repo) => total + repo.indexed_units, 0)
 }
 
+// Design principle 3 ("honest state"): state how much evidence backs an
+// answer instead of letting a confident-sounding paragraph imply more
+// than it has. Returns null for zero citations — there's nothing to
+// report a span over.
+function citationCoverage(citations) {
+  if (citations.length === 0) return null
+  const years = citations.map((citation) => new Date(citation.date).getFullYear())
+  return { count: citations.length, minYear: Math.min(...years), maxYear: Math.max(...years) }
+}
+
 // The units a paragraph cites, in first-appearance order and deduped (a
 // repeated marker within one paragraph gets one margin card, not two).
 function paragraphUnits(paragraph, citationsById) {
@@ -59,6 +69,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const paragraphs = parseAnswer(answer, citations)
   const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
   const { density, setDensity, measure, setMeasure } = useReadingPreferences()
+  const coverage = citationCoverage(citations)
 
   return (
     <article className="answer-page max-w-3xl min-[900px]:max-w-none">
@@ -104,6 +115,14 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
         {decisions === 1 ? '' : 's'}
       </p>
+      {coverage && (
+        <p className="font-ui text-sm text-ink-muted">
+          From {coverage.count} decision{coverage.count === 1 ? '' : 's'}
+          {coverage.minYear === coverage.maxYear
+            ? ` (${coverage.minYear})`
+            : ` spanning ${coverage.minYear}–${coverage.maxYear}`}
+        </p>
+      )}
 
       <div className="answer-grid mt-6 min-[900px]:grid min-[900px]:grid-cols-[minmax(0,68ch)_180px] min-[900px]:gap-x-8 xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
         {paragraphs.map((paragraph) => {

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -1,0 +1,38 @@
+// The annotated page for one question, replacing the chat-bubble
+// rendering of an assistant turn. Per docs/superpowers/specs/2026-08-04-v2-design.md
+// Track B: the question is set as a heading carrying a provenance dek
+// ("searched N repos · M decisions") stated before the answer is read.
+import AnswerPassage from './AnswerPassage.jsx'
+import SourceCardList from './SourceCardList.jsx'
+
+function decisionCount(repos, selectedRepos) {
+  const selected = new Set(selectedRepos)
+  return repos
+    .filter((repo) => selected.has(repo.repo))
+    .reduce((total, repo) => total + repo.indexed_units, 0)
+}
+
+function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
+  const repoCount = selectedRepos.length
+  const decisions = decisionCount(repos, selectedRepos)
+
+  return (
+    <article className="max-w-3xl">
+      <h1 className="font-ui text-2xl text-ink">{question}</h1>
+      <p className="font-ui text-sm text-ink-muted mt-1">
+        searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
+        {decisions === 1 ? '' : 's'}
+      </p>
+
+      <div className="mt-6">
+        <AnswerPassage answer={answer} citations={citations} />
+      </div>
+
+      {citations.length > 0 && (
+        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4" />
+      )}
+    </article>
+  )
+}
+
+export default AnswerPage

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -14,6 +14,7 @@ import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
 import useReadingPreferences from '../lib/useReadingPreferences.js'
 import { AnswerParagraph } from './AnswerPassage.jsx'
 import { parseAnswer } from './parseAnswer.js'
+import PrivacyPanel from './PrivacyPanel.jsx'
 import SourceCard from './SourceCard.jsx'
 
 const DENSITY_OPTIONS = [
@@ -78,7 +79,15 @@ function paragraphUnits(paragraph, citationsById) {
   return units
 }
 
-function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
+function AnswerPage({
+  question,
+  answer,
+  citations,
+  repos,
+  selectedRepos,
+  sentToCloud = false,
+  cloudSynthesisFields = null,
+}) {
   const repoCount = selectedRepos.length
   const decisions = decisionCount(repos, selectedRepos)
   const reducedMotion = usePrefersReducedMotion()
@@ -140,6 +149,15 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
           {isCoverageThin(coverage) ? '; coverage for this area is thin' : ''}
         </p>
       )}
+
+      <details className="mt-2 print:hidden">
+        <summary className="cursor-pointer font-ui text-xs text-ink-muted hover:text-ink">
+          What was sent
+        </summary>
+        <div className="mt-2">
+          <PrivacyPanel sentToCloud={sentToCloud} cloudSynthesisFields={cloudSynthesisFields} />
+        </div>
+      </details>
 
       <div className="answer-grid mt-6 min-[900px]:grid min-[900px]:grid-cols-[minmax(0,68ch)_180px] min-[900px]:gap-x-8 xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
         {paragraphs.map((paragraph) => {

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -48,6 +48,22 @@ function citationCoverage(citations) {
   return { count: citations.length, minYear: Math.min(...years), maxYear: Math.max(...years) }
 }
 
+// Thresholds below are a plain heuristic, not a confidence score — there's
+// no statistical backing behind "3" or "1 per year", they're just a rough
+// line between "a couple of citations" and "an actually covered area".
+// Don't read more rigor into this than exists; it exists only to avoid a
+// confident-sounding answer implying more evidence than it has.
+const THIN_CITATION_COUNT = 3
+const THIN_SPAN_YEARS = 3
+const THIN_CITATIONS_PER_YEAR = 1
+
+function isCoverageThin(coverage) {
+  if (!coverage) return false
+  if (coverage.count < THIN_CITATION_COUNT) return true
+  const spanYears = coverage.maxYear - coverage.minYear + 1
+  return spanYears > THIN_SPAN_YEARS && coverage.count / spanYears < THIN_CITATIONS_PER_YEAR
+}
+
 // The units a paragraph cites, in first-appearance order and deduped (a
 // repeated marker within one paragraph gets one margin card, not two).
 function paragraphUnits(paragraph, citationsById) {
@@ -121,6 +137,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
           {coverage.minYear === coverage.maxYear
             ? ` (${coverage.minYear})`
             : ` spanning ${coverage.minYear}–${coverage.maxYear}`}
+          {isCoverageThin(coverage) ? '; coverage for this area is thin' : ''}
         </p>
       )}
 

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -45,7 +45,16 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
 
   return (
     <article className="answer-page max-w-3xl min-[900px]:max-w-none">
-      <h1 className="font-ui text-2xl text-ink">{question}</h1>
+      <div className="flex items-start justify-between gap-4">
+        <h1 className="font-ui text-2xl text-ink">{question}</h1>
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="print:hidden shrink-0 rounded-lg border border-transparent px-3 py-1.5 text-xs font-ui text-ink-muted hover:border-accent hover:text-ink"
+        >
+          Print / Save as PDF
+        </button>
+      </div>
       <p className="font-ui text-sm text-ink-muted mt-1">
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
         {decisions === 1 ? '' : 's'}

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -2,8 +2,11 @@
 // rendering of an assistant turn. Per docs/superpowers/specs/2026-08-04-v2-design.md
 // Track B: the question is set as a heading carrying a provenance dek
 // ("searched N repos · M decisions") stated before the answer is read,
-// and at >=1280px each paragraph's citations sit in a right margin track
-// beside it, rather than collected in a list at the foot of the answer.
+// and from 900px up each paragraph's citations sit in a right margin
+// track beside it, rather than collected in a list at the foot of the
+// answer. The track narrows from 900-1280px (Tailwind's `min-[900px]:`,
+// since the default breakpoints skip straight from 768px to 1024px) and
+// widens to its full size at >=1280px (`xl:`).
 import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
 import { AnswerParagraph } from './AnswerPassage.jsx'
 import { parseAnswer } from './parseAnswer.js'
@@ -39,23 +42,27 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
 
   return (
-    <article className="max-w-3xl xl:max-w-none">
+    <article className="max-w-3xl min-[900px]:max-w-none">
       <h1 className="font-ui text-2xl text-ink">{question}</h1>
       <p className="font-ui text-sm text-ink-muted mt-1">
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
         {decisions === 1 ? '' : 's'}
       </p>
 
-      <div className="mt-6 xl:grid xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
+      <div className="mt-6 min-[900px]:grid min-[900px]:grid-cols-[minmax(0,68ch)_180px] min-[900px]:gap-x-8 xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
         {paragraphs.map((paragraph) => {
           const units = paragraphUnits(paragraph, citationsById)
           return (
-            <div key={paragraph.key} className="xl:contents">
-              <AnswerParagraph paragraph={paragraph} reducedMotion={reducedMotion} className="xl:col-start-1" />
+            <div key={paragraph.key} className="min-[900px]:contents">
+              <AnswerParagraph
+                paragraph={paragraph}
+                reducedMotion={reducedMotion}
+                className="min-[900px]:col-start-1"
+              />
               {units.length > 0 && (
-                <div className="hidden xl:flex xl:flex-col xl:justify-center xl:gap-4 xl:col-start-2">
+                <div className="hidden min-[900px]:flex min-[900px]:flex-col min-[900px]:justify-center min-[900px]:gap-4 min-[900px]:col-start-2">
                   {units.map(({ unit, number }) => (
-                    <SourceCard key={unit.id} unit={unit} number={number} />
+                    <SourceCard key={unit.id} unit={unit} number={number} widthClassName="w-full" />
                   ))}
                 </div>
               )}
@@ -65,7 +72,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
       </div>
 
       {citations.length > 0 && (
-        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4 xl:hidden" />
+        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4 min-[900px]:hidden" />
       )}
     </article>
   )

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -6,12 +6,14 @@
 // track beside it, rather than collected in a list at the foot of the
 // answer. The track narrows from 900-1280px (Tailwind's `min-[900px]:`,
 // since the default breakpoints skip straight from 768px to 1024px) and
-// widens to its full size at >=1280px (`xl:`).
+// widens to its full size at >=1280px (`xl:`). Below 900px there's no
+// margin track at all: each paragraph's source cards collapse inline,
+// directly after that paragraph, rather than batching every citation in
+// one list at the foot of the answer.
 import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
 import { AnswerParagraph } from './AnswerPassage.jsx'
 import { parseAnswer } from './parseAnswer.js'
 import SourceCard from './SourceCard.jsx'
-import SourceCardList from './SourceCardList.jsx'
 
 function decisionCount(repos, selectedRepos) {
   const selected = new Set(selectedRepos)
@@ -66,14 +68,17 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
                   ))}
                 </div>
               )}
+              {units.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-4 min-[900px]:hidden">
+                  {units.map(({ unit, number }) => (
+                    <SourceCard key={unit.id} unit={unit} number={number} />
+                  ))}
+                </div>
+              )}
             </div>
           )
         })}
       </div>
-
-      {citations.length > 0 && (
-        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4 min-[900px]:hidden" />
-      )}
     </article>
   )
 }

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -1,8 +1,13 @@
 // The annotated page for one question, replacing the chat-bubble
 // rendering of an assistant turn. Per docs/superpowers/specs/2026-08-04-v2-design.md
 // Track B: the question is set as a heading carrying a provenance dek
-// ("searched N repos · M decisions") stated before the answer is read.
-import AnswerPassage from './AnswerPassage.jsx'
+// ("searched N repos · M decisions") stated before the answer is read,
+// and at >=1280px each paragraph's citations sit in a right margin track
+// beside it, rather than collected in a list at the foot of the answer.
+import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
+import { AnswerParagraph } from './AnswerPassage.jsx'
+import { parseAnswer } from './parseAnswer.js'
+import SourceCard from './SourceCard.jsx'
 import SourceCardList from './SourceCardList.jsx'
 
 function decisionCount(repos, selectedRepos) {
@@ -12,24 +17,55 @@ function decisionCount(repos, selectedRepos) {
     .reduce((total, repo) => total + repo.indexed_units, 0)
 }
 
+// The units a paragraph cites, in first-appearance order and deduped (a
+// repeated marker within one paragraph gets one margin card, not two).
+function paragraphUnits(paragraph, citationsById) {
+  const seen = new Set()
+  const units = []
+  for (const part of paragraph.parts) {
+    if (part.type !== 'marker' || seen.has(part.unitId)) continue
+    seen.add(part.unitId)
+    const unit = citationsById.get(part.unitId)
+    if (unit) units.push({ unit, number: part.number })
+  }
+  return units
+}
+
 function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const repoCount = selectedRepos.length
   const decisions = decisionCount(repos, selectedRepos)
+  const reducedMotion = usePrefersReducedMotion()
+  const paragraphs = parseAnswer(answer, citations)
+  const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
 
   return (
-    <article className="max-w-3xl">
+    <article className="max-w-3xl xl:max-w-none">
       <h1 className="font-ui text-2xl text-ink">{question}</h1>
       <p className="font-ui text-sm text-ink-muted mt-1">
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
         {decisions === 1 ? '' : 's'}
       </p>
 
-      <div className="mt-6">
-        <AnswerPassage answer={answer} citations={citations} />
+      <div className="mt-6 xl:grid xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
+        {paragraphs.map((paragraph) => {
+          const units = paragraphUnits(paragraph, citationsById)
+          return (
+            <div key={paragraph.key} className="xl:contents">
+              <AnswerParagraph paragraph={paragraph} reducedMotion={reducedMotion} className="xl:col-start-1" />
+              {units.length > 0 && (
+                <div className="hidden xl:flex xl:flex-col xl:justify-center xl:gap-4 xl:col-start-2">
+                  {units.map(({ unit, number }) => (
+                    <SourceCard key={unit.id} unit={unit} number={number} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {citations.length > 0 && (
-        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4" />
+        <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4 xl:hidden" />
       )}
     </article>
   )

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -44,14 +44,14 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
 
   return (
-    <article className="max-w-3xl min-[900px]:max-w-none">
+    <article className="answer-page max-w-3xl min-[900px]:max-w-none">
       <h1 className="font-ui text-2xl text-ink">{question}</h1>
       <p className="font-ui text-sm text-ink-muted mt-1">
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
         {decisions === 1 ? '' : 's'}
       </p>
 
-      <div className="mt-6 min-[900px]:grid min-[900px]:grid-cols-[minmax(0,68ch)_180px] min-[900px]:gap-x-8 xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
+      <div className="answer-grid mt-6 min-[900px]:grid min-[900px]:grid-cols-[minmax(0,68ch)_180px] min-[900px]:gap-x-8 xl:grid-cols-[minmax(0,68ch)_260px] xl:gap-x-12">
         {paragraphs.map((paragraph) => {
           const units = paragraphUnits(paragraph, citationsById)
           return (
@@ -63,7 +63,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
               />
               {units.length > 0 && (
                 <div
-                  className={`hidden min-[900px]:flex min-[900px]:flex-col min-[900px]:justify-center min-[900px]:gap-4 min-[900px]:col-start-2 ${
+                  className={`answer-grid-margin hidden min-[900px]:flex min-[900px]:flex-col min-[900px]:justify-center min-[900px]:gap-4 min-[900px]:col-start-2 ${
                     reducedMotion ? '' : 'animate-source-group-entrance'
                   }`}
                 >
@@ -74,7 +74,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
               )}
               {units.length > 0 && (
                 <div
-                  className={`mt-4 flex flex-wrap gap-4 min-[900px]:hidden ${
+                  className={`answer-grid-inline mt-4 flex flex-wrap gap-4 min-[900px]:hidden ${
                     reducedMotion ? '' : 'animate-source-group-entrance'
                   }`}
                 >

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -62,14 +62,22 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
                 className="min-[900px]:col-start-1"
               />
               {units.length > 0 && (
-                <div className="hidden min-[900px]:flex min-[900px]:flex-col min-[900px]:justify-center min-[900px]:gap-4 min-[900px]:col-start-2">
+                <div
+                  className={`hidden min-[900px]:flex min-[900px]:flex-col min-[900px]:justify-center min-[900px]:gap-4 min-[900px]:col-start-2 ${
+                    reducedMotion ? '' : 'animate-source-group-entrance'
+                  }`}
+                >
                   {units.map(({ unit, number }) => (
                     <SourceCard key={unit.id} unit={unit} number={number} widthClassName="w-full" />
                   ))}
                 </div>
               )}
               {units.length > 0 && (
-                <div className="mt-4 flex flex-wrap gap-4 min-[900px]:hidden">
+                <div
+                  className={`mt-4 flex flex-wrap gap-4 min-[900px]:hidden ${
+                    reducedMotion ? '' : 'animate-source-group-entrance'
+                  }`}
+                >
                   {units.map(({ unit, number }) => (
                     <SourceCard key={unit.id} unit={unit} number={number} />
                   ))}

--- a/frontend/src/ask/AnswerPage.jsx
+++ b/frontend/src/ask/AnswerPage.jsx
@@ -11,9 +11,19 @@
 // directly after that paragraph, rather than batching every citation in
 // one list at the foot of the answer.
 import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
+import useReadingPreferences from '../lib/useReadingPreferences.js'
 import { AnswerParagraph } from './AnswerPassage.jsx'
 import { parseAnswer } from './parseAnswer.js'
 import SourceCard from './SourceCard.jsx'
+
+const DENSITY_OPTIONS = [
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'compact', label: 'Compact' },
+]
+
+function densityToggleClassName(active) {
+  return `rounded-md px-2 py-1 text-xs font-ui ${active ? 'bg-highlight text-ink' : 'text-ink-muted hover:text-ink'}`
+}
 
 function decisionCount(repos, selectedRepos) {
   const selected = new Set(selectedRepos)
@@ -42,18 +52,34 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
   const reducedMotion = usePrefersReducedMotion()
   const paragraphs = parseAnswer(answer, citations)
   const citationsById = new Map(citations.map((unit) => [unit.id, unit]))
+  const { density, setDensity } = useReadingPreferences()
 
   return (
     <article className="answer-page max-w-3xl min-[900px]:max-w-none">
       <div className="flex items-start justify-between gap-4">
         <h1 className="font-ui text-2xl text-ink">{question}</h1>
-        <button
-          type="button"
-          onClick={() => window.print()}
-          className="print:hidden shrink-0 rounded-lg border border-transparent px-3 py-1.5 text-xs font-ui text-ink-muted hover:border-accent hover:text-ink"
-        >
-          Print / Save as PDF
-        </button>
+        <div className="print:hidden shrink-0 flex items-center gap-3">
+          <div role="group" aria-label="Reading density" className="flex items-center gap-1 rounded-lg bg-surface p-1">
+            {DENSITY_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={density === option.value}
+                onClick={() => setDensity(option.value)}
+                className={densityToggleClassName(density === option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="rounded-lg border border-transparent px-3 py-1.5 text-xs font-ui text-ink-muted hover:border-accent hover:text-ink"
+          >
+            Print / Save as PDF
+          </button>
+        </div>
       </div>
       <p className="font-ui text-sm text-ink-muted mt-1">
         searched {repoCount} repo{repoCount === 1 ? '' : 's'} · {decisions} decision
@@ -68,6 +94,7 @@ function AnswerPage({ question, answer, citations, repos, selectedRepos }) {
               <AnswerParagraph
                 paragraph={paragraph}
                 reducedMotion={reducedMotion}
+                density={density}
                 className="min-[900px]:col-start-1"
               />
               {units.length > 0 && (

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -260,6 +260,60 @@ describe('AnswerPage', () => {
     })
   })
 
+  describe('reading measure toggle', () => {
+    it('defaults to the default width and switches the paragraph column width on click', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const defaultButton = screen.getByRole('button', { name: 'Default' })
+      const wideButton = screen.getByRole('button', { name: 'Wide' })
+      expect(defaultButton).toHaveAttribute('aria-pressed', 'true')
+
+      const paragraph = screen.getByText(/We use OAuth2 for auth/).closest('p')
+      expect(paragraph).toHaveClass('max-w-[70ch]')
+
+      await user.click(wideButton)
+
+      expect(wideButton).toHaveAttribute('aria-pressed', 'true')
+      expect(paragraph).toHaveClass('max-w-[86ch]')
+    })
+
+    it('persists the measure choice across a remount', async () => {
+      const user = userEvent.setup()
+      const { unmount } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+      await user.click(screen.getByRole('button', { name: 'Narrow' }))
+      unmount()
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByRole('button', { name: 'Narrow' })).toHaveAttribute('aria-pressed', 'true')
+    })
+  })
+
   describe('SourceCards group-entrance motion', () => {
     it('applies the group-entrance animation to a paragraph\'s margin and inline card groups by default', () => {
       stubMatchMedia(false)

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -87,6 +87,68 @@ describe('AnswerPage', () => {
     )
 
     expect(screen.getByText(/We use OAuth2 for auth/)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Citation:/ })).toHaveAttribute('href', citation.url)
+    for (const link of screen.getAllByRole('link', { name: /Citation:/ })) {
+      expect(link).toHaveAttribute('href', citation.url)
+    }
+  })
+
+  describe('>=1280px margin grid', () => {
+    it('places a cited paragraph in the reading column and its source card in the margin column, same grid row', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const grid = container.querySelector('.xl\\:grid')
+      expect(grid).toBeInTheDocument()
+
+      const paragraph = screen.getByText(/We use OAuth2 for auth/).closest('p')
+      expect(paragraph).toHaveClass('xl:col-start-1')
+
+      const marginGroup = grid.querySelector('.xl\\:col-start-2')
+      expect(marginGroup).toBeInTheDocument()
+      expect(marginGroup).toHaveClass('hidden', 'xl:flex')
+      const marginLink = marginGroup.querySelector('a')
+      expect(marginLink).toHaveAttribute('href', citation.url)
+
+      // paragraph and its margin group are siblings under the same
+      // xl:contents wrapper, i.e. the same implicit grid row.
+      expect(paragraph.parentElement).toBe(marginGroup.parentElement)
+    })
+
+    it('renders no margin-column element for a paragraph that cites nothing', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="No citation in this one."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(container.querySelector('.xl\\:col-start-2')).not.toBeInTheDocument()
+    })
+
+    it('gives each margin source card its marker number', () => {
+      const other = { ...citation, id: 'owner/repo:commit:abc', url: 'https://github.com/owner/repo/commit/abc' }
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].'}
+          citations={[citation, other]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getAllByText('1')).not.toHaveLength(0)
+      expect(screen.getAllByText('2')).not.toHaveLength(0)
+    })
   })
 })

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AnswerPage from './AnswerPage.jsx'
+
+const citation = {
+  id: 'owner/repo:pr:42',
+  kind: 'pr',
+  ref: '42',
+  url: 'https://github.com/owner/repo/pull/42',
+  title: 'Switch auth to OAuth2 for third-party integrations',
+  author: 'octocat',
+  date: '2024-01-01T00:00:00Z',
+  repo: 'owner/repo',
+}
+
+const repos = [
+  { repo: 'owner/repo', indexed_units: 30 },
+  { repo: 'owner/other', indexed_units: 8 },
+]
+
+describe('AnswerPage', () => {
+  it('renders the question as a heading', () => {
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth."
+        citations={[]}
+        repos={repos}
+        selectedRepos={['owner/repo']}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Why OAuth2?' })).toBeInTheDocument()
+  })
+
+  it('renders a provenance dek computed from selectedRepos and their indexed_units', () => {
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth."
+        citations={[]}
+        repos={repos}
+        selectedRepos={['owner/repo', 'owner/other']}
+      />,
+    )
+
+    expect(screen.getByText('searched 2 repos · 38 decisions')).toBeInTheDocument()
+  })
+
+  it('singularizes the dek for one repo and one decision', () => {
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth."
+        citations={[]}
+        repos={[{ repo: 'owner/repo', indexed_units: 1 }]}
+        selectedRepos={['owner/repo']}
+      />,
+    )
+
+    expect(screen.getByText('searched 1 repo · 1 decision')).toBeInTheDocument()
+  })
+
+  it('only counts indexed_units for selected repos', () => {
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth."
+        citations={[]}
+        repos={repos}
+        selectedRepos={['owner/repo']}
+      />,
+    )
+
+    expect(screen.getByText('searched 1 repo · 30 decisions')).toBeInTheDocument()
+  })
+
+  it('renders the answer body with its citation and sources', () => {
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth [owner/repo:pr:42]."
+        citations={[citation]}
+        repos={repos}
+        selectedRepos={['owner/repo']}
+      />,
+    )
+
+    expect(screen.getByText(/We use OAuth2 for auth/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Citation:/ })).toHaveAttribute('href', citation.url)
+  })
+})

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -340,10 +340,62 @@ describe('AnswerPage', () => {
         />,
       )
 
-      expect(screen.getByText('From 1 decision (2024)')).toBeInTheDocument()
+      expect(screen.getByText('From 1 decision (2024); coverage for this area is thin')).toBeInTheDocument()
     })
 
     it('states the min/max year span across multiple citations', () => {
+      const older = { ...citation, id: 'owner/repo:commit:abc', date: '2022-06-15T00:00:00Z' }
+      const newer = { ...citation, id: 'owner/repo:pr:99', date: '2023-11-01T00:00:00Z' }
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].\n\nThird [owner/repo:pr:99].'}
+          citations={[citation, older, newer]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText('From 3 decisions spanning 2022–2024')).toBeInTheDocument()
+    })
+
+    it('collapses to one year, not a same-year span, when every citation falls in the same year', () => {
+      const sameYearA = { ...citation, id: 'owner/repo:commit:abc', date: '2024-06-15T00:00:00Z' }
+      const sameYearB = { ...citation, id: 'owner/repo:pr:99', date: '2024-02-01T00:00:00Z' }
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].\n\nThird [owner/repo:pr:99].'}
+          citations={[citation, sameYearA, sameYearB]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText('From 3 decisions (2024)')).toBeInTheDocument()
+    })
+  })
+
+  describe('coverage thin heuristic', () => {
+    it('flags a citation set below the count threshold as thin', () => {
+      const second = { ...citation, id: 'owner/repo:commit:abc', date: '2024-06-15T00:00:00Z' }
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].'}
+          citations={[citation, second]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText(/coverage for this area is thin/)).toBeInTheDocument()
+    })
+
+    it('flags a wide, sparse date span as thin even with enough citations', () => {
       const older = { ...citation, id: 'owner/repo:commit:abc', date: '2019-06-15T00:00:00Z' }
       const newer = { ...citation, id: 'owner/repo:pr:99', date: '2023-11-01T00:00:00Z' }
 
@@ -357,23 +409,25 @@ describe('AnswerPage', () => {
         />,
       )
 
-      expect(screen.getByText('From 3 decisions spanning 2019–2024')).toBeInTheDocument()
+      expect(screen.getByText('From 3 decisions spanning 2019–2024; coverage for this area is thin')).toBeInTheDocument()
     })
 
-    it('collapses to one year, not a same-year span, when every citation falls in the same year', () => {
-      const sameYear = { ...citation, id: 'owner/repo:commit:abc', date: '2024-06-15T00:00:00Z' }
+    it('does not flag a well-covered citation set', () => {
+      const second = { ...citation, id: 'owner/repo:commit:abc', date: '2023-06-15T00:00:00Z' }
+      const third = { ...citation, id: 'owner/repo:pr:99', date: '2024-02-01T00:00:00Z' }
 
       render(
         <AnswerPage
           question="Why OAuth2?"
-          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].'}
-          citations={[citation, sameYear]}
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].\n\nThird [owner/repo:pr:99].'}
+          citations={[citation, second, third]}
           repos={repos}
           selectedRepos={['owner/repo']}
         />,
       )
 
-      expect(screen.getByText('From 2 decisions (2024)')).toBeInTheDocument()
+      expect(screen.getByText('From 3 decisions spanning 2023–2024')).toBeInTheDocument()
+      expect(screen.queryByText(/coverage for this area is thin/)).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import AnswerPage from './AnswerPage.jsx'
 
@@ -29,6 +30,7 @@ const repos = [
 describe('AnswerPage', () => {
   afterEach(() => {
     delete window.matchMedia
+    delete window.print
   })
 
   it('renders the question as a heading', () => {
@@ -43,6 +45,25 @@ describe('AnswerPage', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'Why OAuth2?' })).toBeInTheDocument()
+  })
+
+  it('calls window.print when the print button is clicked', async () => {
+    const user = userEvent.setup()
+    window.print = vi.fn()
+
+    render(
+      <AnswerPage
+        question="Why OAuth2?"
+        answer="We use OAuth2 for auth."
+        citations={[]}
+        repos={repos}
+        selectedRepos={['owner/repo']}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Print / Save as PDF' }))
+
+    expect(window.print).toHaveBeenCalledTimes(1)
   })
 
   it('renders a provenance dek computed from selectedRepos and their indexed_units', () => {

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -431,6 +431,63 @@ describe('AnswerPage', () => {
     })
   })
 
+  describe('privacy panel disclosure', () => {
+    it('is present but collapsed by default', () => {
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+          sentToCloud={true}
+          cloudSynthesisFields={['id', 'title']}
+        />,
+      )
+
+      const disclosure = screen.getByText('What was sent').closest('details')
+      expect(disclosure).toBeInTheDocument()
+      expect(disclosure).not.toHaveAttribute('open')
+    })
+
+    it('reveals PrivacyPanel content when expanded', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+          sentToCloud={true}
+          cloudSynthesisFields={['id', 'title']}
+        />,
+      )
+
+      await user.click(screen.getByText('What was sent'))
+
+      expect(screen.getByText('id')).toBeInTheDocument()
+      expect(screen.getByText('title')).toBeInTheDocument()
+    })
+
+    it('shows the local-only state when nothing was sent to the cloud', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      await user.click(screen.getByText('What was sent'))
+
+      expect(screen.getByText('Nothing left this machine for this answer.')).toBeInTheDocument()
+    })
+  })
+
   describe('SourceCards group-entrance motion', () => {
     it('applies the group-entrance animation to a paragraph\'s margin and inline card groups by default', () => {
       stubMatchMedia(false)

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -314,6 +314,69 @@ describe('AnswerPage', () => {
     })
   })
 
+  describe('coverage line', () => {
+    it('renders nothing when there are no citations', () => {
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.queryByText(/^From /)).not.toBeInTheDocument()
+    })
+
+    it('states a single year, not a nonsensical span, for one citation', () => {
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText('From 1 decision (2024)')).toBeInTheDocument()
+    })
+
+    it('states the min/max year span across multiple citations', () => {
+      const older = { ...citation, id: 'owner/repo:commit:abc', date: '2019-06-15T00:00:00Z' }
+      const newer = { ...citation, id: 'owner/repo:pr:99', date: '2023-11-01T00:00:00Z' }
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].\n\nThird [owner/repo:pr:99].'}
+          citations={[citation, older, newer]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText('From 3 decisions spanning 2019–2024')).toBeInTheDocument()
+    })
+
+    it('collapses to one year, not a same-year span, when every citation falls in the same year', () => {
+      const sameYear = { ...citation, id: 'owner/repo:commit:abc', date: '2024-06-15T00:00:00Z' }
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].'}
+          citations={[citation, sameYear]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByText('From 2 decisions (2024)')).toBeInTheDocument()
+    })
+  })
+
   describe('SourceCards group-entrance motion', () => {
     it('applies the group-entrance animation to a paragraph\'s margin and inline card groups by default', () => {
       stubMatchMedia(false)

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -1,6 +1,14 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import AnswerPage from './AnswerPage.jsx'
+
+function stubMatchMedia(matches) {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })
+}
 
 const citation = {
   id: 'owner/repo:pr:42',
@@ -19,6 +27,10 @@ const repos = [
 ]
 
 describe('AnswerPage', () => {
+  afterEach(() => {
+    delete window.matchMedia
+  })
+
   it('renders the question as a heading', () => {
     render(
       <AnswerPage
@@ -169,6 +181,44 @@ describe('AnswerPage', () => {
       const fallback = container.querySelector('.min-\\[900px\\]\\:hidden')
       expect(fallback).toBeInTheDocument()
       expect(fallback.querySelector('a')).toHaveAttribute('href', citation.url)
+    })
+  })
+
+  describe('SourceCards group-entrance motion', () => {
+    it('applies the group-entrance animation to a paragraph\'s margin and inline card groups by default', () => {
+      stubMatchMedia(false)
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const marginGroup = container.querySelector('.min-\\[900px\\]\\:col-start-2')
+      const inlineGroup = container.querySelector('.min-\\[900px\\]\\:hidden')
+      expect(marginGroup).toHaveClass('animate-source-group-entrance')
+      expect(inlineGroup).toHaveClass('animate-source-group-entrance')
+    })
+
+    it('omits the group-entrance animation under reduced motion', () => {
+      stubMatchMedia(true)
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const marginGroup = container.querySelector('.min-\\[900px\\]\\:col-start-2')
+      const inlineGroup = container.querySelector('.min-\\[900px\\]\\:hidden')
+      expect(marginGroup).not.toHaveClass('animate-source-group-entrance')
+      expect(inlineGroup).not.toHaveClass('animate-source-group-entrance')
     })
   })
 

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -189,4 +189,65 @@ describe('AnswerPage', () => {
       expect(grid).toHaveClass('xl:grid-cols-[minmax(0,68ch)_260px]')
     })
   })
+
+  describe('<900px inline citation collapse', () => {
+    const other = { ...citation, id: 'owner/repo:commit:abc', url: 'https://github.com/owner/repo/commit/abc' }
+
+    it('places each note as the next sibling after its own paragraph, not grouped at the end', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'First [owner/repo:pr:42].\n\nSecond [owner/repo:commit:abc].'}
+          citations={[citation, other]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const wrappers = container.querySelectorAll('.min-\\[900px\\]\\:contents')
+      expect(wrappers).toHaveLength(2)
+      const [firstWrapper, secondWrapper] = wrappers
+
+      // each paragraph's inline note is a child of the same wrapper as the
+      // paragraph itself, positioned after it — a real sibling relationship,
+      // not membership in one shared list at the foot of the answer.
+      const firstParagraph = firstWrapper.querySelector('p')
+      const firstInline = firstWrapper.querySelector('.min-\\[900px\\]\\:hidden')
+      expect(firstInline).toBeInTheDocument()
+      expect(firstInline.querySelector('a')).toHaveAttribute('href', citation.url)
+      const firstChildren = Array.from(firstWrapper.children)
+      expect(firstChildren.indexOf(firstInline)).toBeGreaterThan(firstChildren.indexOf(firstParagraph))
+
+      const secondParagraph = secondWrapper.querySelector('p')
+      const secondInline = secondWrapper.querySelector('.min-\\[900px\\]\\:hidden')
+      expect(secondInline).toBeInTheDocument()
+      expect(secondInline.querySelector('a')).toHaveAttribute('href', other.url)
+
+      // real document order: the first paragraph's note precedes the second
+      // paragraph entirely, instead of both notes being batched after it.
+      const position = firstInline.compareDocumentPosition(secondParagraph)
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+      // exactly one inline note group per cited paragraph — no additional
+      // grouped list collecting every citation at the foot of the answer.
+      expect(container.querySelectorAll('.min-\\[900px\\]\\:hidden')).toHaveLength(2)
+    })
+
+    it('renders no inline note for a paragraph that cites nothing', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer={'No citation here.\n\nSecond [owner/repo:pr:42].'}
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const wrappers = container.querySelectorAll('.min-\\[900px\\]\\:contents')
+      expect(wrappers).toHaveLength(2)
+      expect(wrappers[0].querySelector('.min-\\[900px\\]\\:hidden')).not.toBeInTheDocument()
+      expect(wrappers[1].querySelector('.min-\\[900px\\]\\:hidden')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -92,7 +92,7 @@ describe('AnswerPage', () => {
     }
   })
 
-  describe('>=1280px margin grid', () => {
+  describe('>=900px margin grid', () => {
     it('places a cited paragraph in the reading column and its source card in the margin column, same grid row', () => {
       const { container } = render(
         <AnswerPage
@@ -104,20 +104,24 @@ describe('AnswerPage', () => {
         />,
       )
 
-      const grid = container.querySelector('.xl\\:grid')
+      const grid = container.querySelector('.min-\\[900px\\]\\:grid')
       expect(grid).toBeInTheDocument()
 
       const paragraph = screen.getByText(/We use OAuth2 for auth/).closest('p')
-      expect(paragraph).toHaveClass('xl:col-start-1')
+      expect(paragraph).toHaveClass('min-[900px]:col-start-1')
 
-      const marginGroup = grid.querySelector('.xl\\:col-start-2')
+      const marginGroup = grid.querySelector('.min-\\[900px\\]\\:col-start-2')
       expect(marginGroup).toBeInTheDocument()
-      expect(marginGroup).toHaveClass('hidden', 'xl:flex')
+      expect(marginGroup).toHaveClass('hidden', 'min-[900px]:flex')
       const marginLink = marginGroup.querySelector('a')
       expect(marginLink).toHaveAttribute('href', citation.url)
+      // The card fills its grid column instead of a fixed width, so it
+      // doesn't overflow the narrower 900-1280px track.
+      expect(marginLink).toHaveClass('w-full')
+      expect(marginLink).not.toHaveClass('sm:w-64')
 
       // paragraph and its margin group are siblings under the same
-      // xl:contents wrapper, i.e. the same implicit grid row.
+      // min-[900px]:contents wrapper, i.e. the same implicit grid row.
       expect(paragraph.parentElement).toBe(marginGroup.parentElement)
     })
 
@@ -132,7 +136,7 @@ describe('AnswerPage', () => {
         />,
       )
 
-      expect(container.querySelector('.xl\\:col-start-2')).not.toBeInTheDocument()
+      expect(container.querySelector('.min-\\[900px\\]\\:col-start-2')).not.toBeInTheDocument()
     })
 
     it('gives each margin source card its marker number', () => {
@@ -149,6 +153,40 @@ describe('AnswerPage', () => {
 
       expect(screen.getAllByText('1')).not.toHaveLength(0)
       expect(screen.getAllByText('2')).not.toHaveLength(0)
+    })
+
+    it('falls back to a stacked source list, hidden only once the grid takes over at 900px', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const fallback = container.querySelector('.min-\\[900px\\]\\:hidden')
+      expect(fallback).toBeInTheDocument()
+      expect(fallback.querySelector('a')).toHaveAttribute('href', citation.url)
+    })
+  })
+
+  describe('900-1280px narrow margin track', () => {
+    it('defines a narrower margin column than the >=1280px track, widening at xl', () => {
+      const { container } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth [owner/repo:pr:42]."
+          citations={[citation]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const grid = container.querySelector('.min-\\[900px\\]\\:grid')
+      expect(grid).toHaveClass('min-[900px]:grid-cols-[minmax(0,68ch)_180px]')
+      expect(grid).toHaveClass('xl:grid-cols-[minmax(0,68ch)_260px]')
     })
   })
 })

--- a/frontend/src/ask/AnswerPage.test.jsx
+++ b/frontend/src/ask/AnswerPage.test.jsx
@@ -31,6 +31,7 @@ describe('AnswerPage', () => {
   afterEach(() => {
     delete window.matchMedia
     delete window.print
+    localStorage.clear()
   })
 
   it('renders the question as a heading', () => {
@@ -202,6 +203,60 @@ describe('AnswerPage', () => {
       const fallback = container.querySelector('.min-\\[900px\\]\\:hidden')
       expect(fallback).toBeInTheDocument()
       expect(fallback.querySelector('a')).toHaveAttribute('href', citation.url)
+    })
+  })
+
+  describe('reading density toggle', () => {
+    it('defaults to comfortable and switches the paragraph to compact spacing on click', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      const comfortableButton = screen.getByRole('button', { name: 'Comfortable' })
+      const compactButton = screen.getByRole('button', { name: 'Compact' })
+      expect(comfortableButton).toHaveAttribute('aria-pressed', 'true')
+
+      const paragraph = screen.getByText(/We use OAuth2 for auth/).closest('p')
+      expect(paragraph).toHaveClass('leading-[1.7]')
+
+      await user.click(compactButton)
+
+      expect(compactButton).toHaveAttribute('aria-pressed', 'true')
+      expect(paragraph).toHaveClass('leading-[1.4]')
+    })
+
+    it('persists the density choice across a remount', async () => {
+      const user = userEvent.setup()
+      const { unmount } = render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+      await user.click(screen.getByRole('button', { name: 'Compact' }))
+      unmount()
+
+      render(
+        <AnswerPage
+          question="Why OAuth2?"
+          answer="We use OAuth2 for auth."
+          citations={[]}
+          repos={repos}
+          selectedRepos={['owner/repo']}
+        />,
+      )
+
+      expect(screen.getByRole('button', { name: 'Compact' })).toHaveAttribute('aria-pressed', 'true')
     })
   })
 

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -13,13 +13,27 @@ const DENSITY_CLASSES = {
   compact: 'leading-[1.4] mb-3',
 }
 
+// Reading-column width for the measure preference (Track B). 'default'
+// matches the passage's original fixed max-w-[70ch].
+const MEASURE_CLASSES = {
+  narrow: 'max-w-[54ch]',
+  default: 'max-w-[70ch]',
+  wide: 'max-w-[86ch]',
+}
+
 // Renders one already-parsed paragraph. Split out from AnswerPassage so
 // AnswerPage's margin-note layout can interleave paragraphs with their
 // citations' source cards without duplicating the marker-rendering rules.
-export function AnswerParagraph({ paragraph, reducedMotion, density = 'comfortable', className = '' }) {
+export function AnswerParagraph({
+  paragraph,
+  reducedMotion,
+  density = 'comfortable',
+  measure = 'default',
+  className = '',
+}) {
   return (
     <p
-      className={`font-reading text-ink text-[1.0625rem] max-w-[70ch] ${DENSITY_CLASSES[density]} ${
+      className={`font-reading text-ink text-[1.0625rem] ${MEASURE_CLASSES[measure]} ${DENSITY_CLASSES[density]} ${
         reducedMotion ? '' : 'animate-answer-settle'
       } ${className}`}
     >

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -6,13 +6,20 @@ import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
 import CitationMarker from './CitationMarker.jsx'
 import { parseAnswer } from './parseAnswer.js'
 
+// Line-height and inter-paragraph spacing for the density preference
+// (Track B). 'comfortable' matches the passage's original fixed values.
+const DENSITY_CLASSES = {
+  comfortable: 'leading-[1.7] mb-6',
+  compact: 'leading-[1.4] mb-3',
+}
+
 // Renders one already-parsed paragraph. Split out from AnswerPassage so
 // AnswerPage's margin-note layout can interleave paragraphs with their
 // citations' source cards without duplicating the marker-rendering rules.
-export function AnswerParagraph({ paragraph, reducedMotion, className = '' }) {
+export function AnswerParagraph({ paragraph, reducedMotion, density = 'comfortable', className = '' }) {
   return (
     <p
-      className={`font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch] ${
+      className={`font-reading text-ink text-[1.0625rem] max-w-[70ch] ${DENSITY_CLASSES[density]} ${
         reducedMotion ? '' : 'animate-answer-settle'
       } ${className}`}
     >

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -7,17 +7,24 @@ import CitationMarker from './CitationMarker.jsx'
 
 const CITATION_PATTERN = /\[([^[\]]+)\]/g
 
-function parseAnswer(answer, citations) {
-  const knownIds = new Set(citations.map((unit) => unit.id))
-  const numberById = new Map()
+// Splits into paragraphs first, then parses citation markers within each
+// one, so each paragraph's parts are addressable on their own (a margin
+// note needs to know "paragraph 2 cites marker 3" to sit beside paragraph
+// 2). Marker numbering still runs off one shared map, so it follows
+// first-appearance order across the whole answer, not reset per paragraph.
+function parseParagraph(paragraph, knownIds, numberById, paragraphIndex) {
   const parts = []
   let lastIndex = 0
   let match
 
   CITATION_PATTERN.lastIndex = 0
-  while ((match = CITATION_PATTERN.exec(answer)) !== null) {
+  while ((match = CITATION_PATTERN.exec(paragraph)) !== null) {
     if (match.index > lastIndex) {
-      parts.push({ type: 'text', key: parts.length, value: answer.slice(lastIndex, match.index) })
+      parts.push({
+        type: 'text',
+        key: parts.length,
+        value: paragraph.slice(lastIndex, match.index),
+      })
     }
 
     const unitId = match[1]
@@ -31,31 +38,46 @@ function parseAnswer(answer, citations) {
     lastIndex = CITATION_PATTERN.lastIndex
   }
 
-  if (lastIndex < answer.length) {
-    parts.push({ type: 'text', key: parts.length, value: answer.slice(lastIndex) })
+  if (lastIndex < paragraph.length) {
+    parts.push({ type: 'text', key: parts.length, value: paragraph.slice(lastIndex) })
   }
 
-  return parts
+  return { key: paragraphIndex, parts }
+}
+
+function parseAnswer(answer, citations) {
+  const knownIds = new Set(citations.map((unit) => unit.id))
+  const numberById = new Map()
+
+  return answer
+    .split('\n\n')
+    .filter((paragraph) => paragraph.trim().length > 0)
+    .map((paragraph, index) => parseParagraph(paragraph, knownIds, numberById, index))
 }
 
 function AnswerPassage({ answer, citations }) {
-  const parts = parseAnswer(answer, citations)
+  const paragraphs = parseAnswer(answer, citations)
   const reducedMotion = usePrefersReducedMotion()
 
   return (
-    <p
-      className={`font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch] ${
-        reducedMotion ? '' : 'animate-answer-settle'
-      }`}
-    >
-      {parts.map((part) =>
-        part.type === 'marker' ? (
-          <CitationMarker key={part.key} number={part.number} unitId={part.unitId} />
-        ) : (
-          <span key={part.key}>{part.value}</span>
-        ),
-      )}
-    </p>
+    <>
+      {paragraphs.map((paragraph) => (
+        <p
+          key={paragraph.key}
+          className={`font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch] ${
+            reducedMotion ? '' : 'animate-answer-settle'
+          }`}
+        >
+          {paragraph.parts.map((part) =>
+            part.type === 'marker' ? (
+              <CitationMarker key={part.key} number={part.number} unitId={part.unitId} />
+            ) : (
+              <span key={part.key}>{part.value}</span>
+            ),
+          )}
+        </p>
+      ))}
+    </>
   )
 }
 

--- a/frontend/src/ask/AnswerPassage.jsx
+++ b/frontend/src/ask/AnswerPassage.jsx
@@ -4,55 +4,27 @@
 // text itself (per UI-DESIGN.md), not citations' array order.
 import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
 import CitationMarker from './CitationMarker.jsx'
+import { parseAnswer } from './parseAnswer.js'
 
-const CITATION_PATTERN = /\[([^[\]]+)\]/g
-
-// Splits into paragraphs first, then parses citation markers within each
-// one, so each paragraph's parts are addressable on their own (a margin
-// note needs to know "paragraph 2 cites marker 3" to sit beside paragraph
-// 2). Marker numbering still runs off one shared map, so it follows
-// first-appearance order across the whole answer, not reset per paragraph.
-function parseParagraph(paragraph, knownIds, numberById, paragraphIndex) {
-  const parts = []
-  let lastIndex = 0
-  let match
-
-  CITATION_PATTERN.lastIndex = 0
-  while ((match = CITATION_PATTERN.exec(paragraph)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({
-        type: 'text',
-        key: parts.length,
-        value: paragraph.slice(lastIndex, match.index),
-      })
-    }
-
-    const unitId = match[1]
-    if (!knownIds.has(unitId)) {
-      parts.push({ type: 'text', key: parts.length, value: match[0] })
-    } else {
-      if (!numberById.has(unitId)) numberById.set(unitId, numberById.size + 1)
-      parts.push({ type: 'marker', key: parts.length, number: numberById.get(unitId), unitId })
-    }
-
-    lastIndex = CITATION_PATTERN.lastIndex
-  }
-
-  if (lastIndex < paragraph.length) {
-    parts.push({ type: 'text', key: parts.length, value: paragraph.slice(lastIndex) })
-  }
-
-  return { key: paragraphIndex, parts }
-}
-
-function parseAnswer(answer, citations) {
-  const knownIds = new Set(citations.map((unit) => unit.id))
-  const numberById = new Map()
-
-  return answer
-    .split('\n\n')
-    .filter((paragraph) => paragraph.trim().length > 0)
-    .map((paragraph, index) => parseParagraph(paragraph, knownIds, numberById, index))
+// Renders one already-parsed paragraph. Split out from AnswerPassage so
+// AnswerPage's margin-note layout can interleave paragraphs with their
+// citations' source cards without duplicating the marker-rendering rules.
+export function AnswerParagraph({ paragraph, reducedMotion, className = '' }) {
+  return (
+    <p
+      className={`font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch] ${
+        reducedMotion ? '' : 'animate-answer-settle'
+      } ${className}`}
+    >
+      {paragraph.parts.map((part) =>
+        part.type === 'marker' ? (
+          <CitationMarker key={part.key} number={part.number} unitId={part.unitId} />
+        ) : (
+          <span key={part.key}>{part.value}</span>
+        ),
+      )}
+    </p>
+  )
 }
 
 function AnswerPassage({ answer, citations }) {
@@ -62,20 +34,7 @@ function AnswerPassage({ answer, citations }) {
   return (
     <>
       {paragraphs.map((paragraph) => (
-        <p
-          key={paragraph.key}
-          className={`font-reading text-ink text-[1.0625rem] leading-[1.7] max-w-[70ch] ${
-            reducedMotion ? '' : 'animate-answer-settle'
-          }`}
-        >
-          {paragraph.parts.map((part) =>
-            part.type === 'marker' ? (
-              <CitationMarker key={part.key} number={part.number} unitId={part.unitId} />
-            ) : (
-              <span key={part.key}>{part.value}</span>
-            ),
-          )}
-        </p>
+        <AnswerParagraph key={paragraph.key} paragraph={paragraph} reducedMotion={reducedMotion} />
       ))}
     </>
   )

--- a/frontend/src/ask/AnswerPassage.test.jsx
+++ b/frontend/src/ask/AnswerPassage.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import AnswerPassage from './AnswerPassage.jsx'
+import AnswerPassage, { AnswerParagraph } from './AnswerPassage.jsx'
+import { parseAnswer } from './parseAnswer.js'
 
 const citations = [
   { id: 'unit-a', url: 'https://github.com/owner/repo/pull/1' },
@@ -117,5 +118,24 @@ describe('AnswerPassage', () => {
     )
 
     expect(container.querySelectorAll('p')).toHaveLength(1)
+  })
+
+  describe('reading density', () => {
+    const [paragraph] = parseAnswer('Redis was chosen [unit-b].', citations)
+
+    it('defaults to comfortable spacing', () => {
+      render(<AnswerParagraph paragraph={paragraph} reducedMotion={false} />)
+
+      const p = screen.getByText(/Redis was chosen/).closest('p')
+      expect(p).toHaveClass('leading-[1.7]', 'mb-6')
+    })
+
+    it('renders tighter spacing classes for compact density', () => {
+      render(<AnswerParagraph paragraph={paragraph} reducedMotion={false} density="compact" />)
+
+      const p = screen.getByText(/Redis was chosen/).closest('p')
+      expect(p).toHaveClass('leading-[1.4]', 'mb-3')
+      expect(p).not.toHaveClass('leading-[1.7]', 'mb-6')
+    })
   })
 })

--- a/frontend/src/ask/AnswerPassage.test.jsx
+++ b/frontend/src/ask/AnswerPassage.test.jsx
@@ -81,4 +81,41 @@ describe('AnswerPassage', () => {
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
+
+  it('renders one <p> per paragraph for a multi-paragraph answer', () => {
+    const { container } = render(
+      <AnswerPassage
+        answer={'Redis was chosen for caching [unit-a].\n\nPostgres stayed for the ledger [unit-b].'}
+        citations={citations}
+      />,
+    )
+
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs).toHaveLength(2)
+    expect(paragraphs[0]).toHaveTextContent('Redis was chosen for caching')
+    expect(paragraphs[1]).toHaveTextContent('Postgres stayed for the ledger')
+  })
+
+  it('numbers markers by first appearance across the whole answer, not reset per paragraph', () => {
+    render(
+      <AnswerPassage
+        answer={'Redis was chosen [unit-b].\n\nFirst proposed by [unit-a], then [unit-b] again.'}
+        citations={citations}
+      />,
+    )
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(3)
+    expect(links[0]).toHaveAccessibleName('Jump to source 1')
+    expect(links[1]).toHaveAccessibleName('Jump to source 2')
+    expect(links[2]).toHaveAccessibleName('Jump to source 1')
+  })
+
+  it('renders a single <p> for a single-paragraph answer, unchanged from before', () => {
+    const { container } = render(
+      <AnswerPassage answer="Redis was chosen [unit-b]." citations={citations} />,
+    )
+
+    expect(container.querySelectorAll('p')).toHaveLength(1)
+  })
 })

--- a/frontend/src/ask/AnswerPassage.test.jsx
+++ b/frontend/src/ask/AnswerPassage.test.jsx
@@ -138,4 +138,24 @@ describe('AnswerPassage', () => {
       expect(p).not.toHaveClass('leading-[1.7]', 'mb-6')
     })
   })
+
+  describe('reading measure', () => {
+    const [paragraph] = parseAnswer('Redis was chosen [unit-b].', citations)
+
+    it('defaults to the 70ch column width', () => {
+      render(<AnswerParagraph paragraph={paragraph} reducedMotion={false} />)
+
+      expect(screen.getByText(/Redis was chosen/).closest('p')).toHaveClass('max-w-[70ch]')
+    })
+
+    it.each([
+      ['narrow', 'max-w-[54ch]'],
+      ['default', 'max-w-[70ch]'],
+      ['wide', 'max-w-[86ch]'],
+    ])('maps measure %s to %s', (measure, expectedClass) => {
+      render(<AnswerParagraph paragraph={paragraph} reducedMotion={false} measure={measure} />)
+
+      expect(screen.getByText(/Redis was chosen/).closest('p')).toHaveClass(expectedClass)
+    })
+  })
 })

--- a/frontend/src/ask/AskPage.jsx
+++ b/frontend/src/ask/AskPage.jsx
@@ -84,12 +84,12 @@ function AskPage() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="min-h-full flex flex-col">
       <header className="h-14 shrink-0 bg-panel flex items-center justify-between px-4 lg:px-6">
         <RepoFilter repos={repos} selected={selectedRepos} onChange={setSelectedRepos} />
       </header>
 
-      <main className="flex-1 overflow-y-auto px-4 lg:px-6 py-4">
+      <main className="flex-1 px-4 lg:px-6 py-4">
         {messages.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center gap-4 text-center">
             <p className="text-base text-ink-muted">
@@ -120,7 +120,7 @@ function AskPage() {
         )}
       </main>
 
-      <div className="sticky bottom-0 shrink-0 bg-panel px-4 lg:px-6 py-4">
+      <div className="shrink-0 bg-panel px-4 lg:px-6 py-4">
         <div className="max-w-3xl mx-auto">
           <ChatInput key={chatKey} initialValue={prefill} onSubmit={handleAsk} disabled={loading} />
         </div>

--- a/frontend/src/ask/AskPage.jsx
+++ b/frontend/src/ask/AskPage.jsx
@@ -10,6 +10,19 @@ const EXAMPLE_QUESTIONS = [
   'Who made the decision to use Redis, and when?',
 ]
 
+// Repos aren't loaded yet, failed to load, or none are indexed — the
+// static fallback list, not an empty chip row. There's no per-repo
+// "topic" signal yet (that's later decision-browser work), so the
+// generated question stays generic rather than naming a topic the repo
+// may not actually have decisions about.
+function exampleQuestions(repos) {
+  if (!Array.isArray(repos) || repos.length === 0) return EXAMPLE_QUESTIONS
+  return repos.slice(0, 3).map(({ repo }) => {
+    const shortName = repo.includes('/') ? repo.split('/')[1] : repo
+    return `Why is ${shortName} built this way?`
+  })
+}
+
 function AskPage() {
   const [repos, setRepos] = useState(undefined)
   const [selectedRepos, setSelectedRepos] = useState([])
@@ -96,7 +109,7 @@ function AskPage() {
               Ask why something in your codebase is the way it is
             </p>
             <div className="flex flex-wrap justify-center gap-4">
-              {EXAMPLE_QUESTIONS.map((question) => (
+              {exampleQuestions(repos).map((question) => (
                 <button
                   key={question}
                   type="button"

--- a/frontend/src/ask/AskPage.jsx
+++ b/frontend/src/ask/AskPage.jsx
@@ -110,7 +110,12 @@ function AskPage() {
           </div>
         ) : (
           <div className="max-w-3xl mx-auto">
-            <MessageList messages={messages} disabled={loading} />
+            <MessageList
+              messages={messages}
+              repos={Array.isArray(repos) ? repos : []}
+              selectedRepos={selectedRepos}
+              disabled={loading}
+            />
           </div>
         )}
       </main>

--- a/frontend/src/ask/AskPage.jsx
+++ b/frontend/src/ask/AskPage.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getRepos, postQuery } from '../api.js'
 import ChatInput from '../components/ChatInput.jsx'
 import MessageList from '../components/MessageList.jsx'
 import RepoFilter from '../components/RepoFilter.jsx'
+import { useRegisterNewQuestionHandler } from '../lib/useNewQuestion.js'
 
 const EXAMPLE_QUESTIONS = [
   'Why is authentication done this way?',
@@ -95,6 +96,8 @@ function AskPage() {
     setPrefill(question)
     setChatKey((key) => key + 1)
   }
+
+  useRegisterNewQuestionHandler(useCallback(() => setMessages([]), []))
 
   return (
     <div className="min-h-full flex flex-col">

--- a/frontend/src/ask/AskPage.test.jsx
+++ b/frontend/src/ask/AskPage.test.jsx
@@ -107,12 +107,49 @@ describe('AskPage', () => {
 
     render(<AskPage />)
 
-    const chip = await screen.findByRole('button', { name: 'Why is authentication done this way?' })
+    const chip = await screen.findByRole('button', { name: 'Why is repo-a built this way?' })
     await user.click(chip)
 
-    expect(screen.getByLabelText('Ask a question')).toHaveValue(
-      'Why is authentication done this way?',
-    )
+    expect(screen.getByLabelText('Ask a question')).toHaveValue('Why is repo-a built this way?')
+  })
+
+  it('generates up to 3 example chips from indexed repo short names', async () => {
+    getRepos.mockResolvedValue({
+      repos: [
+        { repo: 'owner/repo-a', indexed_units: 12 },
+        { repo: 'owner/repo-b', indexed_units: 3 },
+        { repo: 'owner/repo-c', indexed_units: 1 },
+        { repo: 'owner/repo-d', indexed_units: 1 },
+      ],
+    })
+
+    render(<AskPage />)
+
+    expect(await screen.findByRole('button', { name: 'Why is repo-a built this way?' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Why is repo-b built this way?' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Why is repo-c built this way?' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Why is repo-d built this way?' })).not.toBeInTheDocument()
+  })
+
+  it('falls back to the static example questions while repos are still loading', () => {
+    getRepos.mockReturnValue(new Promise(() => {}))
+
+    render(<AskPage />)
+
+    expect(
+      screen.getByRole('button', { name: 'Why is authentication done this way?' }),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to the static example questions when GET /repos fails', async () => {
+    getRepos.mockRejectedValue(new Error('network error'))
+
+    render(<AskPage />)
+
+    await screen.findByRole('alert')
+    expect(
+      screen.getByRole('button', { name: 'Why is authentication done this way?' }),
+    ).toBeInTheDocument()
   })
 
   it('renders the input area as a plain footer, not a sticky floating bar', async () => {

--- a/frontend/src/ask/AskPage.test.jsx
+++ b/frontend/src/ask/AskPage.test.jsx
@@ -9,6 +9,13 @@ vi.mock('../api.js', () => ({
   postQuery: vi.fn(),
 }))
 
+// AskPage registers a new-question handler with the command palette's
+// shared context (see CommandPalette.test.jsx for that integration) — a
+// real NewQuestionProvider isn't needed for AskPage's own behavior.
+vi.mock('../lib/useNewQuestion.js', () => ({
+  useRegisterNewQuestionHandler: vi.fn(),
+}))
+
 const REPOS = { repos: [{ repo: 'owner/repo-a', indexed_units: 12 }] }
 
 beforeEach(() => {

--- a/frontend/src/ask/AskPage.test.jsx
+++ b/frontend/src/ask/AskPage.test.jsx
@@ -114,4 +114,20 @@ describe('AskPage', () => {
       'Why is authentication done this way?',
     )
   })
+
+  it('renders the input area as a plain footer, not a sticky floating bar', async () => {
+    getRepos.mockResolvedValue(REPOS)
+
+    const { container } = render(<AskPage />)
+    await screen.findByLabelText('Ask a question')
+
+    expect(container.querySelector('.sticky')).not.toBeInTheDocument()
+
+    const input = screen.getByLabelText('Ask a question')
+    const footer = input.closest('form').parentElement.parentElement
+    expect(footer.className).not.toMatch(/\bsticky\b/)
+    // the footer is the last element of the page's own content, i.e. it
+    // scrolls with the composed page rather than floating over it
+    expect(footer.parentElement.lastElementChild).toBe(footer)
+  })
 })

--- a/frontend/src/ask/CitationMarker.jsx
+++ b/frontend/src/ask/CitationMarker.jsx
@@ -1,19 +1,59 @@
 // Superscript inline citation marker. Its href/id contract
-// (`#source-{unitId}` / `source-{unitId}`) is what the SourceCard (next
-// issue) will implement — this component only needs to hold up its end
-// of it.
+// (`#source-{unitId}` / `source-{unitId}`) is what the SourceCard
+// implements — this component only needs to hold up its end of it, which
+// is also how it reaches a note it doesn't render itself (margin column
+// or inline collapse, depending on viewport): by looking it up via that
+// shared id rather than through shared React state.
 //
 // Ink-in stagger: per UI-DESIGN.md's Ask "Signature moment", markers ink
 // in 60ms apart starting 180ms after the passage settles (--dur-surface).
 // `number` is 1-indexed parse order, so marker 1 gets no extra stagger.
+import { useRef } from 'react'
 import usePrefersReducedMotion from '../lib/usePrefersReducedMotion.js'
+
+const WASH_DURATION_MS = 1200
+
+// SourceCard's default (`bg-panel`) and highlighted (`bg-highlight`) fills
+// both set `background-color`, so both classes must never be present at
+// once — whichever is later in the compiled stylesheet would silently win.
+function setHighlighted(source, highlighted) {
+  source.classList.toggle('bg-highlight', highlighted)
+  source.classList.toggle('bg-panel', !highlighted)
+}
 
 function CitationMarker({ number, unitId }) {
   const reducedMotion = usePrefersReducedMotion()
+  const washTimeoutRef = useRef(null)
+
+  function clearWashTimeout() {
+    if (washTimeoutRef.current == null) return
+    clearTimeout(washTimeoutRef.current)
+    washTimeoutRef.current = null
+  }
+
+  function highlight() {
+    clearWashTimeout()
+    const source = document.getElementById(`source-${unitId}`)
+    if (source) setHighlighted(source, true)
+  }
+
+  function unhighlight() {
+    const source = document.getElementById(`source-${unitId}`)
+    if (source) setHighlighted(source, false)
+  }
 
   function handleClick(event) {
     event.preventDefault()
-    document.getElementById(`source-${unitId}`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    const source = document.getElementById(`source-${unitId}`)
+    source?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+
+    if (!source || reducedMotion) return
+    setHighlighted(source, true)
+    clearWashTimeout()
+    washTimeoutRef.current = setTimeout(() => {
+      setHighlighted(source, false)
+      washTimeoutRef.current = null
+    }, WASH_DURATION_MS)
   }
 
   const style = reducedMotion
@@ -25,6 +65,10 @@ function CitationMarker({ number, unitId }) {
       <a
         href={`#source-${unitId}`}
         onClick={handleClick}
+        onMouseEnter={highlight}
+        onMouseLeave={unhighlight}
+        onFocus={highlight}
+        onBlur={unhighlight}
         aria-label={`Jump to source ${number}`}
         style={style}
         className={`font-ui text-xs text-accent cursor-pointer no-underline hover:underline ${

--- a/frontend/src/ask/CitationMarker.test.jsx
+++ b/frontend/src/ask/CitationMarker.test.jsx
@@ -10,6 +10,17 @@ function stubMatchMedia(matches) {
   })
 }
 
+// Mirrors the real SourceCard's default (unhighlighted) class so tests
+// exercise the same bg-highlight/bg-panel swap CitationMarker performs.
+function appendSourceNode() {
+  const source = document.createElement('div')
+  source.id = 'source-abc123'
+  source.className = 'bg-panel'
+  source.scrollIntoView = vi.fn()
+  document.body.appendChild(source)
+  return source
+}
+
 describe('CitationMarker', () => {
   afterEach(() => {
     document.body.innerHTML = ''
@@ -57,5 +68,77 @@ describe('CitationMarker', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Jump to source 1' }))
 
     expect(source.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' })
+  })
+
+  describe('highlight wash', () => {
+    it('washes the linked note on hover and clears it on mouse-leave', () => {
+      render(<CitationMarker number={1} unitId="abc123" />)
+      const source = appendSourceNode()
+      const link = screen.getByRole('link', { name: 'Jump to source 1' })
+
+      fireEvent.mouseEnter(link)
+      expect(source).toHaveClass('bg-highlight')
+      expect(source).not.toHaveClass('bg-panel')
+
+      fireEvent.mouseLeave(link)
+      expect(source).toHaveClass('bg-panel')
+      expect(source).not.toHaveClass('bg-highlight')
+    })
+
+    it('washes the linked note on focus and clears it on blur', () => {
+      render(<CitationMarker number={1} unitId="abc123" />)
+      const source = appendSourceNode()
+      const link = screen.getByRole('link', { name: 'Jump to source 1' })
+
+      fireEvent.focus(link)
+      expect(source).toHaveClass('bg-highlight')
+
+      fireEvent.blur(link)
+      expect(source).toHaveClass('bg-panel')
+      expect(source).not.toHaveClass('bg-highlight')
+    })
+
+    it('clicking washes the note, then fades it back after the 1.2s window', () => {
+      vi.useFakeTimers()
+      try {
+        render(<CitationMarker number={1} unitId="abc123" />)
+        const source = appendSourceNode()
+        const link = screen.getByRole('link', { name: 'Jump to source 1' })
+
+        fireEvent.click(link)
+        expect(source).toHaveClass('bg-highlight')
+        expect(source.scrollIntoView).toHaveBeenCalled()
+
+        vi.advanceTimersByTime(1199)
+        expect(source).toHaveClass('bg-highlight')
+
+        vi.advanceTimersByTime(1)
+        expect(source).toHaveClass('bg-panel')
+        expect(source).not.toHaveClass('bg-highlight')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('skips the timed wash under reduced motion, without breaking the scroll', () => {
+      stubMatchMedia(true)
+      vi.useFakeTimers()
+      try {
+        render(<CitationMarker number={1} unitId="abc123" />)
+        const source = appendSourceNode()
+        const link = screen.getByRole('link', { name: 'Jump to source 1' })
+
+        fireEvent.click(link)
+
+        expect(source.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' })
+        expect(source).not.toHaveClass('bg-highlight')
+        expect(source).toHaveClass('bg-panel')
+
+        vi.advanceTimersByTime(1200)
+        expect(source).not.toHaveClass('bg-highlight')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/frontend/src/ask/PrivacyPanel.jsx
+++ b/frontend/src/ask/PrivacyPanel.jsx
@@ -1,0 +1,29 @@
+// Design principle 4 ("earn the privacy claim on-screen"): show exactly
+// what left the machine for this answer instead of just asserting privacy.
+// `cloudSynthesisFields` is read verbatim from QueryResponse rather than a
+// hardcoded guess, so it can never drift out of sync with what
+// synthesis/answer.py actually sends.
+function PrivacyPanel({ sentToCloud, cloudSynthesisFields }) {
+  if (!sentToCloud) {
+    return (
+      <p className="text-sm text-ink-muted">Nothing left this machine for this answer.</p>
+    )
+  }
+
+  return (
+    <div>
+      <p className="text-sm text-ink-muted">
+        These fields were sent to the cloud model to synthesize this answer:
+      </p>
+      <ul className="mt-1 list-disc pl-5 text-sm text-ink-muted">
+        {(cloudSynthesisFields ?? []).map((field) => (
+          <li key={field} className="font-mono">
+            {field}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default PrivacyPanel

--- a/frontend/src/ask/PrivacyPanel.test.jsx
+++ b/frontend/src/ask/PrivacyPanel.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PrivacyPanel from './PrivacyPanel.jsx'
+
+describe('PrivacyPanel', () => {
+  it('states nothing left the machine for a sources_only-mode response', () => {
+    render(<PrivacyPanel sentToCloud={false} cloudSynthesisFields={null} />)
+
+    expect(screen.getByText('Nothing left this machine for this answer.')).toBeInTheDocument()
+  })
+
+  it('lists the real field names for a synthesized-mode response', () => {
+    render(
+      <PrivacyPanel
+        sentToCloud={true}
+        cloudSynthesisFields={['id', 'title', 'decision', 'rationale', 'url']}
+      />,
+    )
+
+    expect(screen.getByText('id')).toBeInTheDocument()
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('decision')).toBeInTheDocument()
+    expect(screen.getByText('rationale')).toBeInTheDocument()
+    expect(screen.getByText('url')).toBeInTheDocument()
+    expect(screen.queryByText('source_excerpt')).not.toBeInTheDocument()
+  })
+
+  it('does not claim anything was sent when sentToCloud is false even if fields are present', () => {
+    render(<PrivacyPanel sentToCloud={false} cloudSynthesisFields={['id']} />)
+
+    expect(screen.getByText('Nothing left this machine for this answer.')).toBeInTheDocument()
+    expect(screen.queryByText('id')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/ask/SourceCard.jsx
+++ b/frontend/src/ask/SourceCard.jsx
@@ -34,7 +34,13 @@ function relativeDate(dateString) {
 // `w-full` instead, so the card fills whatever width the grid column
 // currently has — the narrow 900-1280px track and the full 260px one
 // above it — rather than a fixed width that would overflow the narrow one.
-function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64' }) {
+//
+// `highlighted` washes the card with `--color-highlight` instead of its
+// default `bg-panel` fill — CitationMarker drives this externally (by id,
+// not by prop, since it doesn't render the card it's washing), but the
+// prop stays the source of truth for what "highlighted" looks like so the
+// two never drift out of sync.
+function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64', highlighted = false }) {
   const accessibleName = `Citation: ${unit.title}, ${unit.kind} in ${unit.repo}`
 
   return (
@@ -44,7 +50,7 @@ function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64' }) {
       target="_blank"
       rel="noreferrer"
       aria-label={accessibleName}
-      className={`block ${widthClassName} rounded-xl border border-transparent bg-panel p-4 transition-colors hover:border-accent`}
+      className={`block ${widthClassName} rounded-xl border border-transparent ${highlighted ? 'bg-highlight' : 'bg-panel'} p-4 transition-colors hover:border-accent`}
     >
       <div className="flex items-center gap-2">
         {number != null && <span className="font-ui text-xs text-ink-muted">{number}</span>}

--- a/frontend/src/ask/SourceCard.jsx
+++ b/frontend/src/ask/SourceCard.jsx
@@ -40,7 +40,17 @@ function relativeDate(dateString) {
 // not by prop, since it doesn't render the card it's washing), but the
 // prop stays the source of truth for what "highlighted" looks like so the
 // two never drift out of sync.
-function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64', highlighted = false }) {
+//
+// `expanded` swaps the title line for the unit's `decision`/`rationale`
+// text — used by SourcesView's degraded mode, where there's no
+// synthesized passage to carry that content instead.
+function SourceCard({
+  unit,
+  number,
+  widthClassName = 'w-full sm:w-64',
+  highlighted = false,
+  expanded = false,
+}) {
   const accessibleName = `Citation: ${unit.title}, ${unit.kind} in ${unit.repo}`
 
   return (
@@ -58,7 +68,18 @@ function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64', highlight
           {badgeText(unit)}
         </span>
       </div>
-      <p className="font-ui text-base text-ink mt-2 line-clamp-2">{unit.title}</p>
+      {expanded ? (
+        <>
+          <p className="font-reading text-ink text-base leading-relaxed mt-2 line-clamp-3">
+            {unit.decision}
+          </p>
+          <p className="font-reading text-ink-muted text-sm leading-relaxed mt-2">
+            {unit.rationale}
+          </p>
+        </>
+      ) : (
+        <p className="font-ui text-base text-ink mt-2 line-clamp-2">{unit.title}</p>
+      )}
       <p className="text-sm text-ink-muted mt-2">
         {unit.author} · {relativeDate(unit.date)} · {unit.repo}
       </p>

--- a/frontend/src/ask/SourceCard.jsx
+++ b/frontend/src/ask/SourceCard.jsx
@@ -29,7 +29,12 @@ function relativeDate(dateString) {
   return formatter.format(Math.round(duration), 'year')
 }
 
-function SourceCard({ unit, number }) {
+// `widthClassName` defaults to a fixed card width for the stacked-list
+// contexts (SourceCardList, SourcesView). AnswerPage's margin track passes
+// `w-full` instead, so the card fills whatever width the grid column
+// currently has — the narrow 900-1280px track and the full 260px one
+// above it — rather than a fixed width that would overflow the narrow one.
+function SourceCard({ unit, number, widthClassName = 'w-full sm:w-64' }) {
   const accessibleName = `Citation: ${unit.title}, ${unit.kind} in ${unit.repo}`
 
   return (
@@ -39,7 +44,7 @@ function SourceCard({ unit, number }) {
       target="_blank"
       rel="noreferrer"
       aria-label={accessibleName}
-      className="block w-full sm:w-64 rounded-xl border border-transparent bg-panel p-4 transition-colors hover:border-accent"
+      className={`block ${widthClassName} rounded-xl border border-transparent bg-panel p-4 transition-colors hover:border-accent`}
     >
       <div className="flex items-center gap-2">
         {number != null && <span className="font-ui text-xs text-ink-muted">{number}</span>}

--- a/frontend/src/ask/SourceCard.jsx
+++ b/frontend/src/ask/SourceCard.jsx
@@ -1,33 +1,7 @@
 // The reading room's citation card — evolved from the Phase 1
 // CitationCard. Its `id` (`source-{unit.id}`) is the scroll target that
 // CitationMarker's `#source-{unitId}` href/click handler jumps to.
-function badgeText(unit) {
-  return unit.kind === 'pr' ? `PR #${unit.ref}` : `commit ${unit.ref.slice(0, 7)}`
-}
-
-function relativeDate(dateString) {
-  const date = new Date(dateString)
-  const seconds = Math.round((date.getTime() - Date.now()) / 1000)
-  const divisions = [
-    [60, 'second'],
-    [60, 'minute'],
-    [24, 'hour'],
-    [7, 'day'],
-    [4.34524, 'week'],
-    [12, 'month'],
-    [Number.POSITIVE_INFINITY, 'year'],
-  ]
-
-  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
-  let duration = seconds
-  for (const [amount, unit] of divisions) {
-    if (Math.abs(duration) < amount) {
-      return formatter.format(Math.round(duration), unit)
-    }
-    duration /= amount
-  }
-  return formatter.format(Math.round(duration), 'year')
-}
+import { badgeText, relativeDate } from '../lib/sourceFormat.js'
 
 // `widthClassName` defaults to a fixed card width for the stacked-list
 // contexts (SourceCardList, SourcesView). AnswerPage's margin track passes

--- a/frontend/src/ask/SourceCard.test.jsx
+++ b/frontend/src/ask/SourceCard.test.jsx
@@ -8,6 +8,8 @@ const prUnit = {
   ref: '42',
   url: 'https://github.com/owner/repo/pull/42',
   title: 'Switch auth to OAuth2 for third-party integrations',
+  decision: 'Switched auth to OAuth2 device flow.',
+  rationale: 'Avoids storing long-lived tokens for third-party integrations.',
   author: 'octocat',
   date: '2024-01-01T00:00:00Z',
   repo: 'owner/repo',
@@ -95,5 +97,18 @@ describe('SourceCard', () => {
     const link = screen.getByRole('link')
     expect(link).toHaveClass('bg-highlight')
     expect(link).not.toHaveClass('bg-panel')
+  })
+
+  it('renders decision and rationale text instead of the title when expanded', () => {
+    render(<SourceCard unit={prUnit} expanded />)
+    expect(screen.getByText(prUnit.decision)).toBeInTheDocument()
+    expect(screen.getByText(prUnit.rationale)).toBeInTheDocument()
+    expect(screen.queryByText(prUnit.title)).not.toBeInTheDocument()
+  })
+
+  it('renders the title instead of decision/rationale by default', () => {
+    render(<SourceCard unit={prUnit} />)
+    expect(screen.getByText(prUnit.title)).toBeInTheDocument()
+    expect(screen.queryByText(prUnit.decision)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/ask/SourceCard.test.jsx
+++ b/frontend/src/ask/SourceCard.test.jsx
@@ -82,4 +82,18 @@ describe('SourceCard', () => {
     expect(link).toHaveClass('w-full')
     expect(link).not.toHaveClass('sm:w-64')
   })
+
+  it('defaults to the panel background, not highlighted', () => {
+    render(<SourceCard unit={prUnit} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveClass('bg-panel')
+    expect(link).not.toHaveClass('bg-highlight')
+  })
+
+  it('washes with the highlight background when highlighted', () => {
+    render(<SourceCard unit={prUnit} highlighted />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveClass('bg-highlight')
+    expect(link).not.toHaveClass('bg-panel')
+  })
 })

--- a/frontend/src/ask/SourceCard.test.jsx
+++ b/frontend/src/ask/SourceCard.test.jsx
@@ -70,4 +70,16 @@ describe('SourceCard', () => {
     render(<SourceCard unit={prUnit} />)
     expect(screen.queryByText('1')).not.toBeInTheDocument()
   })
+
+  it('defaults to a fixed card width', () => {
+    render(<SourceCard unit={prUnit} />)
+    expect(screen.getByRole('link')).toHaveClass('w-full', 'sm:w-64')
+  })
+
+  it('accepts a widthClassName override, e.g. to fill a margin grid column', () => {
+    render(<SourceCard unit={prUnit} widthClassName="w-full" />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveClass('w-full')
+    expect(link).not.toHaveClass('sm:w-64')
+  })
 })

--- a/frontend/src/ask/SourceCardList.jsx
+++ b/frontend/src/ask/SourceCardList.jsx
@@ -4,11 +4,11 @@ import SourceCard from './SourceCard.jsx'
 // synthesized answer (MessageList, wrapped) and in SourcesView's
 // degraded mode (stacked). Layout differs by className; the list logic
 // doesn't.
-function SourceCardList({ citations, className = 'flex flex-wrap gap-4' }) {
+function SourceCardList({ citations, className = 'flex flex-wrap gap-4', expanded = false }) {
   return (
     <div className={className}>
       {citations.map((unit) => (
-        <SourceCard key={unit.url} unit={unit} />
+        <SourceCard key={unit.url} unit={unit} expanded={expanded} />
       ))}
     </div>
   )

--- a/frontend/src/ask/SourcesView.jsx
+++ b/frontend/src/ask/SourcesView.jsx
@@ -1,16 +1,48 @@
+import { useState } from 'react'
 import SourceCardList from './SourceCardList.jsx'
+
+const BANNER_DISMISSED_KEY = 'sourcesViewBannerDismissed'
 
 // Degraded-mode rendering for `/query`'s `mode: "sources_only"` — no
 // Gemini key configured, so we show the retrieved units directly instead
 // of a synthesized passage. Per UI-DESIGN.md this is a product state, not
-// an error, so it gets the same reading-room treatment, not danger styling.
+// an error, so it gets the same reading-room treatment, not danger styling:
+// a serif lead-in stating the count, expanded SourceCards carrying the
+// extracted decision/rationale text in place of the synthesized passage,
+// and a quiet banner pointing at Settings. The banner dismissal is kept in
+// `sessionStorage` (not `localStorage`) because the spec calls it a
+// per-session quieting, not a permanent one.
 function SourcesView({ citations }) {
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem(BANNER_DISMISSED_KEY) === 'true',
+  )
+
+  function dismissBanner() {
+    sessionStorage.setItem(BANNER_DISMISSED_KEY, 'true')
+    setDismissed(true)
+  }
+
   return (
     <div className="max-w-3xl">
+      {!dismissed && (
+        <div className="flex items-center justify-between gap-4 rounded-xl bg-highlight px-4 py-3 mb-4">
+          <p className="font-ui text-sm text-ink">
+            Add a Gemini key in Settings to get synthesized answers.
+          </p>
+          <button
+            type="button"
+            onClick={dismissBanner}
+            aria-label="Dismiss"
+            className="font-ui text-xs text-ink-muted hover:text-ink"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       <p className="font-reading text-ink text-[1.0625rem] leading-[1.7]">
-        No Gemini key configured — showing retrieved sources directly.
+        {citations.length} decision{citations.length === 1 ? '' : 's'} found —
       </p>
-      <SourceCardList citations={citations} className="mt-4 flex flex-col gap-4" />
+      <SourceCardList citations={citations} className="mt-4 flex flex-col gap-4" expanded />
     </div>
   )
 }

--- a/frontend/src/ask/SourcesView.test.jsx
+++ b/frontend/src/ask/SourcesView.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import SourcesView from './SourcesView.jsx'
 
 const citations = [
@@ -9,6 +10,8 @@ const citations = [
     ref: '42',
     url: 'https://github.com/owner/repo/pull/42',
     title: 'Switch auth to OAuth2 for third-party integrations',
+    decision: 'Switched auth to OAuth2 device flow.',
+    rationale: 'Avoids storing long-lived tokens for third-party integrations.',
     author: 'octocat',
     date: '2024-01-01T00:00:00Z',
     repo: 'owner/repo',
@@ -19,6 +22,8 @@ const citations = [
     ref: 'a1b2c3d4e5f6',
     url: 'https://github.com/owner/repo/commit/a1b2c3d4e5f6',
     title: 'Add retry logic to the GitHub client',
+    decision: 'Added exponential-backoff retries to the GitHub client.',
+    rationale: 'Rate-limit responses were surfacing as hard failures.',
     author: 'octocat',
     date: '2024-01-01T00:00:00Z',
     repo: 'owner/repo',
@@ -26,11 +31,22 @@ const citations = [
 ]
 
 describe('SourcesView', () => {
-  it('renders the explanatory header', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('renders a serif lead-in stating the real citation count', () => {
     render(<SourcesView citations={citations} />)
-    expect(
-      screen.getByText('No Gemini key configured — showing retrieved sources directly.'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('2 decisions found —')).toBeInTheDocument()
+  })
+
+  it('singularizes the lead-in for exactly one citation', () => {
+    render(<SourcesView citations={[citations[0]]} />)
+    expect(screen.getByText('1 decision found —')).toBeInTheDocument()
   })
 
   it('renders one SourceCard per citation', () => {
@@ -38,8 +54,40 @@ describe('SourcesView', () => {
     expect(screen.getAllByRole('link')).toHaveLength(2)
   })
 
+  it('renders each card expanded, with decision and rationale text', () => {
+    render(<SourcesView citations={citations} />)
+    expect(screen.getByText(citations[0].decision)).toBeInTheDocument()
+    expect(screen.getByText(citations[0].rationale)).toBeInTheDocument()
+    expect(screen.getByText(citations[1].decision)).toBeInTheDocument()
+    expect(screen.getByText(citations[1].rationale)).toBeInTheDocument()
+  })
+
   it('renders no source cards when citations is empty', () => {
     render(<SourcesView citations={[]} />)
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('0 decisions found —')).toBeInTheDocument()
+  })
+
+  it('shows the Settings banner by default', () => {
+    render(<SourcesView citations={citations} />)
+    expect(
+      screen.getByText('Add a Gemini key in Settings to get synthesized answers.'),
+    ).toBeInTheDocument()
+  })
+
+  it('dismisses the banner on click and keeps it dismissed within the session', async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(<SourcesView citations={citations} />)
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(
+      screen.queryByText('Add a Gemini key in Settings to get synthesized answers.'),
+    ).not.toBeInTheDocument()
+
+    unmount()
+    render(<SourcesView citations={citations} />)
+    expect(
+      screen.queryByText('Add a Gemini key in Settings to get synthesized answers.'),
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/ask/parseAnswer.js
+++ b/frontend/src/ask/parseAnswer.js
@@ -1,0 +1,52 @@
+// Parses an answer string into paragraphs of text/marker parts. Shared by
+// AnswerPassage (flat rendering) and AnswerPage (margin-note layout, which
+// needs to know per paragraph which citations it references).
+const CITATION_PATTERN = /\[([^[\]]+)\]/g
+
+// Splits into paragraphs first, then parses citation markers within each
+// one, so each paragraph's parts are addressable on their own (a margin
+// note needs to know "paragraph 2 cites marker 3" to sit beside paragraph
+// 2). Marker numbering still runs off one shared map, so it follows
+// first-appearance order across the whole answer, not reset per paragraph.
+function parseParagraph(paragraph, knownIds, numberById, paragraphIndex) {
+  const parts = []
+  let lastIndex = 0
+  let match
+
+  CITATION_PATTERN.lastIndex = 0
+  while ((match = CITATION_PATTERN.exec(paragraph)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({
+        type: 'text',
+        key: parts.length,
+        value: paragraph.slice(lastIndex, match.index),
+      })
+    }
+
+    const unitId = match[1]
+    if (!knownIds.has(unitId)) {
+      parts.push({ type: 'text', key: parts.length, value: match[0] })
+    } else {
+      if (!numberById.has(unitId)) numberById.set(unitId, numberById.size + 1)
+      parts.push({ type: 'marker', key: parts.length, number: numberById.get(unitId), unitId })
+    }
+
+    lastIndex = CITATION_PATTERN.lastIndex
+  }
+
+  if (lastIndex < paragraph.length) {
+    parts.push({ type: 'text', key: parts.length, value: paragraph.slice(lastIndex) })
+  }
+
+  return { key: paragraphIndex, parts }
+}
+
+export function parseAnswer(answer, citations) {
+  const knownIds = new Set(citations.map((unit) => unit.id))
+  const numberById = new Map()
+
+  return answer
+    .split('\n\n')
+    .filter((paragraph) => paragraph.trim().length > 0)
+    .map((paragraph, index) => parseParagraph(paragraph, knownIds, numberById, index))
+}

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -115,6 +115,10 @@ function CommandPalette() {
             </li>
           ))}
         </ul>
+        <div className="border-t border-surface px-4 py-3">
+          <h2 className="text-xs font-ui uppercase tracking-wide text-ink-muted">Past questions</h2>
+          <p className="mt-1 text-sm text-ink-muted">No question history yet</p>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -1,19 +1,30 @@
-// The empty shell for Track B's command palette: a global Cmd/Ctrl+K
-// overlay with a filtered, arrow-navigable action list. Mounted once in
-// AppShell (wraps every authenticated route) so the shortcut works from
-// anywhere. `ACTIONS` is a static array on purpose — a dynamic
-// registry is speculative generality until a real second consumer needs
-// to register actions of its own; the navigation actions land here in a
-// later issue.
-import { useEffect, useRef, useState } from 'react'
-
-const ACTIONS = []
+// Track B's command palette: a global Cmd/Ctrl+K overlay with a
+// filtered, arrow-navigable action list. Mounted once in AppShell (wraps
+// every authenticated route) so the shortcut works from anywhere. The
+// action list is a static array built from four baseline actions on
+// purpose — a dynamic registry is speculative generality until a real
+// second consumer needs to register actions of its own.
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useNewQuestion } from '../lib/useNewQuestion.js'
 
 function CommandPalette() {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
   const inputRef = useRef(null)
+  const navigate = useNavigate()
+  const requestNewQuestion = useNewQuestion()
+
+  const actions = useMemo(
+    () => [
+      { id: 'go-ask', label: 'Go to Ask', run: () => navigate('/') },
+      { id: 'go-library', label: 'Go to Library', run: () => navigate('/library') },
+      { id: 'go-settings', label: 'Go to Settings', run: () => navigate('/settings') },
+      { id: 'new-question', label: 'New question', run: () => requestNewQuestion() },
+    ],
+    [navigate, requestNewQuestion],
+  )
 
   useEffect(() => {
     function handleKeyDown(event) {
@@ -39,7 +50,7 @@ function CommandPalette() {
 
   if (!open) return null
 
-  const filtered = ACTIONS.filter((action) => action.label.toLowerCase().includes(query.toLowerCase()))
+  const filtered = actions.filter((action) => action.label.toLowerCase().includes(query.toLowerCase()))
 
   function runAction(index) {
     const action = filtered[index]

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -3,7 +3,9 @@
 // every authenticated route) so the shortcut works from anywhere. The
 // action list is a static array built from four baseline actions on
 // purpose — a dynamic registry is speculative generality until a real
-// second consumer needs to register actions of its own.
+// second consumer needs to register actions of its own. AppShell is the
+// one exception: it contributes the focus-mode toggle via props, since
+// the palette has no other way to reach AppShell's own render state.
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useNewQuestion } from '../lib/useNewQuestion.js'
@@ -16,7 +18,7 @@ function getFocusableElements(container) {
   )
 }
 
-function CommandPalette() {
+function CommandPalette({ focusModeActive = false, onToggleFocusMode } = {}) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
@@ -26,15 +28,23 @@ function CommandPalette() {
   const navigate = useNavigate()
   const requestNewQuestion = useNewQuestion()
 
-  const actions = useMemo(
-    () => [
+  const actions = useMemo(() => {
+    const baseline = [
       { id: 'go-ask', label: 'Go to Ask', run: () => navigate('/') },
       { id: 'go-library', label: 'Go to Library', run: () => navigate('/library') },
       { id: 'go-settings', label: 'Go to Settings', run: () => navigate('/settings') },
       { id: 'new-question', label: 'New question', run: () => requestNewQuestion() },
-    ],
-    [navigate, requestNewQuestion],
-  )
+    ]
+    if (!onToggleFocusMode) return baseline
+    return [
+      ...baseline,
+      {
+        id: 'toggle-focus-mode',
+        label: focusModeActive ? 'Exit focus mode' : 'Enter focus mode',
+        run: onToggleFocusMode,
+      },
+    ]
+  }, [navigate, requestNewQuestion, focusModeActive, onToggleFocusMode])
 
   useEffect(() => {
     function handleKeyDown(event) {

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -8,11 +8,21 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useNewQuestion } from '../lib/useNewQuestion.js'
 
+function getFocusableElements(container) {
+  return Array.from(
+    container.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  )
+}
+
 function CommandPalette() {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
   const inputRef = useRef(null)
+  const dialogRef = useRef(null)
+  const previouslyFocusedRef = useRef(null)
   const navigate = useNavigate()
   const requestNewQuestion = useNewQuestion()
 
@@ -43,9 +53,13 @@ function CommandPalette() {
 
   useEffect(() => {
     if (!open) return
+    previouslyFocusedRef.current = document.activeElement
     setQuery('')
     setHighlightedIndex(0)
     inputRef.current?.focus()
+    return () => {
+      previouslyFocusedRef.current?.focus?.()
+    }
   }, [open])
 
   if (!open) return null
@@ -77,14 +91,34 @@ function CommandPalette() {
     }
   }
 
+  function handleDialogKeyDown(event) {
+    if (event.key !== 'Tab') return
+    const focusable = getFocusableElements(dialogRef.current)
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      }
+    } else if (document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center bg-ink/40 pt-[15vh]"
       onClick={() => setOpen(false)}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-label="Command palette"
+        aria-modal="true"
+        onKeyDown={handleDialogKeyDown}
         className="w-full max-w-lg mx-4 rounded-xl bg-panel shadow-lg overflow-hidden"
         onClick={(event) => event.stopPropagation()}
       >
@@ -98,6 +132,9 @@ function CommandPalette() {
           aria-label="Command palette search"
           className="w-full font-ui text-base text-ink bg-transparent px-4 py-3 border-b border-surface focus:outline-none"
         />
+        <p role="status" aria-live="polite" className="sr-only">
+          {filtered.length} matching command{filtered.length === 1 ? '' : 's'}
+        </p>
         <ul role="listbox" aria-label="Commands" className="max-h-80 overflow-y-auto py-2">
           {filtered.length === 0 && <li className="px-4 py-2 text-sm text-ink-muted">No matching commands</li>}
           {filtered.map((action, index) => (

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -1,0 +1,112 @@
+// The empty shell for Track B's command palette: a global Cmd/Ctrl+K
+// overlay with a filtered, arrow-navigable action list. Mounted once in
+// AppShell (wraps every authenticated route) so the shortcut works from
+// anywhere. `ACTIONS` is a static array on purpose — a dynamic
+// registry is speculative generality until a real second consumer needs
+// to register actions of its own; the navigation actions land here in a
+// later issue.
+import { useEffect, useRef, useState } from 'react'
+
+const ACTIONS = []
+
+function CommandPalette() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    function handleKeyDown(event) {
+      const isToggle = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k'
+      if (isToggle) {
+        event.preventDefault()
+        setOpen((current) => !current)
+      } else if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    setHighlightedIndex(0)
+    inputRef.current?.focus()
+  }, [open])
+
+  if (!open) return null
+
+  const filtered = ACTIONS.filter((action) => action.label.toLowerCase().includes(query.toLowerCase()))
+
+  function runAction(index) {
+    const action = filtered[index]
+    if (!action) return
+    action.run()
+    setOpen(false)
+  }
+
+  function handleQueryChange(event) {
+    setQuery(event.target.value)
+    setHighlightedIndex(0)
+  }
+
+  function handleInputKeyDown(event) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlightedIndex((current) => Math.min(current + 1, filtered.length - 1))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlightedIndex((current) => Math.max(current - 1, 0))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      runAction(highlightedIndex)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-ink/40 pt-[15vh]"
+      onClick={() => setOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-label="Command palette"
+        className="w-full max-w-lg mx-4 rounded-xl bg-panel shadow-lg overflow-hidden"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={handleQueryChange}
+          onKeyDown={handleInputKeyDown}
+          placeholder="Type a command…"
+          aria-label="Command palette search"
+          className="w-full font-ui text-base text-ink bg-transparent px-4 py-3 border-b border-surface focus:outline-none"
+        />
+        <ul role="listbox" aria-label="Commands" className="max-h-80 overflow-y-auto py-2">
+          {filtered.length === 0 && <li className="px-4 py-2 text-sm text-ink-muted">No matching commands</li>}
+          {filtered.map((action, index) => (
+            <li key={action.id} role="option" aria-selected={index === highlightedIndex}>
+              <button
+                type="button"
+                onClick={() => runAction(index)}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`w-full text-left px-4 py-2 text-sm font-ui ${
+                  index === highlightedIndex ? 'bg-highlight text-ink' : 'text-ink'
+                }`}
+              >
+                {action.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default CommandPalette

--- a/frontend/src/components/CommandPalette.test.jsx
+++ b/frontend/src/components/CommandPalette.test.jsx
@@ -1,16 +1,51 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import CommandPalette from './CommandPalette.jsx'
+import AskPage from '../ask/AskPage.jsx'
+import { getRepos, postQuery } from '../api.js'
+import { NewQuestionProvider } from '../lib/useNewQuestion.js'
+
+vi.mock('../api.js', () => ({
+  getRepos: vi.fn(),
+  postQuery: vi.fn(),
+}))
+
+function LocationDisplay() {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}</div>
+}
+
+function renderPalette({ path = '/' } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <NewQuestionProvider>
+        <CommandPalette />
+        <LocationDisplay />
+      </NewQuestionProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  getRepos.mockResolvedValue({ repos: [] })
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
 
 describe('CommandPalette', () => {
   it('is closed by default', () => {
-    render(<CommandPalette />)
+    renderPalette()
 
     expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
   })
 
   it('opens on Ctrl+K and closes on Escape', () => {
-    render(<CommandPalette />)
+    renderPalette()
 
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
     expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
@@ -20,7 +55,7 @@ describe('CommandPalette', () => {
   })
 
   it('opens on Cmd+K too', () => {
-    render(<CommandPalette />)
+    renderPalette()
 
     fireEvent.keyDown(window, { key: 'k', metaKey: true })
 
@@ -28,7 +63,7 @@ describe('CommandPalette', () => {
   })
 
   it('toggles closed when Ctrl+K is pressed again while open', () => {
-    render(<CommandPalette />)
+    renderPalette()
 
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
@@ -37,7 +72,7 @@ describe('CommandPalette', () => {
   })
 
   it('closes when clicking the backdrop', () => {
-    const { container } = render(<CommandPalette />)
+    const { container } = renderPalette()
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
 
     fireEvent.click(container.querySelector('.fixed.inset-0'))
@@ -45,33 +80,53 @@ describe('CommandPalette', () => {
     expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
   })
 
-  it('shows a placeholder message when there are no actions to show', () => {
-    render(<CommandPalette />)
+  it('lists the four baseline actions and filters them as the query changes', () => {
+    renderPalette()
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    expect(screen.getByRole('option', { name: 'Go to Ask' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Go to Library' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Go to Settings' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'New question' })).toBeInTheDocument()
+
+    const input = screen.getByRole('textbox', { name: 'Command palette search' })
+    fireEvent.change(input, { target: { value: 'library' } })
+
+    expect(screen.getByRole('option', { name: 'Go to Library' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Go to Ask' })).not.toBeInTheDocument()
+  })
+
+  it('shows a placeholder message when the query matches nothing', () => {
+    renderPalette()
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Command palette search' }), {
+      target: { value: 'nonexistent command' },
+    })
 
     expect(screen.getByText('No matching commands')).toBeInTheDocument()
   })
 
-  it('filters the action list as the query changes, and arrow keys move the highlighted selection', () => {
-    render(<CommandPalette />)
+  it('moves the highlighted selection with arrow keys and runs it on Enter', () => {
+    renderPalette()
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
 
     const input = screen.getByRole('textbox', { name: 'Command palette search' })
-    fireEvent.change(input, { target: { value: 'anything' } })
-
-    // With no registered actions yet, any query still yields the empty state.
-    expect(screen.getByText('No matching commands')).toBeInTheDocument()
-
     fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(screen.getByRole('option', { name: 'Go to Settings' })).toHaveAttribute('aria-selected', 'true')
+
     fireEvent.keyDown(input, { key: 'ArrowUp' })
+    expect(screen.getByRole('option', { name: 'Go to Library' })).toHaveAttribute('aria-selected', 'true')
+
     fireEvent.keyDown(input, { key: 'Enter' })
 
-    // Still open: Enter with no matching action is a no-op, not a crash.
-    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
+    expect(screen.getByTestId('location')).toHaveTextContent('/library')
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
   })
 
   it('resets the query and focuses the input each time it reopens', () => {
-    render(<CommandPalette />)
+    renderPalette()
 
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
     const firstInput = screen.getByRole('textbox', { name: 'Command palette search' })
@@ -83,5 +138,68 @@ describe('CommandPalette', () => {
 
     expect(secondInput.value).toBe('')
     expect(secondInput).toHaveFocus()
+  })
+
+  describe('navigation actions', () => {
+    it('selecting "Go to Library" navigates to /library', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Library' }))
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/library')
+    })
+
+    it('selecting "Go to Settings" navigates to /settings', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Settings' }))
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/settings')
+    })
+
+    it('selecting "Go to Ask" navigates to /', () => {
+      renderPalette({ path: '/library' })
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Ask' }))
+
+      expect(screen.getByTestId('location').textContent).toBe('/')
+    })
+  })
+
+  describe('"New question" action', () => {
+    it("clears the Ask page's current conversation when invoked from there", async () => {
+      const user = userEvent.setup()
+      getRepos.mockResolvedValue({ repos: [{ repo: 'owner/repo-a', indexed_units: 12 }] })
+      postQuery.mockResolvedValue({ answer: 'We use OAuth2 for auth.', citations: [], retrieved_count: 0 })
+
+      render(
+        <MemoryRouter>
+          <NewQuestionProvider>
+            <AskPage />
+            <CommandPalette />
+          </NewQuestionProvider>
+        </MemoryRouter>,
+      )
+
+      await user.type(await screen.findByLabelText('Ask a question'), 'Why OAuth2?')
+      await user.click(screen.getByRole('button', { name: 'Ask' }))
+      expect(await screen.findByText('We use OAuth2 for auth.')).toBeInTheDocument()
+
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+      fireEvent.click(screen.getByRole('button', { name: 'New question' }))
+
+      expect(screen.queryByText('We use OAuth2 for auth.')).not.toBeInTheDocument()
+      expect(screen.getByText('Ask why something in your codebase is the way it is')).toBeInTheDocument()
+    })
+
+    it('is a no-op, not a crash, when no page has registered a handler', () => {
+      renderPalette({ path: '/library' })
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      expect(() => fireEvent.click(screen.getByRole('button', { name: 'New question' }))).not.toThrow()
+    })
   })
 })

--- a/frontend/src/components/CommandPalette.test.jsx
+++ b/frontend/src/components/CommandPalette.test.jsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CommandPalette from './CommandPalette.jsx'
+
+describe('CommandPalette', () => {
+  it('is closed by default', () => {
+    render(<CommandPalette />)
+
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+  })
+
+  it('opens on Ctrl+K and closes on Escape', () => {
+    render(<CommandPalette />)
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+  })
+
+  it('opens on Cmd+K too', () => {
+    render(<CommandPalette />)
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true })
+
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
+  })
+
+  it('toggles closed when Ctrl+K is pressed again while open', () => {
+    render(<CommandPalette />)
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+  })
+
+  it('closes when clicking the backdrop', () => {
+    const { container } = render(<CommandPalette />)
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    fireEvent.click(container.querySelector('.fixed.inset-0'))
+
+    expect(screen.queryByRole('dialog', { name: 'Command palette' })).not.toBeInTheDocument()
+  })
+
+  it('shows a placeholder message when there are no actions to show', () => {
+    render(<CommandPalette />)
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    expect(screen.getByText('No matching commands')).toBeInTheDocument()
+  })
+
+  it('filters the action list as the query changes, and arrow keys move the highlighted selection', () => {
+    render(<CommandPalette />)
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+    const input = screen.getByRole('textbox', { name: 'Command palette search' })
+    fireEvent.change(input, { target: { value: 'anything' } })
+
+    // With no registered actions yet, any query still yields the empty state.
+    expect(screen.getByText('No matching commands')).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // Still open: Enter with no matching action is a no-op, not a crash.
+    expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument()
+  })
+
+  it('resets the query and focuses the input each time it reopens', () => {
+    render(<CommandPalette />)
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+    const firstInput = screen.getByRole('textbox', { name: 'Command palette search' })
+    fireEvent.change(firstInput, { target: { value: 'leftover query' } })
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+    const secondInput = screen.getByRole('textbox', { name: 'Command palette search' })
+
+    expect(secondInput.value).toBe('')
+    expect(secondInput).toHaveFocus()
+  })
+})

--- a/frontend/src/components/CommandPalette.test.jsx
+++ b/frontend/src/components/CommandPalette.test.jsx
@@ -169,6 +169,71 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('accessibility', () => {
+    it('has dialog semantics with aria-modal', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      expect(screen.getByRole('dialog', { name: 'Command palette' })).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('returns focus to the element that had focus before opening, after Escape closes it', () => {
+      render(
+        <MemoryRouter>
+          <NewQuestionProvider>
+            <button type="button">Trigger</button>
+            <CommandPalette />
+          </NewQuestionProvider>
+        </MemoryRouter>,
+      )
+
+      const trigger = screen.getByRole('button', { name: 'Trigger' })
+      trigger.focus()
+      expect(trigger).toHaveFocus()
+
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+      expect(screen.getByRole('textbox', { name: 'Command palette search' })).toHaveFocus()
+
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(trigger).toHaveFocus()
+    })
+
+    it('wraps Shift+Tab focus from the input to the last focusable element', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      const input = screen.getByRole('textbox', { name: 'Command palette search' })
+      fireEvent.keyDown(input, { key: 'Tab', shiftKey: true })
+
+      expect(screen.getByRole('button', { name: 'New question' })).toHaveFocus()
+    })
+
+    it('wraps Tab focus from the last focusable element back to the input', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      const newQuestionButton = screen.getByRole('button', { name: 'New question' })
+      newQuestionButton.focus()
+      fireEvent.keyDown(newQuestionButton, { key: 'Tab' })
+
+      expect(screen.getByRole('textbox', { name: 'Command palette search' })).toHaveFocus()
+    })
+
+    it('announces the filtered result count via a status region as the query changes', () => {
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      expect(screen.getByText('4 matching commands')).toBeInTheDocument()
+
+      const input = screen.getByRole('textbox', { name: 'Command palette search' })
+      fireEvent.change(input, { target: { value: 'library' } })
+      expect(screen.getByText('1 matching command')).toBeInTheDocument()
+
+      fireEvent.change(input, { target: { value: 'nonexistent command' } })
+      expect(screen.getByText('0 matching commands')).toBeInTheDocument()
+    })
+  })
+
   describe('search past questions', () => {
     it('shows an empty state and makes no network or storage calls', () => {
       const getItemSpy = vi.spyOn(Storage.prototype, 'getItem')

--- a/frontend/src/components/CommandPalette.test.jsx
+++ b/frontend/src/components/CommandPalette.test.jsx
@@ -169,6 +169,24 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('search past questions', () => {
+    it('shows an empty state and makes no network or storage calls', () => {
+      const getItemSpy = vi.spyOn(Storage.prototype, 'getItem')
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+      renderPalette()
+      fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+
+      expect(screen.getByText('No question history yet')).toBeInTheDocument()
+      expect(getRepos).not.toHaveBeenCalled()
+      expect(getItemSpy).not.toHaveBeenCalled()
+      expect(setItemSpy).not.toHaveBeenCalled()
+
+      getItemSpy.mockRestore()
+      setItemSpy.mockRestore()
+    })
+  })
+
   describe('"New question" action', () => {
     it("clears the Ask page's current conversation when invoked from there", async () => {
       const user = userEvent.setup()

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -1,11 +1,10 @@
 import { useEffect, useRef } from 'react'
-import AnswerPassage from '../ask/AnswerPassage.jsx'
-import SourceCardList from '../ask/SourceCardList.jsx'
+import AnswerPage from '../ask/AnswerPage.jsx'
 import SourcesView from '../ask/SourcesView.jsx'
 import ErrorCard from './ErrorCard.jsx'
 import LoadingCard from './LoadingCard.jsx'
 
-function AssistantMessage({ message, disabled }) {
+function AssistantMessage({ message, question, repos, selectedRepos, disabled }) {
   if (message.type === 'loading') return <LoadingCard />
   if (message.type === 'error') {
     return <ErrorCard message={message.message} onRetry={message.onRetry} disabled={disabled} />
@@ -19,10 +18,13 @@ function AssistantMessage({ message, disabled }) {
       return <SourcesView citations={citations} />
     }
     return (
-      <div className="max-w-3xl">
-        <AnswerPassage answer={message.answer} citations={citations} />
-        {citations.length > 0 && <SourceCardList citations={citations} className="mt-4 flex flex-wrap gap-4" />}
-      </div>
+      <AnswerPage
+        question={question}
+        answer={message.answer}
+        citations={citations}
+        repos={repos}
+        selectedRepos={selectedRepos}
+      />
     )
   }
   return (
@@ -34,7 +36,7 @@ function AssistantMessage({ message, disabled }) {
   )
 }
 
-function MessageList({ messages, disabled }) {
+function MessageList({ messages, repos = [], selectedRepos = [], disabled }) {
   const bottomRef = useRef(null)
 
   useEffect(() => {
@@ -52,7 +54,13 @@ function MessageList({ messages, disabled }) {
           </div>
         ) : (
           <div key={index} className="flex justify-start">
-            <AssistantMessage message={message} disabled={disabled} />
+            <AssistantMessage
+              message={message}
+              question={messages[index - 1]?.role === 'user' ? messages[index - 1].content : ''}
+              repos={repos}
+              selectedRepos={selectedRepos}
+              disabled={disabled}
+            />
           </div>
         ),
       )}

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -57,7 +57,7 @@ describe('MessageList', () => {
             role: 'assistant',
             type: 'answer',
             mode: 'synthesized',
-            answer: 'We use OAuth2 for auth.',
+            answer: 'We use OAuth2 for auth [owner/repo:pr:42].',
             citations: [citation],
           },
         ]}
@@ -67,8 +67,8 @@ describe('MessageList', () => {
     )
     expect(screen.getByRole('heading', { name: 'Why OAuth2?' })).toBeInTheDocument()
     expect(screen.getByText('searched 1 repo · 5 decisions')).toBeInTheDocument()
-    expect(screen.getByText('We use OAuth2 for auth.')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Citation:/ })).toHaveAttribute('href', citation.url)
+    expect(screen.getByText(/We use OAuth2 for auth/)).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /Citation:/ })[0]).toHaveAttribute('href', citation.url)
   })
 
   it('renders an AnswerPage for an assistant message with an omitted type (defaults to answer)', () => {

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -94,9 +94,7 @@ describe('MessageList', () => {
         ]}
       />,
     )
-    expect(
-      screen.getByText('No Gemini key configured — showing retrieved sources directly.'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('1 decision found —')).toBeInTheDocument()
     expect(screen.getByRole('link')).toHaveAttribute('href', citation.url)
   })
 

--- a/frontend/src/components/MessageList.test.jsx
+++ b/frontend/src/components/MessageList.test.jsx
@@ -48,10 +48,11 @@ describe('MessageList', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled()
   })
 
-  it('renders AnswerPassage with its sources for a synthesized answer message', () => {
+  it('renders an AnswerPage with its sources for a synthesized answer message', () => {
     render(
       <MessageList
         messages={[
+          { role: 'user', content: 'Why OAuth2?' },
           {
             role: 'assistant',
             type: 'answer',
@@ -60,13 +61,17 @@ describe('MessageList', () => {
             citations: [citation],
           },
         ]}
+        repos={[{ repo: 'owner/repo', indexed_units: 5 }]}
+        selectedRepos={['owner/repo']}
       />,
     )
+    expect(screen.getByRole('heading', { name: 'Why OAuth2?' })).toBeInTheDocument()
+    expect(screen.getByText('searched 1 repo · 5 decisions')).toBeInTheDocument()
     expect(screen.getByText('We use OAuth2 for auth.')).toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute('href', citation.url)
+    expect(screen.getByRole('link', { name: /Citation:/ })).toHaveAttribute('href', citation.url)
   })
 
-  it('renders AnswerPassage for an assistant message with an omitted type (defaults to answer)', () => {
+  it('renders an AnswerPage for an assistant message with an omitted type (defaults to answer)', () => {
     render(
       <MessageList
         messages={[{ role: 'assistant', answer: 'We use OAuth2 for auth.', citations: [] }]}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,6 +77,17 @@ body {
   }
 }
 
+@keyframes source-group-entrance {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .animate-answer-settle {
   animation: answer-settle var(--dur-surface) var(--ease-out) both;
 }
@@ -86,9 +97,22 @@ body {
   animation: citation-ink-in var(--dur-state) var(--ease-out) both;
 }
 
+/*
+ * Each paragraph's SourceCards arrive together as one group, not
+ * staggered per-card like CitationMarker — offset from the passage's own
+ * settle animation the same way CitationMarker computes its stagger:
+ * relative to --dur-surface.
+ */
+.animate-source-group-entrance {
+  opacity: 0;
+  animation: source-group-entrance var(--dur-surface) var(--ease-out) both;
+  animation-delay: calc(var(--dur-surface) + 90ms);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-answer-settle,
-  .animate-citation-ink-in {
+  .animate-citation-ink-in,
+  .animate-source-group-entrance {
     animation: none;
     opacity: 1;
     transform: none;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -118,3 +118,12 @@ body {
     transform: none;
   }
 }
+
+/*
+ * FileTree's decision-density heatmap: a node sets `--heat-intensity` and
+ * this class, rather than an inline color-mix(), so the accent/highlight
+ * mixing formula lives in one place instead of being duplicated per node.
+ */
+.heat {
+  background-color: color-mix(in oklch, var(--color-accent) var(--heat-intensity, 0%), transparent);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,3 +127,32 @@ body {
 .heat {
   background-color: color-mix(in oklch, var(--color-accent) var(--heat-intensity, 0%), transparent);
 }
+
+/*
+ * AnswerPage print stylesheet (Track B spec: "a print and PDF
+ * stylesheet"). TopNav hides via Tailwind's own `print:hidden` on its
+ * header. These three classes force AnswerPage back to its own
+ * <900px inline-citation-collapse layout for paper — reusing it rather
+ * than building a third citation layout — regardless of the actual
+ * viewport width the browser renders the print preview at: unlayered
+ * rules here already win the cascade over Tailwind's `min-[900px]:`
+ * utilities (which live inside Tailwind's `@layer utilities`), the same
+ * mechanism the `.heat`/`.animate-*` classes above rely on.
+ */
+@media print {
+  .answer-page {
+    max-width: none;
+  }
+
+  .answer-grid {
+    display: block;
+  }
+
+  .answer-grid-margin {
+    display: none;
+  }
+
+  .answer-grid-inline {
+    display: flex;
+  }
+}

--- a/frontend/src/lib/sourceFormat.js
+++ b/frontend/src/lib/sourceFormat.js
@@ -1,0 +1,29 @@
+// Shared DecisionUnit display formatting — extracted from SourceCard.jsx
+// once DecisionTimeline became a second consumer, per DRY.
+export function badgeText(unit) {
+  return unit.kind === 'pr' ? `PR #${unit.ref}` : `commit ${unit.ref.slice(0, 7)}`
+}
+
+export function relativeDate(dateString) {
+  const date = new Date(dateString)
+  const seconds = Math.round((date.getTime() - Date.now()) / 1000)
+  const divisions = [
+    [60, 'second'],
+    [60, 'minute'],
+    [24, 'hour'],
+    [7, 'day'],
+    [4.34524, 'week'],
+    [12, 'month'],
+    [Number.POSITIVE_INFINITY, 'year'],
+  ]
+
+  const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+  let duration = seconds
+  for (const [amount, unit] of divisions) {
+    if (Math.abs(duration) < amount) {
+      return formatter.format(Math.round(duration), unit)
+    }
+    duration /= amount
+  }
+  return formatter.format(Math.round(duration), 'year')
+}

--- a/frontend/src/lib/useNewQuestion.js
+++ b/frontend/src/lib/useNewQuestion.js
@@ -1,0 +1,43 @@
+// Lets the command palette's "New question" action reach AskPage's
+// message state without CommandPalette importing AskPage directly — it
+// mounts in AppShell, above every route, and shouldn't reach into a
+// specific page's internals. AskPage registers its own clear-messages
+// handler on mount; the palette calls whatever handler is currently
+// registered (a no-op if AskPage isn't mounted).
+import { createContext, createElement, useCallback, useContext, useEffect, useRef } from 'react'
+
+const NewQuestionContext = createContext(null)
+
+export function NewQuestionProvider({ children }) {
+  const handlerRef = useRef(null)
+
+  const setHandler = useCallback((handler) => {
+    handlerRef.current = handler
+  }, [])
+
+  const requestNewQuestion = useCallback(() => {
+    handlerRef.current?.()
+  }, [])
+
+  return createElement(NewQuestionContext.Provider, { value: { setHandler, requestNewQuestion } }, children)
+}
+
+export function useRegisterNewQuestionHandler(handler) {
+  const context = useContext(NewQuestionContext)
+  if (!context) {
+    throw new Error('useRegisterNewQuestionHandler must be used within a NewQuestionProvider')
+  }
+
+  useEffect(() => {
+    context.setHandler(handler)
+    return () => context.setHandler(null)
+  }, [context, handler])
+}
+
+export function useNewQuestion() {
+  const context = useContext(NewQuestionContext)
+  if (!context) {
+    throw new Error('useNewQuestion must be used within a NewQuestionProvider')
+  }
+  return context.requestNewQuestion
+}

--- a/frontend/src/lib/useReadingPreferences.js
+++ b/frontend/src/lib/useReadingPreferences.js
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react'
+
+const STORAGE_KEY = 'readingPreferences'
+
+const DEFAULTS = { density: 'comfortable' }
+
+function readStored() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS
+  } catch {
+    return DEFAULTS
+  }
+}
+
+// Track B's reading-column preferences: disposable client-only display
+// settings (unlike bookmarks/annotations, losing these costs nothing), so
+// localStorage is enough. Stored as one object under one key so each
+// preference shares persistence logic instead of growing its own storage
+// key.
+function useReadingPreferences() {
+  const [preferences, setPreferences] = useState(readStored)
+
+  const update = useCallback((patch) => {
+    setPreferences((current) => {
+      const next = { ...current, ...patch }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+      return next
+    })
+  }, [])
+
+  const setDensity = useCallback((density) => update({ density }), [update])
+
+  return { ...preferences, setDensity }
+}
+
+export default useReadingPreferences

--- a/frontend/src/lib/useReadingPreferences.js
+++ b/frontend/src/lib/useReadingPreferences.js
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 
 const STORAGE_KEY = 'readingPreferences'
 
-const DEFAULTS = { density: 'comfortable', measure: 'default' }
+const DEFAULTS = { density: 'comfortable', measure: 'default', focusMode: false }
 
 function readStored() {
   try {
@@ -17,13 +17,15 @@ function readStored() {
 // settings (unlike bookmarks/annotations, losing these costs nothing), so
 // localStorage is enough. Stored as one object under one key so each
 // preference shares persistence logic instead of growing its own storage
-// key.
+// key. Focus mode joins density/measure here (rather than resetting per
+// navigation) so all three reading preferences behave the same way.
 function useReadingPreferences() {
   const [preferences, setPreferences] = useState(readStored)
 
   const update = useCallback((patch) => {
     setPreferences((current) => {
-      const next = { ...current, ...patch }
+      const partial = typeof patch === 'function' ? patch(current) : patch
+      const next = { ...current, ...partial }
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
       return next
     })
@@ -31,8 +33,12 @@ function useReadingPreferences() {
 
   const setDensity = useCallback((density) => update({ density }), [update])
   const setMeasure = useCallback((measure) => update({ measure }), [update])
+  const toggleFocusMode = useCallback(
+    () => update((current) => ({ focusMode: !current.focusMode })),
+    [update],
+  )
 
-  return { ...preferences, setDensity, setMeasure }
+  return { ...preferences, setDensity, setMeasure, toggleFocusMode }
 }
 
 export default useReadingPreferences

--- a/frontend/src/lib/useReadingPreferences.js
+++ b/frontend/src/lib/useReadingPreferences.js
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 
 const STORAGE_KEY = 'readingPreferences'
 
-const DEFAULTS = { density: 'comfortable' }
+const DEFAULTS = { density: 'comfortable', measure: 'default' }
 
 function readStored() {
   try {
@@ -30,8 +30,9 @@ function useReadingPreferences() {
   }, [])
 
   const setDensity = useCallback((density) => update({ density }), [update])
+  const setMeasure = useCallback((measure) => update({ measure }), [update])
 
-  return { ...preferences, setDensity }
+  return { ...preferences, setDensity, setMeasure }
 }
 
 export default useReadingPreferences

--- a/frontend/src/lib/useReadingPreferences.test.js
+++ b/frontend/src/lib/useReadingPreferences.test.js
@@ -42,4 +42,39 @@ describe('useReadingPreferences', () => {
 
     expect(result.current.density).toBe('comfortable')
   })
+
+  it('defaults measure to default', () => {
+    const { result } = renderHook(() => useReadingPreferences())
+
+    expect(result.current.measure).toBe('default')
+  })
+
+  it('updates measure independently of density and persists both', () => {
+    const { result } = renderHook(() => useReadingPreferences())
+
+    act(() => {
+      result.current.setDensity('compact')
+    })
+    act(() => {
+      result.current.setMeasure('wide')
+    })
+
+    expect(result.current.density).toBe('compact')
+    expect(result.current.measure).toBe('wide')
+    expect(JSON.parse(localStorage.getItem('readingPreferences'))).toMatchObject({
+      density: 'compact',
+      measure: 'wide',
+    })
+  })
+
+  it('reads a previously persisted measure across a simulated remount', () => {
+    const { result: first } = renderHook(() => useReadingPreferences())
+    act(() => {
+      first.current.setMeasure('narrow')
+    })
+
+    const { result: second } = renderHook(() => useReadingPreferences())
+
+    expect(second.current.measure).toBe('narrow')
+  })
 })

--- a/frontend/src/lib/useReadingPreferences.test.js
+++ b/frontend/src/lib/useReadingPreferences.test.js
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import useReadingPreferences from './useReadingPreferences.js'
+
+describe('useReadingPreferences', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults density to comfortable', () => {
+    const { result } = renderHook(() => useReadingPreferences())
+
+    expect(result.current.density).toBe('comfortable')
+  })
+
+  it('updates density and persists it to localStorage', () => {
+    const { result } = renderHook(() => useReadingPreferences())
+
+    act(() => {
+      result.current.setDensity('compact')
+    })
+
+    expect(result.current.density).toBe('compact')
+    expect(JSON.parse(localStorage.getItem('readingPreferences'))).toMatchObject({ density: 'compact' })
+  })
+
+  it('reads a previously persisted density across a simulated remount', () => {
+    const { result: first } = renderHook(() => useReadingPreferences())
+    act(() => {
+      first.current.setDensity('compact')
+    })
+
+    const { result: second } = renderHook(() => useReadingPreferences())
+
+    expect(second.current.density).toBe('compact')
+  })
+
+  it('falls back to defaults when localStorage holds malformed JSON', () => {
+    localStorage.setItem('readingPreferences', 'not json')
+
+    const { result } = renderHook(() => useReadingPreferences())
+
+    expect(result.current.density).toBe('comfortable')
+  })
+})

--- a/frontend/src/library/DecisionTimeline.jsx
+++ b/frontend/src/library/DecisionTimeline.jsx
@@ -1,0 +1,93 @@
+// Track B's decision timeline: a chronological, grouped-by-date list of a
+// repo's decisions, fed by GET /decisions. Reuses SourceCard.jsx's
+// badge/date formatting (via the shared lib/sourceFormat.js module, now
+// that this is a second consumer) instead of reimplementing it.
+import { useEffect, useState } from 'react'
+import { getDecisions } from '../api.js'
+import { badgeText, relativeDate } from '../lib/sourceFormat.js'
+
+function dateGroupLabel(dateString) {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+// `units` already arrives newest-first from GET /decisions — grouping by
+// day preserves that order both across and within groups.
+function groupByDate(units) {
+  const groups = []
+  let current = null
+  for (const unit of units) {
+    const label = dateGroupLabel(unit.date)
+    if (current == null || current.label !== label) {
+      current = { label, units: [] }
+      groups.push(current)
+    }
+    current.units.push(unit)
+  }
+  return groups
+}
+
+function DecisionTimeline({ repo }) {
+  const [units, setUnits] = useState(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    setUnits(undefined)
+    getDecisions({ repo })
+      .then((result) => {
+        if (!cancelled) setUnits(result.units)
+      })
+      .catch(() => {
+        if (!cancelled) setUnits('error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [repo])
+
+  if (units === undefined) {
+    return <p className="text-sm text-ink-muted">Loading timeline…</p>
+  }
+
+  if (units === 'error') {
+    return <p className="text-sm text-danger">Couldn't load the timeline.</p>
+  }
+
+  if (units.length === 0) {
+    return <p className="font-reading text-ink">No decisions indexed yet.</p>
+  }
+
+  const groups = groupByDate(units)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {groups.map((group) => (
+        <div key={group.label}>
+          <h2 className="font-ui text-xs uppercase tracking-wide text-ink-muted">
+            {group.label}
+          </h2>
+          <ul className="mt-2 flex flex-col gap-2">
+            {group.units.map((unit) => (
+              <li key={unit.id} id={`source-${unit.id}`} className="bg-panel rounded-xl p-4">
+                <div className="flex items-center gap-2">
+                  <span className="inline-block rounded bg-highlight text-ink-muted font-mono text-xs px-2 py-1">
+                    {badgeText(unit)}
+                  </span>
+                </div>
+                <p className="font-ui text-base text-ink mt-2">{unit.title}</p>
+                <p className="text-sm text-ink-muted mt-2">
+                  {unit.author} · {relativeDate(unit.date)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default DecisionTimeline

--- a/frontend/src/library/DecisionTimeline.jsx
+++ b/frontend/src/library/DecisionTimeline.jsx
@@ -32,11 +32,13 @@ function groupByDate(units) {
 
 function DecisionTimeline({ repo }) {
   const [units, setUnits] = useState(undefined)
+  const [since, setSince] = useState('')
+  const [until, setUntil] = useState('')
 
   useEffect(() => {
     let cancelled = false
     setUnits(undefined)
-    getDecisions({ repo })
+    getDecisions({ repo, since: since || undefined, until: until || undefined })
       .then((result) => {
         if (!cancelled) setUnits(result.units)
       })
@@ -46,46 +48,65 @@ function DecisionTimeline({ repo }) {
     return () => {
       cancelled = true
     }
-  }, [repo])
+  }, [repo, since, until])
 
+  const filters = (
+    <div className="flex items-center gap-2">
+      <label className="flex items-center gap-2 text-sm text-ink-muted">
+        From
+        <input
+          type="date"
+          value={since}
+          onChange={(event) => setSince(event.target.value)}
+          className="bg-panel rounded px-2 py-1 text-sm text-ink"
+        />
+      </label>
+      <label className="flex items-center gap-2 text-sm text-ink-muted">
+        To
+        <input
+          type="date"
+          value={until}
+          onChange={(event) => setUntil(event.target.value)}
+          className="bg-panel rounded px-2 py-1 text-sm text-ink"
+        />
+      </label>
+    </div>
+  )
+
+  let content
   if (units === undefined) {
-    return <p className="text-sm text-ink-muted">Loading timeline…</p>
+    content = <p className="text-sm text-ink-muted">Loading timeline…</p>
+  } else if (units === 'error') {
+    content = <p className="text-sm text-danger">Couldn't load the timeline.</p>
+  } else if (units.length === 0) {
+    content = <p className="font-reading text-ink">No decisions indexed yet.</p>
+  } else {
+    content = groupByDate(units).map((group) => (
+      <div key={group.label}>
+        <h2 className="font-ui text-xs uppercase tracking-wide text-ink-muted">{group.label}</h2>
+        <ul className="mt-2 flex flex-col gap-2">
+          {group.units.map((unit) => (
+            <li key={unit.id} id={`source-${unit.id}`} className="bg-panel rounded-xl p-4">
+              <div className="flex items-center gap-2">
+                <span className="inline-block rounded bg-highlight text-ink-muted font-mono text-xs px-2 py-1">
+                  {badgeText(unit)}
+                </span>
+              </div>
+              <p className="font-ui text-base text-ink mt-2">{unit.title}</p>
+              <p className="text-sm text-ink-muted mt-2">
+                {unit.author} · {relativeDate(unit.date)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))
   }
-
-  if (units === 'error') {
-    return <p className="text-sm text-danger">Couldn't load the timeline.</p>
-  }
-
-  if (units.length === 0) {
-    return <p className="font-reading text-ink">No decisions indexed yet.</p>
-  }
-
-  const groups = groupByDate(units)
 
   return (
     <div className="flex flex-col gap-6">
-      {groups.map((group) => (
-        <div key={group.label}>
-          <h2 className="font-ui text-xs uppercase tracking-wide text-ink-muted">
-            {group.label}
-          </h2>
-          <ul className="mt-2 flex flex-col gap-2">
-            {group.units.map((unit) => (
-              <li key={unit.id} id={`source-${unit.id}`} className="bg-panel rounded-xl p-4">
-                <div className="flex items-center gap-2">
-                  <span className="inline-block rounded bg-highlight text-ink-muted font-mono text-xs px-2 py-1">
-                    {badgeText(unit)}
-                  </span>
-                </div>
-                <p className="font-ui text-base text-ink mt-2">{unit.title}</p>
-                <p className="text-sm text-ink-muted mt-2">
-                  {unit.author} · {relativeDate(unit.date)}
-                </p>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
+      {filters}
+      {content}
     </div>
   )
 }

--- a/frontend/src/library/DecisionTimeline.test.jsx
+++ b/frontend/src/library/DecisionTimeline.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import DecisionTimeline from './DecisionTimeline.jsx'
 import { getDecisions } from '../api.js'
@@ -102,5 +103,32 @@ describe('DecisionTimeline', () => {
 
     rerender(<DecisionTimeline repo="owner/repo-b" />)
     expect(getDecisions).toHaveBeenCalledWith({ repo: 'owner/repo-b' })
+  })
+
+  it('re-fetches with since/until when a date range is set, then drops them on clear', async () => {
+    const user = userEvent.setup()
+    getDecisions.mockResolvedValue({ units: [], total: 0, page: 1, limit: 20 })
+    render(<DecisionTimeline repo="owner/repo" />)
+
+    await screen.findByText('No decisions indexed yet.')
+    expect(getDecisions).toHaveBeenCalledWith({ repo: 'owner/repo', since: undefined, until: undefined })
+
+    await user.type(screen.getByLabelText('From'), '2026-01-01')
+    expect(getDecisions).toHaveBeenLastCalledWith({
+      repo: 'owner/repo',
+      since: '2026-01-01',
+      until: undefined,
+    })
+
+    await user.type(screen.getByLabelText('To'), '2026-02-01')
+    expect(getDecisions).toHaveBeenLastCalledWith({
+      repo: 'owner/repo',
+      since: '2026-01-01',
+      until: '2026-02-01',
+    })
+
+    await user.clear(screen.getByLabelText('From'))
+    await user.clear(screen.getByLabelText('To'))
+    expect(getDecisions).toHaveBeenLastCalledWith({ repo: 'owner/repo', since: undefined, until: undefined })
   })
 })

--- a/frontend/src/library/DecisionTimeline.test.jsx
+++ b/frontend/src/library/DecisionTimeline.test.jsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import DecisionTimeline from './DecisionTimeline.jsx'
+import { getDecisions } from '../api.js'
+
+vi.mock('../api.js', () => ({
+  getDecisions: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+const UNITS = [
+  {
+    id: 'unit-1',
+    repo: 'owner/repo',
+    kind: 'pr',
+    ref: '42',
+    url: 'https://github.com/owner/repo/pull/42',
+    author: 'alice',
+    date: '2026-02-10T12:00:00Z',
+    title: 'Switch to OAuth2 device flow',
+    decision: 'Use device flow',
+    rationale: 'Simpler for CLI-less setup',
+    alternatives: [],
+    source_excerpt: '',
+  },
+  {
+    id: 'unit-2',
+    repo: 'owner/repo',
+    kind: 'commit',
+    ref: 'abcdef1234',
+    url: 'https://github.com/owner/repo/commit/abcdef1234',
+    author: 'bob',
+    date: '2026-02-10T09:00:00Z',
+    title: 'Cache PersistentClient factory',
+    decision: 'Cache the client',
+    rationale: 'Avoid repeated disk opens',
+    alternatives: [],
+    source_excerpt: '',
+  },
+  {
+    id: 'unit-3',
+    repo: 'owner/repo',
+    kind: 'commit',
+    ref: '9876543210',
+    url: 'https://github.com/owner/repo/commit/9876543210',
+    author: 'carol',
+    date: '2026-01-05T09:00:00Z',
+    title: 'Add diff filter for lockfiles',
+    decision: 'Drop lockfile hunks',
+    rationale: 'Keep extraction prompts small',
+    alternatives: [],
+    source_excerpt: '',
+  },
+]
+
+describe('DecisionTimeline', () => {
+  it('shows a loading state before the fetch resolves', () => {
+    getDecisions.mockReturnValue(new Promise(() => {}))
+    render(<DecisionTimeline repo="owner/repo" />)
+
+    expect(screen.getByText('Loading timeline…')).toBeInTheDocument()
+  })
+
+  it('shows an explicit empty state when there are no decisions', async () => {
+    getDecisions.mockResolvedValue({ units: [], total: 0, page: 1, limit: 20 })
+    render(<DecisionTimeline repo="owner/repo" />)
+
+    expect(await screen.findByText('No decisions indexed yet.')).toBeInTheDocument()
+  })
+
+  it('shows an error state when the fetch fails', async () => {
+    getDecisions.mockRejectedValue(new Error('network error'))
+    render(<DecisionTimeline repo="owner/repo" />)
+
+    expect(await screen.findByText("Couldn't load the timeline.")).toBeInTheDocument()
+  })
+
+  it('groups entries by date and preserves the newest-first order from the API', async () => {
+    getDecisions.mockResolvedValue({ units: UNITS, total: 3, page: 1, limit: 20 })
+    render(<DecisionTimeline repo="owner/repo" />)
+
+    const headings = await screen.findAllByRole('heading', { level: 2 })
+    expect(headings.map((h) => h.textContent)).toEqual(['February 10, 2026', 'January 5, 2026'])
+
+    const titles = screen.getAllByText(/Switch to OAuth2|Cache PersistentClient|Add diff filter/)
+    expect(titles.map((t) => t.textContent)).toEqual([
+      'Switch to OAuth2 device flow',
+      'Cache PersistentClient factory',
+      'Add diff filter for lockfiles',
+    ])
+  })
+
+  it('fetches the given repo and re-fetches when the repo prop changes', async () => {
+    getDecisions.mockResolvedValue({ units: [], total: 0, page: 1, limit: 20 })
+    const { rerender } = render(<DecisionTimeline repo="owner/repo-a" />)
+
+    await screen.findByText('No decisions indexed yet.')
+    expect(getDecisions).toHaveBeenCalledWith({ repo: 'owner/repo-a' })
+
+    rerender(<DecisionTimeline repo="owner/repo-b" />)
+    expect(getDecisions).toHaveBeenCalledWith({ repo: 'owner/repo-b' })
+  })
+})

--- a/frontend/src/library/FileTree.jsx
+++ b/frontend/src/library/FileTree.jsx
@@ -1,29 +1,62 @@
 // Nested file-tree view built from a flat list of repo paths (e.g.
-// `Object.keys()` of the decisions-by-path aggregation). Prerequisite
-// shell for the heatmap coloring and click-to-question issues that
-// follow — this issue only builds the collapsible tree itself.
+// `Object.keys()` of the decisions-by-path aggregation), heatmap-colored
+// by decision density when a `{path: count}` map is supplied. Prerequisite
+// shell for the click-to-question issue that follows.
 import { useState } from 'react'
 
 // A ~40-line recursive build: no tree library needed for splitting `/`
-// paths into a nested { dirs, files } shape.
-function buildTree(paths) {
-  const root = { dirs: new Map(), files: [] }
+// paths into a nested { dirs, files } shape. Each node carries its own
+// full path (for counts lookup/click-to-question) and a `count` that's
+// the sum of its descendant files' counts, so a directory heats up when
+// any file beneath it does.
+function buildTree(paths, counts) {
+  const root = { dirs: new Map(), files: [], path: '', count: 0 }
   for (const path of paths) {
+    const fileCount = counts[path] ?? 0
     const segments = path.split('/')
     let node = root
+    node.count += fileCount
+    let prefix = ''
     for (const segment of segments.slice(0, -1)) {
+      prefix = prefix ? `${prefix}/${segment}` : segment
       if (!node.dirs.has(segment)) {
-        node.dirs.set(segment, { dirs: new Map(), files: [] })
+        node.dirs.set(segment, { dirs: new Map(), files: [], path: prefix, count: 0 })
       }
       node = node.dirs.get(segment)
+      node.count += fileCount
     }
-    node.files.push(segments[segments.length - 1])
+    node.files.push({ name: segments[segments.length - 1], path, count: fileCount })
   }
   return root
 }
 
-function DirNode({ name, node }) {
+function treeMaxCount(node) {
+  let max = node.count
+  for (const child of node.dirs.values()) {
+    max = Math.max(max, treeMaxCount(child))
+  }
+  for (const file of node.files) {
+    max = Math.max(max, file.count)
+  }
+  return max
+}
+
+// Intensity is normalized against the whole tree's own max count (not a
+// fixed scale) so the heatmap uses its full visual range regardless of
+// repo size, and expressed as a `--heat-intensity` custom property rather
+// than a literal `color-mix()` inline value — jsdom's style parser
+// accepts arbitrary custom-property strings but not modern color
+// functions, and this keeps the `color-mix`/`--color-accent` mixing in
+// one CSS rule (`.heat` in index.css) instead of duplicated per node.
+function heatStyle(count, maxCount) {
+  if (!count || !maxCount) return null
+  const intensity = Math.round((count / maxCount) * 80) + 15
+  return { className: 'heat', style: { '--heat-intensity': `${intensity}%` } }
+}
+
+function DirNode({ name, node, maxCount }) {
   const [open, setOpen] = useState(true)
+  const heat = heatStyle(node.count, maxCount)
 
   return (
     <li>
@@ -31,34 +64,43 @@ function DirNode({ name, node }) {
         type="button"
         aria-expanded={open}
         onClick={() => setOpen((current) => !current)}
-        className="flex items-center gap-1 text-sm text-ink"
+        className={`flex items-center gap-1 text-sm text-ink rounded px-1 ${heat ? heat.className : ''}`}
+        style={heat?.style}
       >
         <span aria-hidden="true">{open ? '▾' : '▸'}</span>
         {name}
       </button>
-      {open && <TreeList node={node} indent />}
+      {open && <TreeList node={node} maxCount={maxCount} indent />}
     </li>
   )
 }
 
-function TreeList({ node, indent }) {
+function TreeList({ node, maxCount, indent }) {
   return (
     <ul className={`flex flex-col gap-1 ${indent ? 'pl-4' : ''}`}>
       {[...node.dirs.entries()].map(([name, child]) => (
-        <DirNode key={name} name={name} node={child} />
+        <DirNode key={name} name={name} node={child} maxCount={maxCount} />
       ))}
-      {node.files.map((file) => (
-        <li key={file} className="text-sm text-ink-muted">
-          {file}
-        </li>
-      ))}
+      {node.files.map((file) => {
+        const heat = heatStyle(file.count, maxCount)
+        return (
+          <li
+            key={file.path}
+            className={`text-sm text-ink-muted rounded px-1 ${heat ? heat.className : ''}`}
+            style={heat?.style}
+          >
+            {file.name}
+          </li>
+        )
+      })}
     </ul>
   )
 }
 
-function FileTree({ paths }) {
-  const root = buildTree(paths)
-  return <TreeList node={root} />
+function FileTree({ paths, counts = {} }) {
+  const root = buildTree(paths, counts)
+  const maxCount = treeMaxCount(root)
+  return <TreeList node={root} maxCount={maxCount} />
 }
 
 export default FileTree

--- a/frontend/src/library/FileTree.jsx
+++ b/frontend/src/library/FileTree.jsx
@@ -1,0 +1,64 @@
+// Nested file-tree view built from a flat list of repo paths (e.g.
+// `Object.keys()` of the decisions-by-path aggregation). Prerequisite
+// shell for the heatmap coloring and click-to-question issues that
+// follow — this issue only builds the collapsible tree itself.
+import { useState } from 'react'
+
+// A ~40-line recursive build: no tree library needed for splitting `/`
+// paths into a nested { dirs, files } shape.
+function buildTree(paths) {
+  const root = { dirs: new Map(), files: [] }
+  for (const path of paths) {
+    const segments = path.split('/')
+    let node = root
+    for (const segment of segments.slice(0, -1)) {
+      if (!node.dirs.has(segment)) {
+        node.dirs.set(segment, { dirs: new Map(), files: [] })
+      }
+      node = node.dirs.get(segment)
+    }
+    node.files.push(segments[segments.length - 1])
+  }
+  return root
+}
+
+function DirNode({ name, node }) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <li>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="flex items-center gap-1 text-sm text-ink"
+      >
+        <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+        {name}
+      </button>
+      {open && <TreeList node={node} indent />}
+    </li>
+  )
+}
+
+function TreeList({ node, indent }) {
+  return (
+    <ul className={`flex flex-col gap-1 ${indent ? 'pl-4' : ''}`}>
+      {[...node.dirs.entries()].map(([name, child]) => (
+        <DirNode key={name} name={name} node={child} />
+      ))}
+      {node.files.map((file) => (
+        <li key={file} className="text-sm text-ink-muted">
+          {file}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function FileTree({ paths }) {
+  const root = buildTree(paths)
+  return <TreeList node={root} />
+}
+
+export default FileTree

--- a/frontend/src/library/FileTree.test.jsx
+++ b/frontend/src/library/FileTree.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import FileTree from './FileTree.jsx'
+
+const PATHS = ['backend/auth.py', 'backend/models.py', 'frontend/src/api.js']
+
+describe('FileTree', () => {
+  it('nests files under their directories', () => {
+    render(<FileTree paths={PATHS} />)
+
+    const backend = screen.getByRole('button', { name: /backend/ })
+    const backendFiles = within(backend.closest('li')).getAllByText(/\.py$/)
+    expect(backendFiles.map((f) => f.textContent)).toEqual(['auth.py', 'models.py'])
+
+    const src = screen.getByRole('button', { name: /src/ })
+    const srcFiles = within(src.closest('li')).getAllByText(/\.js$/)
+    expect(srcFiles.map((f) => f.textContent)).toEqual(['api.js'])
+  })
+
+  it('expands and collapses a directory on click', async () => {
+    const user = userEvent.setup()
+    render(<FileTree paths={PATHS} />)
+
+    const backend = screen.getByRole('button', { name: /backend/ })
+    expect(backend).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('auth.py')).toBeInTheDocument()
+
+    await user.click(backend)
+    expect(backend).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('auth.py')).not.toBeInTheDocument()
+
+    await user.click(backend)
+    expect(backend).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('auth.py')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/library/FileTree.test.jsx
+++ b/frontend/src/library/FileTree.test.jsx
@@ -34,4 +34,37 @@ describe('FileTree', () => {
     expect(backend).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('auth.py')).toBeInTheDocument()
   })
+
+  it('applies higher heat intensity to a path with a higher decision count', () => {
+    const counts = { 'backend/auth.py': 8, 'backend/models.py': 2, 'frontend/src/api.js': 0 }
+    render(<FileTree paths={PATHS} counts={counts} />)
+
+    const auth = screen.getByText('auth.py')
+    const models = screen.getByText('models.py')
+    expect(auth).toHaveClass('heat')
+    expect(models).toHaveClass('heat')
+
+    const authIntensity = parseInt(auth.style.getPropertyValue('--heat-intensity'), 10)
+    const modelsIntensity = parseInt(models.style.getPropertyValue('--heat-intensity'), 10)
+    expect(authIntensity).toBeGreaterThan(modelsIntensity)
+  })
+
+  it('applies no highlight to a path with zero decisions', () => {
+    const counts = { 'backend/auth.py': 8, 'backend/models.py': 2, 'frontend/src/api.js': 0 }
+    render(<FileTree paths={PATHS} counts={counts} />)
+
+    const api = screen.getByText('api.js')
+    expect(api).not.toHaveClass('heat')
+    expect(api.style.getPropertyValue('--heat-intensity')).toBe('')
+  })
+
+  it('colors a directory by its aggregated descendant count', () => {
+    const counts = { 'backend/auth.py': 8, 'backend/models.py': 2, 'frontend/src/api.js': 0 }
+    render(<FileTree paths={PATHS} counts={counts} />)
+
+    const backend = screen.getByRole('button', { name: /backend/ })
+    const src = screen.getByRole('button', { name: /src/ })
+    expect(backend).toHaveClass('heat')
+    expect(src).not.toHaveClass('heat')
+  })
 })

--- a/frontend/src/library/IndexProgress.jsx
+++ b/frontend/src/library/IndexProgress.jsx
@@ -5,15 +5,22 @@ import { relativeDate } from '../lib/sourceFormat.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
 import RetryButton from './RetryButton.jsx'
 
+const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000
+
+function isStale(indexedAt) {
+  return Date.now() - new Date(indexedAt).getTime() > STALE_THRESHOLD_MS
+}
+
 const PHASE_LABELS = {
   queued: () => 'Queued…',
   fetching: (counts) => `Reading commits — ${counts.fetched} examined`,
   extracting: (counts) => `Extracting decisions — ${counts.extracted} recorded of ${counts.fetched}`,
   embedding: (counts) => `Embedding ${counts.extracted} decisions…`,
-  done: (counts, indexedAt) =>
-    indexedAt
-      ? `Indexed ${counts.stored} decisions · indexed ${relativeDate(indexedAt)}`
-      : `Indexed ${counts.stored} decisions`,
+  done: (counts, indexedAt) => {
+    if (!indexedAt) return `Indexed ${counts.stored} decisions`
+    const label = `Indexed ${counts.stored} decisions · indexed ${relativeDate(indexedAt)}`
+    return isStale(indexedAt) ? `${label} · consider re-indexing` : label
+  },
 }
 
 function extractProgressPercent(counts) {

--- a/frontend/src/library/IndexProgress.jsx
+++ b/frontend/src/library/IndexProgress.jsx
@@ -1,6 +1,7 @@
 // Per-repo ingestion progress line, reused verbatim by Onboarding's Step
 // 3 and the Library page (UI-DESIGN.md). Presentational only — reads the
 // shared useIngestStatus poller, no local polling of its own.
+import { relativeDate } from '../lib/sourceFormat.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
 import RetryButton from './RetryButton.jsx'
 
@@ -9,7 +10,10 @@ const PHASE_LABELS = {
   fetching: (counts) => `Reading commits — ${counts.fetched} examined`,
   extracting: (counts) => `Extracting decisions — ${counts.extracted} recorded of ${counts.fetched}`,
   embedding: (counts) => `Embedding ${counts.extracted} decisions…`,
-  done: (counts) => `Indexed ${counts.stored} decisions`,
+  done: (counts, indexedAt) =>
+    indexedAt
+      ? `Indexed ${counts.stored} decisions · indexed ${relativeDate(indexedAt)}`
+      : `Indexed ${counts.stored} decisions`,
 }
 
 function extractProgressPercent(counts) {
@@ -17,7 +21,7 @@ function extractProgressPercent(counts) {
   return Math.min(100, (counts.extracted / counts.fetched) * 100)
 }
 
-function IndexProgress({ repo }) {
+function IndexProgress({ repo, indexedAt = null }) {
   const { status, refetch } = useIngestStatus()
   const repoState = status?.repos.find((r) => r.repo === repo)
 
@@ -37,7 +41,7 @@ function IndexProgress({ repo }) {
   return (
     <div>
       <p className="text-sm text-ink-muted" role="status">
-        {PHASE_LABELS[repoState.phase](repoState.counts)}
+        {PHASE_LABELS[repoState.phase](repoState.counts, indexedAt)}
       </p>
       {repoState.phase === 'extracting' && (
         <div className="h-1 rounded bg-surface">

--- a/frontend/src/library/IndexProgress.test.jsx
+++ b/frontend/src/library/IndexProgress.test.jsx
@@ -73,6 +73,19 @@ describe('IndexProgress', () => {
     expect(screen.getByText('Indexed 37 decisions')).toBeInTheDocument()
   })
 
+  it('includes a relative time string in the done label when indexed_at is known', () => {
+    mockStatus({ repo: 'owner/repo', phase: 'done', counts: { fetched: 214, extracted: 37, skipped: 5, stored: 37 } })
+    const indexedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+    render(<IndexProgress repo="owner/repo" indexedAt={indexedAt} />)
+    expect(screen.getByText('Indexed 37 decisions · indexed 2 days ago')).toBeInTheDocument()
+  })
+
+  it('falls back to the count-only done label when indexed_at is null', () => {
+    mockStatus({ repo: 'owner/repo', phase: 'done', counts: { fetched: 214, extracted: 37, skipped: 5, stored: 37 } })
+    render(<IndexProgress repo="owner/repo" indexedAt={null} />)
+    expect(screen.getByText('Indexed 37 decisions')).toBeInTheDocument()
+  })
+
   it('renders the failed state with the server error message', () => {
     mockStatus({
       repo: 'owner/repo',

--- a/frontend/src/library/IndexProgress.test.jsx
+++ b/frontend/src/library/IndexProgress.test.jsx
@@ -86,6 +86,20 @@ describe('IndexProgress', () => {
     expect(screen.getByText('Indexed 37 decisions')).toBeInTheDocument()
   })
 
+  it('appends a stale marker when indexed_at is more than 30 days ago', () => {
+    mockStatus({ repo: 'owner/repo', phase: 'done', counts: { fetched: 214, extracted: 37, skipped: 5, stored: 37 } })
+    const indexedAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString()
+    render(<IndexProgress repo="owner/repo" indexedAt={indexedAt} />)
+    expect(screen.getByText('Indexed 37 decisions · indexed last month · consider re-indexing')).toBeInTheDocument()
+  })
+
+  it('does not append a stale marker when indexed_at is under 30 days ago', () => {
+    mockStatus({ repo: 'owner/repo', phase: 'done', counts: { fetched: 214, extracted: 37, skipped: 5, stored: 37 } })
+    const indexedAt = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000).toISOString()
+    render(<IndexProgress repo="owner/repo" indexedAt={indexedAt} />)
+    expect(screen.getByText('Indexed 37 decisions · indexed 4 weeks ago')).toBeInTheDocument()
+  })
+
   it('renders the failed state with the server error message', () => {
     mockStatus({
       repo: 'owner/repo',

--- a/frontend/src/library/LibraryPage.jsx
+++ b/frontend/src/library/LibraryPage.jsx
@@ -66,10 +66,24 @@ function LibraryPage() {
       )}
 
       {repos === 'error' && (
-        <p className="mt-4 text-sm text-danger">Couldn't load the library.</p>
+        <div className="mt-4 flex items-center gap-3">
+          <p className="text-sm text-danger">Couldn't load the library.</p>
+          <button type="button" onClick={refresh} className="text-sm text-ink-muted underline">
+            Retry
+          </button>
+        </div>
       )}
       {Array.isArray(repos) && repos.length === 0 && (
-        <p className="mt-4 font-reading text-ink">Nothing in the library yet.</p>
+        <div className="mt-4">
+          <p className="font-reading text-ink">Nothing in the library yet.</p>
+          <button
+            type="button"
+            onClick={() => setShowAddPanel(true)}
+            className="mt-2 text-sm text-ink-muted underline"
+          >
+            Add repos to get started.
+          </button>
+        </div>
       )}
       {Array.isArray(repos) && repos.length > 0 && (
         <div className="mt-4 flex flex-col gap-4">

--- a/frontend/src/library/LibraryPage.jsx
+++ b/frontend/src/library/LibraryPage.jsx
@@ -2,7 +2,7 @@
 // indexed-unit counts from GET /repos, plus Add repos (opens
 // AddReposPanel) and per-row Remove (#80).
 import { useEffect, useState } from 'react'
-import { getRepos, patchConfig } from '../api.js'
+import { getRepos, patchConfig, postIngest } from '../api.js'
 import AddReposPanel from './AddReposPanel.jsx'
 import RepoRow from './RepoRow.jsx'
 
@@ -34,6 +34,11 @@ function LibraryPage() {
     const remaining = repos.filter((repo) => repo.repo !== repoName)
     await patchConfig({ indexed_repos: remaining.map((repo) => repo.repo) })
     setRepos(remaining)
+  }
+
+  async function handleReindex(repoName) {
+    await postIngest({ repos: [repoName] })
+    refresh()
   }
 
   return (
@@ -69,7 +74,7 @@ function LibraryPage() {
       {Array.isArray(repos) && repos.length > 0 && (
         <div className="mt-4 flex flex-col gap-4">
           {repos.map((repo) => (
-            <RepoRow key={repo.repo} repo={repo} onRemove={handleRemove} />
+            <RepoRow key={repo.repo} repo={repo} onRemove={handleRemove} onReindex={handleReindex} />
           ))}
         </div>
       )}

--- a/frontend/src/library/LibraryPage.test.jsx
+++ b/frontend/src/library/LibraryPage.test.jsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getRepos, patchConfig } from '../api.js'
+import { getRepos, patchConfig, postIngest } from '../api.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
 import LibraryPage from './LibraryPage.jsx'
 
@@ -94,5 +94,20 @@ describe('LibraryPage', () => {
     expect(patchConfig).toHaveBeenCalledWith({ indexed_repos: ['owner/repo-b'] })
     expect(screen.queryByText('owner/repo-a')).not.toBeInTheDocument()
     expect(screen.getByText('owner/repo-b')).toBeInTheDocument()
+  })
+
+  it('re-indexing a repo calls POST /ingest with that repo and refreshes the list', async () => {
+    getRepos.mockResolvedValue(REPOS)
+    postIngest.mockResolvedValue({})
+    useIngestStatus.mockReturnValue({ status: { active: false, repos: [] }, refetch: vi.fn() })
+
+    render(<LibraryPage />)
+    await screen.findByText('owner/repo-a')
+
+    const [reindexA] = screen.getAllByRole('button', { name: 'Re-index' })
+    fireEvent.click(reindexA)
+
+    await vi.waitFor(() => expect(postIngest).toHaveBeenCalledWith({ repos: ['owner/repo-a'] }))
+    expect(getRepos).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/library/LibraryPage.test.jsx
+++ b/frontend/src/library/LibraryPage.test.jsx
@@ -28,7 +28,7 @@ describe('LibraryPage', () => {
     expect(await screen.findByText('owner/repo-a')).toBeInTheDocument()
     expect(screen.getByText('12 decisions')).toBeInTheDocument()
     expect(screen.getByText('owner/repo-b')).toBeInTheDocument()
-    expect(screen.getByText('0 decisions')).toBeInTheDocument()
+    expect(screen.getByText(/No decisions extracted yet/)).toBeInTheDocument()
   })
 
   it('shows the empty-library prompt when there are no repos', async () => {
@@ -62,7 +62,7 @@ describe('LibraryPage', () => {
     render(<LibraryPage />)
 
     expect(await screen.findByText('Embedding 12 decisions…')).toBeInTheDocument()
-    expect(screen.getByText('0 decisions')).toBeInTheDocument()
+    expect(screen.getByText(/No decisions extracted yet/)).toBeInTheDocument()
   })
 
   it('opens the AddReposPanel from the Add repos button', async () => {

--- a/frontend/src/library/LibraryPage.test.jsx
+++ b/frontend/src/library/LibraryPage.test.jsx
@@ -49,6 +49,33 @@ describe('LibraryPage', () => {
     expect(await screen.findByText("Couldn't load the library.")).toBeInTheDocument()
   })
 
+  it('retrying after an error re-fetches and renders the repos', async () => {
+    getRepos.mockRejectedValueOnce(new Error('network error'))
+    getRepos.mockResolvedValueOnce(REPOS)
+    useIngestStatus.mockReturnValue({ status: { active: false, repos: [] }, refetch: vi.fn() })
+
+    render(<LibraryPage />)
+    await screen.findByText("Couldn't load the library.")
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('owner/repo-a')).toBeInTheDocument()
+    expect(screen.queryByText("Couldn't load the library.")).not.toBeInTheDocument()
+    expect(getRepos).toHaveBeenCalledTimes(2)
+  })
+
+  it('the empty-library prompt links to the Add repos action', async () => {
+    getRepos.mockResolvedValue({ repos: [] })
+    useIngestStatus.mockReturnValue({ status: { active: false, repos: [] }, refetch: vi.fn() })
+
+    render(<LibraryPage />)
+    await screen.findByText('Nothing in the library yet.')
+
+    expect(screen.queryByRole('heading', { name: 'Add repos' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add repos to get started.' }))
+    expect(screen.getByRole('heading', { name: 'Add repos' })).toBeInTheDocument()
+  })
+
   it('shows a row with live IndexProgress when that repo has an active job', async () => {
     getRepos.mockResolvedValue(REPOS)
     useIngestStatus.mockReturnValue({

--- a/frontend/src/library/RepoRow.jsx
+++ b/frontend/src/library/RepoRow.jsx
@@ -4,6 +4,7 @@
 // for inline confirmation (no modal, per UI-DESIGN.md) before calling the
 // onRemove callback LibraryPage supplies.
 import { useState } from 'react'
+import { patchRepo } from '../api.js'
 import InlineConfirm from '../components/InlineConfirm.jsx'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
 import IndexProgress from './IndexProgress.jsx'
@@ -21,6 +22,24 @@ function RepoRow({ repo, onRemove, onReindex }) {
   const [error, setError] = useState(null)
   const [reindexing, setReindexing] = useState(false)
   const [reindexError, setReindexError] = useState(null)
+  const [cloudAllowed, setCloudAllowed] = useState(repo.cloud_synthesis_allowed ?? true)
+  const [toggling, setToggling] = useState(false)
+  const [toggleError, setToggleError] = useState(null)
+
+  async function handleToggleCloud() {
+    const next = !cloudAllowed
+    setToggling(true)
+    setToggleError(null)
+    setCloudAllowed(next)
+    try {
+      await patchRepo(repo.repo, { cloud_synthesis_allowed: next })
+    } catch {
+      setCloudAllowed(!next)
+      setToggleError("Couldn't update cloud synthesis setting.")
+    } finally {
+      setToggling(false)
+    }
+  }
 
   async function handleConfirmRemove() {
     setRemoving(true)
@@ -72,6 +91,16 @@ function RepoRow({ repo, onRemove, onReindex }) {
         <div className="flex items-center gap-3 shrink-0 sm:order-3">
           <button
             type="button"
+            role="switch"
+            aria-checked={cloudAllowed}
+            onClick={handleToggleCloud}
+            disabled={toggling}
+            className="text-sm text-ink-muted disabled:opacity-50"
+          >
+            {cloudAllowed ? 'Cloud synthesis: on' : 'Cloud synthesis: off'}
+          </button>
+          <button
+            type="button"
             onClick={handleReindex}
             disabled={reindexing}
             className="text-sm text-ink-muted disabled:opacity-50"
@@ -99,6 +128,11 @@ function RepoRow({ repo, onRemove, onReindex }) {
         {reindexError && (
           <p role="alert" className="text-sm text-danger">
             {reindexError}
+          </p>
+        )}
+        {toggleError && (
+          <p role="alert" className="text-sm text-danger">
+            {toggleError}
           </p>
         )}
       </div>

--- a/frontend/src/library/RepoRow.jsx
+++ b/frontend/src/library/RepoRow.jsx
@@ -65,7 +65,7 @@ function RepoRow({ repo, onRemove }) {
       </div>
       <div className="sm:order-2">
         {active ? (
-          <IndexProgress repo={repo.repo} />
+          <IndexProgress repo={repo.repo} indexedAt={repo.indexed_at} />
         ) : (
           <p className="text-sm text-ink-muted">
             {repo.indexed_units} {repo.indexed_units === 1 ? 'decision' : 'decisions'}

--- a/frontend/src/library/RepoRow.jsx
+++ b/frontend/src/library/RepoRow.jsx
@@ -13,12 +13,14 @@ function hasActiveJob(status, repo) {
   return repoState != null && repoState.phase !== 'done' && repoState.phase !== 'failed'
 }
 
-function RepoRow({ repo, onRemove }) {
+function RepoRow({ repo, onRemove, onReindex }) {
   const { status } = useIngestStatus()
   const active = hasActiveJob(status, repo.repo)
   const [confirming, setConfirming] = useState(false)
   const [removing, setRemoving] = useState(false)
   const [error, setError] = useState(null)
+  const [reindexing, setReindexing] = useState(false)
+  const [reindexError, setReindexError] = useState(null)
 
   async function handleConfirmRemove() {
     setRemoving(true)
@@ -28,6 +30,18 @@ function RepoRow({ repo, onRemove }) {
     } catch {
       setError("Couldn't remove this repo.")
       setRemoving(false)
+    }
+  }
+
+  async function handleReindex() {
+    setReindexing(true)
+    setReindexError(null)
+    try {
+      await onReindex(repo.repo)
+    } catch {
+      setReindexError("Couldn't start re-indexing.")
+    } finally {
+      setReindexing(false)
     }
   }
 
@@ -55,13 +69,19 @@ function RepoRow({ repo, onRemove }) {
     <div className="bg-panel rounded-xl p-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <div className="flex items-center justify-between gap-4 sm:contents">
         <span className="font-mono text-sm text-ink truncate min-w-0">{repo.repo}</span>
-        <button
-          type="button"
-          onClick={() => setConfirming(true)}
-          className="text-sm text-ink-muted shrink-0 sm:order-3"
-        >
-          Remove
-        </button>
+        <div className="flex items-center gap-3 shrink-0 sm:order-3">
+          <button
+            type="button"
+            onClick={handleReindex}
+            disabled={reindexing}
+            className="text-sm text-ink-muted disabled:opacity-50"
+          >
+            {reindexing ? 'Re-indexing…' : 'Re-index'}
+          </button>
+          <button type="button" onClick={() => setConfirming(true)} className="text-sm text-ink-muted">
+            Remove
+          </button>
+        </div>
       </div>
       <div className="sm:order-2">
         {active ? (
@@ -69,6 +89,11 @@ function RepoRow({ repo, onRemove }) {
         ) : (
           <p className="text-sm text-ink-muted">
             {repo.indexed_units} {repo.indexed_units === 1 ? 'decision' : 'decisions'}
+          </p>
+        )}
+        {reindexError && (
+          <p role="alert" className="text-sm text-danger">
+            {reindexError}
           </p>
         )}
       </div>

--- a/frontend/src/library/RepoRow.jsx
+++ b/frontend/src/library/RepoRow.jsx
@@ -86,6 +86,11 @@ function RepoRow({ repo, onRemove, onReindex }) {
       <div className="sm:order-2">
         {active ? (
           <IndexProgress repo={repo.repo} indexedAt={repo.indexed_at} />
+        ) : repo.indexed_units === 0 ? (
+          <p className="text-sm text-ink-muted">
+            No decisions extracted yet — commits may be too terse for extraction to find a decision, or try Re-index
+            if this seems wrong
+          </p>
         ) : (
           <p className="text-sm text-ink-muted">
             {repo.indexed_units} {repo.indexed_units === 1 ? 'decision' : 'decisions'}

--- a/frontend/src/library/RepoRow.test.jsx
+++ b/frontend/src/library/RepoRow.test.jsx
@@ -42,6 +42,26 @@ describe('RepoRow', () => {
     expect(screen.queryByText('42 decisions')).not.toBeInTheDocument()
   })
 
+  it('shows a zero-decision explanation instead of a bare "0 decisions" when idle', () => {
+    mockStatus(null)
+    render(<RepoRow repo={{ repo: 'owner/repo', indexed_units: 0 }} />)
+
+    expect(screen.getByText(/No decisions extracted yet/)).toBeInTheDocument()
+    expect(screen.queryByText('0 decisions')).not.toBeInTheDocument()
+  })
+
+  it('shows the live IndexProgress line, not the zero-decision explanation, while still indexing', () => {
+    mockStatus({
+      repo: 'owner/repo',
+      phase: 'fetching',
+      counts: { fetched: 5, extracted: 0, skipped: 0, stored: 0 },
+    })
+    render(<RepoRow repo={{ repo: 'owner/repo', indexed_units: 0 }} />)
+
+    expect(screen.getByText('Reading commits — 5 examined')).toBeInTheDocument()
+    expect(screen.queryByText(/No decisions extracted yet/)).not.toBeInTheDocument()
+  })
+
   it('falls back to the static count once the repo job is done', () => {
     mockStatus({
       repo: 'owner/repo',

--- a/frontend/src/library/RepoRow.test.jsx
+++ b/frontend/src/library/RepoRow.test.jsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import { patchRepo } from '../api.js'
 import { useIngestStatus } from '../lib/useIngestStatus.js'
 import RepoRow from './RepoRow.jsx'
 
 vi.mock('../lib/useIngestStatus.js', () => ({ useIngestStatus: vi.fn() }))
+vi.mock('../api.js', () => ({ patchRepo: vi.fn() }))
 
 const repo = { repo: 'owner/repo', indexed_units: 42 }
 
@@ -150,5 +152,41 @@ describe('RepoRow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Re-index' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't start re-indexing.")
+  })
+
+  it('reflects the initial cloud_synthesis_allowed value on render', () => {
+    mockStatus(null)
+    render(<RepoRow repo={{ ...repo, cloud_synthesis_allowed: false }} />)
+
+    expect(screen.getByRole('switch', { name: 'Cloud synthesis: off' })).toBeInTheDocument()
+  })
+
+  it('defaults the toggle to on when cloud_synthesis_allowed is absent', () => {
+    mockStatus(null)
+    render(<RepoRow repo={repo} />)
+
+    expect(screen.getByRole('switch', { name: 'Cloud synthesis: on' })).toBeInTheDocument()
+  })
+
+  it('toggling calls PATCH /repos/{repo} with the flipped value', async () => {
+    mockStatus(null)
+    patchRepo.mockResolvedValue({})
+    render(<RepoRow repo={{ ...repo, cloud_synthesis_allowed: true }} />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Cloud synthesis: on' }))
+
+    expect(patchRepo).toHaveBeenCalledWith('owner/repo', { cloud_synthesis_allowed: false })
+    expect(await screen.findByRole('switch', { name: 'Cloud synthesis: off' })).toBeInTheDocument()
+  })
+
+  it('reverts the toggle and shows an inline error when the PATCH fails', async () => {
+    mockStatus(null)
+    patchRepo.mockRejectedValue(new Error('network error'))
+    render(<RepoRow repo={{ ...repo, cloud_synthesis_allowed: true }} />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Cloud synthesis: on' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't update cloud synthesis setting.")
+    expect(screen.getByRole('switch', { name: 'Cloud synthesis: on' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/library/RepoRow.test.jsx
+++ b/frontend/src/library/RepoRow.test.jsx
@@ -111,4 +111,24 @@ describe('RepoRow', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't remove this repo.")
   })
+
+  it('calls onReindex with the repo name when Re-index is clicked', async () => {
+    mockStatus(null)
+    const onReindex = vi.fn().mockResolvedValue()
+    render(<RepoRow repo={repo} onReindex={onReindex} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-index' }))
+
+    expect(onReindex).toHaveBeenCalledWith('owner/repo')
+  })
+
+  it('shows an inline error when onReindex fails', async () => {
+    mockStatus(null)
+    const onReindex = vi.fn().mockRejectedValue(new Error('network error'))
+    render(<RepoRow repo={repo} onReindex={onReindex} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-index' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't start re-indexing.")
+  })
 })

--- a/frontend/src/settings/DataSection.jsx
+++ b/frontend/src/settings/DataSection.jsx
@@ -83,7 +83,7 @@ function DataSection() {
           {confirming && (
             <div className="mt-2 flex items-center justify-between gap-4">
               <InlineConfirm
-                message="Clear the index? This cannot be undone."
+                message={`Clear ${decisionCount ?? 0} indexed decisions? This cannot be undone.`}
                 confirmLabel="Clear index"
                 onConfirm={handleClear}
                 onCancel={() => setConfirming(false)}

--- a/frontend/src/settings/DataSection.jsx
+++ b/frontend/src/settings/DataSection.jsx
@@ -1,14 +1,13 @@
-// Settings' Data section (UI-DESIGN.md): read-only index location and
-// a full-wipe "Clear index" action (destructive, inline confirm — same
-// pattern as GitHubSection/GeminiSection/RepoRow). Decision count (also
-// named in UI-DESIGN.md's Data row) is deliberately not shown — no such
-// field exists in ConfigResponse yet; tracked as a follow-up in #95.
+// Settings' Data section (UI-DESIGN.md): read-only index location, the
+// total decision count, and a full-wipe "Clear index" action (destructive,
+// inline confirm — same pattern as GitHubSection/GeminiSection/RepoRow).
 import { useEffect, useState } from 'react'
 import InlineConfirm from '../components/InlineConfirm.jsx'
 import { clearIndex, getConfig } from '../api.js'
 
 function DataSection() {
   const [dataDir, setDataDir] = useState(undefined)
+  const [decisionCount, setDecisionCount] = useState(undefined)
   const [confirming, setConfirming] = useState(false)
   const [clearing, setClearing] = useState(false)
   const [cleared, setCleared] = useState(false)
@@ -19,10 +18,16 @@ function DataSection() {
 
     getConfig()
       .then((result) => {
-        if (!cancelled) setDataDir(result.chroma_data_dir)
+        if (!cancelled) {
+          setDataDir(result.chroma_data_dir)
+          setDecisionCount(result.decision_count)
+        }
       })
       .catch(() => {
-        if (!cancelled) setDataDir(null)
+        if (!cancelled) {
+          setDataDir(null)
+          setDecisionCount(null)
+        }
       })
 
     return () => {
@@ -57,6 +62,12 @@ function DataSection() {
       {dataDir !== undefined && (
         <>
           {dataDir && <p className="mt-1 font-mono text-sm text-ink-muted">{dataDir}</p>}
+
+          {decisionCount != null && (
+            <p className="mt-1 text-sm text-ink-muted">
+              {decisionCount} indexed decision{decisionCount === 1 ? '' : 's'}
+            </p>
+          )}
 
           {!confirming && (
             <button

--- a/frontend/src/settings/DataSection.test.jsx
+++ b/frontend/src/settings/DataSection.test.jsx
@@ -45,7 +45,7 @@ describe('DataSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear index' }))
     expect(clearIndex).not.toHaveBeenCalled()
-    expect(screen.getByText(/Clear the index\?/)).toBeInTheDocument()
+    expect(screen.getByText('Clear 42 indexed decisions? This cannot be undone.')).toBeInTheDocument()
   })
 
   it('confirming calls DELETE /repos and shows a cleared message', async () => {
@@ -72,7 +72,9 @@ describe('DataSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(clearIndex).not.toHaveBeenCalled()
-    expect(screen.queryByText(/Clear the index\?/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Clear 42 indexed decisions? This cannot be undone.'),
+    ).not.toBeInTheDocument()
   })
 
   it('shows an inline error when clearing fails', async () => {

--- a/frontend/src/settings/DataSection.test.jsx
+++ b/frontend/src/settings/DataSection.test.jsx
@@ -11,15 +11,34 @@ afterEach(() => {
 
 describe('DataSection', () => {
   it('renders the index location from config', async () => {
-    getConfig.mockResolvedValue({ chroma_data_dir: '/home/user/.adr-engine/chroma' })
+    getConfig.mockResolvedValue({
+      chroma_data_dir: '/home/user/.adr-engine/chroma',
+      decision_count: 42,
+    })
 
     render(<DataSection />)
 
     expect(await screen.findByText('/home/user/.adr-engine/chroma')).toBeInTheDocument()
   })
 
+  it('renders the total decision count from config', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 42 })
+
+    render(<DataSection />)
+
+    expect(await screen.findByText('42 indexed decisions')).toBeInTheDocument()
+  })
+
+  it('uses singular copy for a single indexed decision', async () => {
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 1 })
+
+    render(<DataSection />)
+
+    expect(await screen.findByText('1 indexed decision')).toBeInTheDocument()
+  })
+
   it('requires confirmation before calling the clear-index API', async () => {
-    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 42 })
 
     render(<DataSection />)
     await screen.findByText('/data')
@@ -30,7 +49,7 @@ describe('DataSection', () => {
   })
 
   it('confirming calls DELETE /repos and shows a cleared message', async () => {
-    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 42 })
     clearIndex.mockResolvedValue(null)
 
     render(<DataSection />)
@@ -44,7 +63,7 @@ describe('DataSection', () => {
   })
 
   it('cancel dismisses the confirmation without calling the API', async () => {
-    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 42 })
 
     render(<DataSection />)
     await screen.findByText('/data')
@@ -57,7 +76,7 @@ describe('DataSection', () => {
   })
 
   it('shows an inline error when clearing fails', async () => {
-    getConfig.mockResolvedValue({ chroma_data_dir: '/data' })
+    getConfig.mockResolvedValue({ chroma_data_dir: '/data', decision_count: 42 })
     clearIndex.mockRejectedValue(new Error('boom'))
 
     render(<DataSection />)

--- a/frontend/src/settings/GeminiSection.jsx
+++ b/frontend/src/settings/GeminiSection.jsx
@@ -2,19 +2,12 @@
 // existing key, an input to set/update it, and a remove action (inline
 // confirm — same pattern as GitHubSection/RepoRow).
 //
-// UI-DESIGN.md's Settings table calls for a live "1-token ping" to
-// Gemini on save ("Key rejected by Gemini" / "✓ Synthesized answers
-// on"). Issue #82's own scope explicitly rules this out ("Live Gemini
-// API key verification (out of scope everywhere per SYSTEM-DESIGN.md —
-// PATCH validates format only, not by calling Gemini)") — the two docs
-// disagree. Following the issue's explicit scope (and SYSTEM-DESIGN.md's
-// broader "no live verification" policy) rather than silently making a
-// real external API call during every key save; only cheap PATCH-side
-// format validation happens here. Flagging for a docs reconciliation
-// rather than resolving it unilaterally in either direction.
+// Live "1-token ping" validation on save reinstated per
+// docs/superpowers/specs/2026-08-04-v2-design.md decision 9, resolving
+// the docs/#82 disagreement in UI-DESIGN.md's favor.
 import { useEffect, useState } from 'react'
 import InlineConfirm from '../components/InlineConfirm.jsx'
-import { getConfig, patchConfig } from '../api.js'
+import { getConfig, patchConfig, validateGemini } from '../api.js'
 
 function GeminiSection() {
   const [existingMasked, setExistingMasked] = useState(undefined)
@@ -22,6 +15,7 @@ function GeminiSection() {
   const [saving, setSaving] = useState(false)
   const [removing, setRemoving] = useState(false)
   const [confirmingRemove, setConfirmingRemove] = useState(false)
+  const [validation, setValidation] = useState(null)
   const [error, setError] = useState(null)
 
   useEffect(() => {
@@ -42,11 +36,18 @@ function GeminiSection() {
 
   async function handleSave() {
     setSaving(true)
+    setValidation(null)
     setError(null)
     try {
       const result = await patchConfig({ gemini_api_key: key })
       setExistingMasked(result.gemini_api_key)
       setKey('')
+      try {
+        const outcome = await validateGemini()
+        setValidation(outcome.ok ? { ok: true } : { ok: false, message: 'Key rejected by Gemini' })
+      } catch {
+        setValidation({ ok: false, message: 'Could not reach the backend to validate the key.' })
+      }
     } catch {
       setError('Could not save the key. Check it and try again.')
     } finally {
@@ -56,6 +57,7 @@ function GeminiSection() {
 
   async function handleRemove() {
     setRemoving(true)
+    setValidation(null)
     setError(null)
     try {
       await patchConfig({ gemini_api_key: null })
@@ -120,6 +122,18 @@ function GeminiSection() {
                 Save
               </button>
             </div>
+          )}
+
+          {validation?.ok && (
+            <p role="status" className="mt-2 text-sm text-ink-muted">
+              ✓ Synthesized answers on
+            </p>
+          )}
+
+          {validation && !validation.ok && (
+            <p role="alert" className="mt-2 text-sm text-danger">
+              {validation.message}
+            </p>
           )}
 
           {error && (

--- a/frontend/src/settings/GeminiSection.test.jsx
+++ b/frontend/src/settings/GeminiSection.test.jsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getConfig, patchConfig } from '../api.js'
+import { getConfig, patchConfig, validateGemini } from '../api.js'
 import GeminiSection from './GeminiSection.jsx'
 
-vi.mock('../api.js', () => ({ getConfig: vi.fn(), patchConfig: vi.fn() }))
+vi.mock('../api.js', () => ({ getConfig: vi.fn(), patchConfig: vi.fn(), validateGemini: vi.fn() }))
 
 afterEach(() => {
   vi.resetAllMocks()
@@ -31,6 +31,7 @@ describe('GeminiSection', () => {
   it('save calls PATCH /config with the new key', async () => {
     getConfig.mockResolvedValue({ gemini_api_key: null })
     patchConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef' })
+    validateGemini.mockResolvedValue({ ok: true, detail: null })
 
     render(<GeminiSection />)
     await screen.findByLabelText('Gemini API key')
@@ -40,6 +41,35 @@ describe('GeminiSection', () => {
 
     expect(patchConfig).toHaveBeenCalledWith({ gemini_api_key: 'sk-test-123' })
     expect(await screen.findByText('gk_1…cdef')).toBeInTheDocument()
+  })
+
+  it('save pings Gemini and shows the synthesized-answers state on a valid key', async () => {
+    getConfig.mockResolvedValue({ gemini_api_key: null })
+    patchConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef' })
+    validateGemini.mockResolvedValue({ ok: true, detail: null })
+
+    render(<GeminiSection />)
+    await screen.findByLabelText('Gemini API key')
+
+    fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-test-123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('✓ Synthesized answers on')).toBeInTheDocument()
+    expect(validateGemini).toHaveBeenCalled()
+  })
+
+  it('save pings Gemini and shows the rejected-key state from the endpoint response', async () => {
+    getConfig.mockResolvedValue({ gemini_api_key: null })
+    patchConfig.mockResolvedValue({ gemini_api_key: 'gk_1…cdef' })
+    validateGemini.mockResolvedValue({ ok: false, detail: 'Gemini returned 401' })
+
+    render(<GeminiSection />)
+    await screen.findByLabelText('Gemini API key')
+
+    fireEvent.change(screen.getByLabelText('Gemini API key'), { target: { value: 'sk-bad-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Key rejected by Gemini')
   })
 
   it('shows an inline error when the save fails', async () => {

--- a/frontend/src/settings/ModelsSection.jsx
+++ b/frontend/src/settings/ModelsSection.jsx
@@ -1,15 +1,9 @@
 // Settings' Models section (UI-DESIGN.md): Ollama host and model name
-// inputs, saved together via a single PATCH /config.
-//
-// UI-DESIGN.md calls for save to ping Ollama's `/api/tags` to validate
-// host/model reachability. Issue #83 explicitly rules this out ("Skip
-// adding a new Ollama-health backend endpoint... flag as a follow-up if
-// a live check turns out to be genuinely needed") — same doc/issue
-// disagreement as GeminiSection's live-verification note, resolved the
-// same way: follow the issue's explicit scope, PATCH-only, no live
-// Ollama check.
+// inputs, saved together via a single PATCH /config, followed by a live
+// validation ping (POST /config/validate-ollama) per
+// docs/superpowers/specs/2026-08-04-v2-design.md decision 9.
 import { useEffect, useState } from 'react'
-import { getConfig, patchConfig } from '../api.js'
+import { getConfig, patchConfig, validateOllama } from '../api.js'
 
 function ModelsSection() {
   const [loaded, setLoaded] = useState(false)
@@ -18,6 +12,7 @@ function ModelsSection() {
   const [embeddingModel, setEmbeddingModel] = useState('')
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
+  const [validation, setValidation] = useState(null)
   const [error, setError] = useState(null)
 
   useEffect(() => {
@@ -43,6 +38,7 @@ function ModelsSection() {
   async function handleSave() {
     setSaving(true)
     setSaved(false)
+    setValidation(null)
     setError(null)
     try {
       await patchConfig({
@@ -51,6 +47,11 @@ function ModelsSection() {
         ollama_embedding_model: embeddingModel,
       })
       setSaved(true)
+      try {
+        setValidation(await validateOllama())
+      } catch {
+        setValidation({ ok: false, detail: 'Could not reach the backend to validate Ollama.' })
+      }
     } catch {
       setError('Could not save model settings. Check them and try again.')
     } finally {
@@ -120,6 +121,18 @@ function ModelsSection() {
               </span>
             )}
           </div>
+
+          {validation?.ok && (
+            <p role="status" className="mt-2 text-sm text-ink-muted">
+              ✓ Reachable
+            </p>
+          )}
+
+          {validation && !validation.ok && (
+            <p role="alert" className="mt-2 text-sm text-danger">
+              {validation.detail}
+            </p>
+          )}
 
           {error && (
             <p role="alert" className="mt-2 text-sm text-danger">

--- a/frontend/src/settings/ModelsSection.jsx
+++ b/frontend/src/settings/ModelsSection.jsx
@@ -70,37 +70,40 @@ function ModelsSection() {
 
       {loaded && (
         <>
-          <div className="mt-2 flex flex-col gap-3">
-            <label className="flex flex-col gap-1 text-sm text-ink-muted">
-              Ollama host
-              <input
-                type="text"
-                value={host}
-                onChange={(event) => setHost(event.target.value)}
-                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm text-ink-muted">
-              Extraction model
-              <input
-                type="text"
-                value={extractionModel}
-                onChange={(event) => setExtractionModel(event.target.value)}
-                placeholder="phi4-mini (default)"
-                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm text-ink-muted">
-              Embedding model
-              <input
-                type="text"
-                value={embeddingModel}
-                onChange={(event) => setEmbeddingModel(event.target.value)}
-                placeholder="nomic-embed-text (default)"
-                className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
-              />
-            </label>
-          </div>
+          <details className="mt-2">
+            <summary className="cursor-pointer font-ui text-sm text-ink-muted hover:text-ink">Advanced</summary>
+            <div className="mt-2 flex flex-col gap-3">
+              <label className="flex flex-col gap-1 text-sm text-ink-muted">
+                Ollama host
+                <input
+                  type="text"
+                  value={host}
+                  onChange={(event) => setHost(event.target.value)}
+                  className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-ink-muted">
+                Extraction model
+                <input
+                  type="text"
+                  value={extractionModel}
+                  onChange={(event) => setExtractionModel(event.target.value)}
+                  placeholder="phi4-mini (default)"
+                  className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-ink-muted">
+                Embedding model
+                <input
+                  type="text"
+                  value={embeddingModel}
+                  onChange={(event) => setEmbeddingModel(event.target.value)}
+                  placeholder="nomic-embed-text (default)"
+                  className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
+                />
+              </label>
+            </div>
+          </details>
 
           <div className="mt-3 flex items-center gap-4">
             <button

--- a/frontend/src/settings/ModelsSection.jsx
+++ b/frontend/src/settings/ModelsSection.jsx
@@ -86,6 +86,7 @@ function ModelsSection() {
                 type="text"
                 value={extractionModel}
                 onChange={(event) => setExtractionModel(event.target.value)}
+                placeholder="phi4-mini (default)"
                 className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
               />
             </label>
@@ -95,6 +96,7 @@ function ModelsSection() {
                 type="text"
                 value={embeddingModel}
                 onChange={(event) => setEmbeddingModel(event.target.value)}
+                placeholder="nomic-embed-text (default)"
                 className="font-mono rounded-lg border border-transparent bg-surface px-3 py-2 text-sm text-ink"
               />
             </label>

--- a/frontend/src/settings/ModelsSection.test.jsx
+++ b/frontend/src/settings/ModelsSection.test.jsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getConfig, patchConfig } from '../api.js'
+import { getConfig, patchConfig, validateOllama } from '../api.js'
 import ModelsSection from './ModelsSection.jsx'
 
-vi.mock('../api.js', () => ({ getConfig: vi.fn(), patchConfig: vi.fn() }))
+vi.mock('../api.js', () => ({ getConfig: vi.fn(), patchConfig: vi.fn(), validateOllama: vi.fn() }))
 
 afterEach(() => {
   vi.resetAllMocks()
@@ -31,6 +31,7 @@ describe('ModelsSection', () => {
       ollama_embedding_model: 'nomic-embed-text',
     })
     patchConfig.mockResolvedValue({})
+    validateOllama.mockResolvedValue({ ok: true, detail: null })
 
     render(<ModelsSection />)
     await screen.findByLabelText('Ollama host')
@@ -45,6 +46,46 @@ describe('ModelsSection', () => {
       ollama_embedding_model: 'nomic-embed-text',
     })
     expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
+  it('save pings Ollama and shows the reachable state on success', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    patchConfig.mockResolvedValue({})
+    validateOllama.mockResolvedValue({ ok: true, detail: null })
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('✓ Reachable')).toBeInTheDocument()
+    expect(validateOllama).toHaveBeenCalled()
+  })
+
+  it('save pings Ollama and shows the specific detail message on failure', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    patchConfig.mockResolvedValue({})
+    validateOllama.mockResolvedValue({
+      ok: false,
+      detail: 'model(s) not found on Ollama: llama3, nomic-embed-text',
+    })
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'model(s) not found on Ollama: llama3, nomic-embed-text',
+    )
   })
 
   it('shows the effective default as a placeholder, not a value, when models are unconfigured', async () => {
@@ -69,6 +110,7 @@ describe('ModelsSection', () => {
       ollama_embedding_model: null,
     })
     patchConfig.mockResolvedValue({})
+    validateOllama.mockResolvedValue({ ok: true, detail: null })
 
     render(<ModelsSection />)
     await screen.findByLabelText('Extraction model')
@@ -106,6 +148,7 @@ describe('ModelsSection', () => {
       ollama_embedding_model: 'nomic-embed-text',
     })
     patchConfig.mockResolvedValue({})
+    validateOllama.mockResolvedValue({ ok: true, detail: null })
 
     render(<ModelsSection />)
     await screen.findByLabelText('Ollama host')

--- a/frontend/src/settings/ModelsSection.test.jsx
+++ b/frontend/src/settings/ModelsSection.test.jsx
@@ -82,6 +82,46 @@ describe('ModelsSection', () => {
     })
   })
 
+  it('collapses the model inputs behind an Advanced disclosure by default, expandable on click', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    const details = screen.getByText('Advanced').closest('details')
+    expect(details).not.toHaveAttribute('open')
+
+    fireEvent.click(screen.getByText('Advanced'))
+    expect(details).toHaveAttribute('open')
+  })
+
+  it('save submits current field values even while the Advanced disclosure is collapsed', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    patchConfig.mockResolvedValue({})
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Ollama host')
+
+    expect(screen.getByText('Advanced').closest('details')).not.toHaveAttribute('open')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(patchConfig).toHaveBeenCalledWith({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: 'llama3',
+      ollama_embedding_model: 'nomic-embed-text',
+    })
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
   it('shows an inline error when the save fails', async () => {
     getConfig.mockResolvedValue({
       ollama_host: 'http://localhost:11434',

--- a/frontend/src/settings/ModelsSection.test.jsx
+++ b/frontend/src/settings/ModelsSection.test.jsx
@@ -47,6 +47,41 @@ describe('ModelsSection', () => {
     expect(await screen.findByText('Saved')).toBeInTheDocument()
   })
 
+  it('shows the effective default as a placeholder, not a value, when models are unconfigured', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: null,
+      ollama_embedding_model: null,
+    })
+
+    render(<ModelsSection />)
+
+    expect(await screen.findByLabelText('Extraction model')).toHaveValue('')
+    expect(screen.getByLabelText('Extraction model')).toHaveAttribute('placeholder', 'phi4-mini (default)')
+    expect(screen.getByLabelText('Embedding model')).toHaveValue('')
+    expect(screen.getByLabelText('Embedding model')).toHaveAttribute('placeholder', 'nomic-embed-text (default)')
+  })
+
+  it('saving without typing anything does not submit the placeholder text', async () => {
+    getConfig.mockResolvedValue({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: null,
+      ollama_embedding_model: null,
+    })
+    patchConfig.mockResolvedValue({})
+
+    render(<ModelsSection />)
+    await screen.findByLabelText('Extraction model')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(patchConfig).toHaveBeenCalledWith({
+      ollama_host: 'http://localhost:11434',
+      ollama_extraction_model: '',
+      ollama_embedding_model: '',
+    })
+  })
+
   it('shows an inline error when the save fails', async () => {
     getConfig.mockResolvedValue({
       ollama_host: 'http://localhost:11434',

--- a/frontend/src/shell/AppShell.jsx
+++ b/frontend/src/shell/AppShell.jsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom'
+import CommandPalette from '../components/CommandPalette.jsx'
 import TopNav from './TopNav.jsx'
 
 function AppShell() {
@@ -8,6 +9,7 @@ function AppShell() {
       <div className="flex-1 max-w-5xl mx-auto w-full">
         <Outlet />
       </div>
+      <CommandPalette />
     </div>
   )
 }

--- a/frontend/src/shell/AppShell.jsx
+++ b/frontend/src/shell/AppShell.jsx
@@ -1,15 +1,18 @@
 import { Outlet } from 'react-router-dom'
 import CommandPalette from '../components/CommandPalette.jsx'
+import useReadingPreferences from '../lib/useReadingPreferences.js'
 import TopNav from './TopNav.jsx'
 
 function AppShell() {
+  const { focusMode, toggleFocusMode } = useReadingPreferences()
+
   return (
     <div className="min-h-svh bg-surface text-ink flex flex-col">
-      <TopNav />
+      {!focusMode && <TopNav />}
       <div className="flex-1 max-w-5xl mx-auto w-full">
         <Outlet />
       </div>
-      <CommandPalette />
+      <CommandPalette focusModeActive={focusMode} onToggleFocusMode={toggleFocusMode} />
     </div>
   )
 }

--- a/frontend/src/shell/AppShell.test.jsx
+++ b/frontend/src/shell/AppShell.test.jsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getIngestStatus } from '../api.js'
+import { IngestStatusProvider } from '../lib/useIngestStatus.js'
+import { NewQuestionProvider } from '../lib/useNewQuestion.js'
+import AppShell from './AppShell.jsx'
+
+vi.mock('../api.js', () => ({ getIngestStatus: vi.fn() }))
+
+function renderShell() {
+  return render(
+    <MemoryRouter>
+      <IngestStatusProvider>
+        <NewQuestionProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<div>Page content</div>} />
+            </Route>
+          </Routes>
+        </NewQuestionProvider>
+      </IngestStatusProvider>
+    </MemoryRouter>,
+  )
+}
+
+function openPalette() {
+  fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+}
+
+beforeEach(() => {
+  getIngestStatus.mockResolvedValue({ active: false, repos: [] })
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+  localStorage.clear()
+})
+
+describe('AppShell', () => {
+  it('renders TopNav by default', () => {
+    renderShell()
+
+    expect(screen.getByText('adr-engine')).toBeInTheDocument()
+  })
+
+  it('hides TopNav once focus mode is toggled on from the command palette', () => {
+    renderShell()
+
+    openPalette()
+    fireEvent.click(screen.getByRole('button', { name: 'Enter focus mode' }))
+
+    expect(screen.queryByText('adr-engine')).not.toBeInTheDocument()
+    expect(screen.getByText('Page content')).toBeInTheDocument()
+  })
+
+  it('shows TopNav again once focus mode is toggled back off', () => {
+    renderShell()
+
+    openPalette()
+    fireEvent.click(screen.getByRole('button', { name: 'Enter focus mode' }))
+    openPalette()
+    fireEvent.click(screen.getByRole('button', { name: 'Exit focus mode' }))
+
+    expect(screen.getByText('adr-engine')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/shell/TopNav.jsx
+++ b/frontend/src/shell/TopNav.jsx
@@ -48,7 +48,7 @@ function linkClassName({ isActive }) {
 
 function TopNav() {
   return (
-    <header className="h-14 shrink-0 bg-panel">
+    <header className="h-14 shrink-0 bg-panel print:hidden">
       <div className="max-w-5xl mx-auto h-full flex items-center justify-between px-4 lg:px-6">
         <span className="text-lg font-semibold">adr-engine</span>
         <nav className="flex items-center gap-4">


### PR DESCRIPTION
Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #131
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #141
Closes #142
Closes #143
Closes #144
Closes #146
Closes #147
Closes #148
Closes #149
Closes #150
Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158
Closes #159
Closes #160
Closes #161
Closes #162
Closes #163
Closes #164
Closes #165
Closes #166

## Changelog
- `eval.harness.main()` no longer requires a live Ollama instance: golden-question embeddings are read from a frozen `golden_question_embeddings.json` fixture instead of computed live, matching the module's own "no network call" docstring and ARCHITECTURE.md's CI testing constraints.
- `RepoInfo` gains `indexed_at`, set when a repo's ingestion job reaches phase `"done"` and surfaced on `GET /repos` and `PATCH /repos/{repo}`.
- `GET /config` gains `decision_count`, the sum of indexed decisions across every configured repo.
- `QueryResponse` gains `sent_to_cloud` and `cloud_synthesis_fields`, reporting exactly which `DecisionUnit` fields were sent to Gemini for a given answer (sourced from a single named constant in `synthesis/answer.py` so it can't drift from the real sender).
- New `POST /config/validate-gemini` and `POST /config/validate-ollama` endpoints run a real, minimal ping against the configured Gemini key and Ollama host/models, for use on explicit config save only.
- `AnswerPassage` now splits answers into paragraphs before parsing citation markers and renders one `<p>` per paragraph, laying the groundwork for margin citations while keeping marker numbering in first-appearance order across the whole answer.
- New `AnswerPage` component replaces chat-bubble rendering of assistant answers with an annotated page per question: the question as a heading, a provenance dek ("searched N repos · M decisions"), and the answer body.
- `AnswerPage` lays out a two-column margin citation grid from 900px up — a ~68ch reading column plus a right margin track holding each paragraph's cited `SourceCard`s beside it, narrower (180px) from 900-1280px and full width (260px) at >=1280px. `SourceCard` gains an optional `widthClassName` prop so margin instances fill their grid column instead of a fixed width.
- Below 900px, citations no longer batch into one stacked list at the foot of the answer — each paragraph's cited `SourceCard`s now collapse inline, directly after that paragraph, in real document order.
- Removed the sticky `ChatInput` bar on the Ask page: "Ask another question" is now the last element of the page's own document flow, scrolling with it instead of floating over a gap of dead space below a short answer.
- Hovering or focusing a `CitationMarker` now washes its linked `SourceCard` with `--color-highlight` (keyed by the shared `#source-{unitId}` id, since marker and card don't share a React ancestor); clicking gives the note a 1.2s wash instead of only scrolling to it. Both skip cleanly under reduced motion. `SourceCard` gains a `highlighted` prop as the documented source of truth for that styling.
- `SourcesView`'s degraded mode (`/query` `mode: "sources_only"`) rewritten to spec: a serif lead-in stating the decision count, expanded `SourceCard`s carrying the extracted decision/rationale text in place of a synthesized passage, and a dismissible session-scoped banner pointing at Settings, styled as a product state rather than an error.
- The Ask page's empty state now generates its example question chips from the user's actually-indexed repos instead of a hardcoded static list, with a loading/error fallback to the generic examples.
- `AnswerPage`'s per-paragraph `SourceCard` groups (both the >=900px margin track and the <900px inline collapse) now animate in together as a group, offset `--dur-surface + 90ms` from the passage's own settle animation — the third and final piece of the Ask page's signature-motion sequence, alongside the existing passage fade-up and citation-marker ink-in stagger. Skips cleanly under reduced motion.
- New command palette (`Cmd`/`Ctrl+K`), mounted once in `AppShell` so it's reachable from every authenticated route: a filtered, arrow-navigable action list with four baseline actions — jump to Ask/Library/Settings, and "New question", which clears the Ask page's current conversation via a small shared context rather than a direct import.
- Command palette gains a "search past questions" section with an unconditional "No question history yet" empty state — no storage or network calls yet, ahead of Track C's persisted question history.
- Command palette accessibility pass: `aria-modal` dialog semantics, a Tab/Shift+Tab focus trap scoped to the palette, focus restored to whatever triggered `⌘K` when it closes, and a `role="status"` region announcing the filtered result count as the query changes.
- New `GET /decisions` endpoint: a repo-scoped, `since`/`until`-bounded, newest-first, paginated listing of `DecisionUnit`s (`store.list_units`), backing Track B's future timeline and graph views.
- New `DecisionTimeline` component (`frontend/src/library/DecisionTimeline.jsx`): fetches `GET /decisions` for a repo and renders entries grouped by date, newest-first, with explicit loading/empty/error states. `SourceCard`'s `badgeText`/`relativeDate` formatting helpers moved to a shared `lib/sourceFormat.js` now that this is a second consumer. Not yet reachable from routing — that's blocked on the graph view's dependency decision (#138), see #139/#140.
- `DecisionTimeline` gains a from/to date-range filter (native `<input type="date">`, no picker library) that feeds `since`/`until` into `GET /decisions`; clearing either date returns to the unfiltered list.
- New `GET /decisions/by-path` endpoint (`ingestion/store.count_units_by_path`): aggregates decision counts per file path from each unit's `files_changed`, for a repo — groundwork for the file-tree heatmap and click-to-question issues.
- New `FileTree` component (`frontend/src/library/FileTree.jsx`): builds a nested directory/file tree from a flat list of `/`-split paths, with collapsible directory nodes (expanded by default). Pure presentational shell, not yet wired to the `by-path` endpoint.
- `FileTree` now colors nodes by decision density: each node carries its own aggregated count (a directory sums its descendant files' counts) from the `by-path` map, normalized against the tree's own max and expressed via a `--heat-intensity` custom property consumed by a single `.heat` `color-mix()` rule in `index.css` — chosen over an inline `color-mix()` value because jsdom's style parser accepts custom properties but rejects modern color functions outright.
- New `@media print` rules for `AnswerPage`: `TopNav` hides via Tailwind's `print:hidden`; the margin-citation grid collapses to `AnswerPage`'s own <900px inline-citation layout for paper instead of a third layout, via three unlayered override classes that win the cascade over the `min-[900px]:` utilities regardless of the print viewport's rendered width.
- `AnswerPage` gains a "Print / Save as PDF" button calling `window.print()` directly — the print stylesheet above already makes the browser's native print-to-PDF destination produce a well-typeset result, so no PDF-generation library is pulled in.
- New `useReadingPreferences` hook (`frontend/src/lib/useReadingPreferences.js`): a `localStorage`-backed store for Track B's reading-column display preferences — `density` (`compact`/`comfortable`, affecting `AnswerPassage`'s line-height and inter-paragraph spacing) and `measure` (`narrow`/`default`/`wide`, affecting the reading column's `max-width`) — both kept in one stored object since they're conceptually the same settings, not two independent storage keys. `AnswerPage` exposes both as toggle controls next to the print button.
- `useReadingPreferences` gains `focusMode`, a third persisted reading preference. `AppShell` suppresses `TopNav` when it's on, and the command palette gains an "Enter/Exit focus mode" action (contributed via props, since the palette has no other way to reach `AppShell`'s render state) as its trigger.
- `AnswerPage` gains a coverage line under the provenance dek, computed client-side from the existing `citations` array: citation count and the min/max year across their dates (collapsing to one year, not a "2024–2024" span, when every citation falls in the same year).
- The coverage line gains a "coverage for this area is thin" qualifier, appended by a plain threshold heuristic (few citations, or a wide date span sparsely covered) documented in code as a heuristic with no statistical backing, not a confidence score.
- New `PrivacyPanel` component (`frontend/src/ask/PrivacyPanel.jsx`): reads `sent_to_cloud`/`cloud_synthesis_fields` off a query response and states plainly when nothing left the machine, or lists the real field names sent to Gemini otherwise.
- `AnswerPage` wires `PrivacyPanel` in behind a collapsed-by-default "What was sent" `<details>` disclosure, one click away without competing with the reading surface.
- `IndexProgress`'s `done` label now appends a relative "indexed N days ago" string sourced from `RepoInfo.indexed_at`, reusing the shared `relativeDate` helper; falls back to the count-only label for a never-indexed repo. `RepoRow` threads `indexed_at` through.
- `IndexProgress`'s `done` label now appends " · consider re-indexing" when `indexed_at` is more than 30 days old.
- `RepoRow` gains a "Re-index" text button beside Remove, calling `POST /ingest` scoped to that repo and refreshing the Library list on completion.
- `RepoRow` replaces the bare "0 decisions" line with a short explanation when a repo has zero indexed decisions and isn't currently indexing, so an empty index reads as an honest state rather than a broken one.
- `RepoRow` gains a per-repo cloud/local synthesis toggle, reading and writing `RepoInfo.cloud_synthesis_allowed` via a new `PATCH /repos/{repo}` wrapper (`patchRepo`) in `api.js`, surfacing Track A's backend-only privacy flag in the UI.
- `LibraryPage`'s error state gains a Retry action re-triggering the existing fetch; its empty state now links directly to the Add repos action instead of just stating there's nothing there.
- `ModelsSection`'s extraction/embedding model inputs now show the real effective default (`phi4-mini (default)`, `nomic-embed-text (default)`) as a placeholder when unconfigured, instead of rendering as an unexplained empty box.
- `ModelsSection`'s Ollama host/extraction/embedding inputs now collapse behind a native `<details>`/`<summary>` "Advanced" disclosure, collapsed by default; Save still submits current field values while collapsed since the inputs never leave the DOM.
- `ModelsSection`'s Save now pings `POST /config/validate-ollama` after a successful `PATCH /config`, showing "✓ Reachable" on success or the endpoint's specific unreachable/model-missing detail on failure.
- `GeminiSection`'s Save now pings `POST /config/validate-gemini` after a successful `PATCH /config`, showing "✓ Synthesized answers on" or "Key rejected by Gemini" — reinstating the live check the component's own header comment had previously deferred, per the v2 design's docs reconciliation (decision 9).
- `DataSection` now renders the total indexed decision count (`ConfigResponse.decision_count`) alongside the index location.
- `DataSection`'s clear-index confirmation now reads "Clear N indexed decisions? This cannot be undone." using the real count, replacing the previous generic copy.

**Manual verification note:** jsdom can't render real layout, so the margin-grid, responsive-collapse, and signature-motion tests assert DOM structure/classes/timing values, not actual pixel alignment, animation playback, or `@media print` rules. A human should confirm in a browser: the visual layout across the 900px and 1280px breakpoints, no dead space below the input on a tall viewport with a short answer, the SourceCards group-entrance timing and command palette overlay, the FileTree heatmap's actual color intensities, the print preview of an `AnswerPage` (no `TopNav`, full-width reading column, inline citations, and that the new Print button itself is excluded from the printed page), the density/measure/focus-mode toggles' actual visual effect, the coverage line's thin-heuristic thresholds against a range of real answers, the new privacy-panel disclosure and indexed_at status line's visual placement, the Library repo-row states (stale marker, Re-index button, zero-decision explanation, cloud/local toggle), the Library empty/error state actions and Models settings placeholders, and the new Models/Gemini Advanced disclosure and live-validation states (reachable/unreachable, key accepted/rejected) against a real Ollama host and Gemini key. This sandbox has no usable browser (chromium is present but launching it requires interactive approval this unattended run can't grant), so the print stylesheet's cascade-ordering was verified by inspecting the built CSS output instead of an actual print preview. `pytest` from `backend/` (253 tests, unaffected by this update) and `npm test`/`npm run lint`/`npm run build` from `frontend/` (320 tests as of this update) were run and pass.

Issue #145 (file-tree click scopes a question to that path) was evaluated and intentionally left out of this PR — see the comment on that issue for the two design questions blocking it (directory click already means expand/collapse; the backend path filter needs a real design decision on how it composes with top-k ANN search).
